### PR TITLE
Add value_by_key reader to chaindb + better drop_db #85

### DIFF
--- a/libraries/chain/chaindb/mongo_driver.cpp
+++ b/libraries/chain/chaindb/mongo_driver.cpp
@@ -378,7 +378,7 @@ namespace cyberway { namespace chaindb {
         } catch (...) {
             CYBERWAY_ASSERT(false, driver_primary_key_exception,
                 "External database locate row in the table ${table} with wrong value of primary key.",
-                ("table_name", get_full_table_name(table)));
+                ("table", get_full_table_name(table)));
         } }
 
         document make_pk_document(const table_info& table, primary_key_t pk) {
@@ -845,9 +845,9 @@ namespace cyberway { namespace chaindb {
 
     mongodb_driver::~mongodb_driver() = default;
 
-    void mongodb_driver::drop_db() {
+    void mongodb_driver::drop_db(const string& name) {
         // TODO: maybe reset member vars and re-init, but now drop_db() usage is limited, looks like it's unneeded
-        impl_->mongo_conn_[get_system_code_name()].drop();
+        impl_->mongo_conn_[name.empty() ? get_system_code_name() : name].drop();
     }
 
     const cursor_info& mongodb_driver::clone(const cursor_request& request) {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -577,7 +577,7 @@ struct controller_impl {
     */
    void initialize_fork_db() {
       wlog( " Initializing new blockchain with genesis state                  " );
-      chaindb.drop_db();
+      chaindb.drop_db();  // drops only system db, contract dbs are still alive. TODO: fix
       producer_schedule_type initial_schedule{ 0, {{config::system_account_name, conf.genesis.initial_key}} };
 
       block_header_state genheader;

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -71,7 +71,7 @@ namespace cyberway { namespace chaindb {
         chaindb_controller(const microseconds& max_abi_time, chaindb_type, string);
         ~chaindb_controller();
 
-        void drop_db();
+        void drop_db(const string& name = "");
 
         bool has_abi(const account_name&);
         void add_abi(const account_name&, abi_def);
@@ -114,6 +114,9 @@ namespace cyberway { namespace chaindb {
         cursor_t      insert(const table_request&, cache_item_ptr, variant, size_t);
         primary_key_t update(const table_request&, primary_key_t, variant, size_t);
         primary_key_t remove(const table_request&, primary_key_t);
+
+        variant value_by_key(const account_name code, const account_name scope, table_name_t tbl, primary_key_t pk);
+        variant value_at_cursor(const cursor_t, const index_request&, primary_key_t);
 
     private:
         struct controller_impl_;

--- a/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
+++ b/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
@@ -22,7 +22,7 @@ namespace cyberway { namespace chaindb {
     public:
         virtual ~driver_interface();
 
-        virtual void drop_db() = 0;
+        virtual void drop_db(const string& name) = 0;
 
         virtual const cursor_info& clone(const cursor_request&) = 0;
 

--- a/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
+++ b/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
@@ -12,7 +12,7 @@ namespace cyberway { namespace chaindb {
         mongodb_driver(const std::string&);
         ~mongodb_driver();
 
-        void drop_db() override;
+        void drop_db(const string& name) override;
 
         const cursor_info& clone(const cursor_request&) override;
 


### PR DESCRIPTION
1. `value_by_key` can be used to read data from chaindb (+`value_at_cursor`)
2. `drop_db` now accepts database name to drop contract's tables. drops system db if name not set
3. fixed assert message variable name

resolves #85