### PR TITLE
Add domain object and table for domain names #136

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -144,6 +144,10 @@ void apply_context::exec( action_trace& trace )
 
 } /// exec()
 
+bool apply_context::is_domain(const domain_name& domain) const {
+   return nullptr != db.find<domain_object,by_name>(domain);
+}
+
 bool apply_context::is_account( const account_name& account )const {
    return nullptr != db.find<account_object,by_name>( account );
 }

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -508,6 +508,10 @@ class apply_context {
       bool is_account(const account_name& account)const;
 
       /**
+       * @return true if domain name exists, false if it does not
+       */
+      bool is_domain(const domain_name& domain) const;
+      /**
        * Requires that the current action be delivered to account
        */
       void require_recipient(account_name account);

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -6,6 +6,7 @@
 
 #include <eosio/chain/abi_serializer.hpp>
 #include <eosio/chain/account_object.hpp>
+#include <eosio/chain/domain_object.hpp>
 #include <eosio/chain/snapshot.hpp>
 
 #include <cyberway/chaindb/common.hpp>
@@ -165,6 +166,7 @@ namespace eosio { namespace chain {
          chaindb_controller& chaindb() const;
 
          const account_object&                 get_account( account_name n )const;
+         const domain_object&                  get_domain(domain_name n) const;
          const global_property_object&         get_global_properties()const;
          const dynamic_global_property_object& get_dynamic_global_properties()const;
          const resource_limits_manager&        get_resource_limits_manager()const;

--- a/libraries/chain/include/eosio/chain/domain_name.hpp
+++ b/libraries/chain/include/eosio/chain/domain_name.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include <string>
+
+namespace eosio { namespace chain {
+
+using domain_name = std::string;
+
+void validate_domain_name(const domain_name& n);
+
+} } // eosio::chain
+

--- a/libraries/chain/include/eosio/chain/domain_object.hpp
+++ b/libraries/chain/include/eosio/chain/domain_object.hpp
@@ -1,0 +1,44 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
+#pragma once
+#include <eosio/chain/types.hpp>
+#include <eosio/chain/database_utils.hpp>
+#include <eosio/chain/block_timestamp.hpp>
+#include <eosio/chain/multi_index_includes.hpp>
+
+namespace eosio { namespace chain {
+
+class domain_object : public chainbase::object<domain_object_type, domain_object> {
+   OBJECT_CTOR(domain_object)
+
+   id_type              id;
+   account_name         owner;
+   block_timestamp_type creation_date;
+   domain_name          name;
+};
+using domain_id_type = domain_object::id_type;
+
+struct by_name;
+struct by_owner;
+using domain_index = cyberway::chaindb::shared_multi_index_container<
+   domain_object,
+   cyberway::chaindb::indexed_by<
+      cyberway::chaindb::ordered_unique<cyberway::chaindb::tag<by_id>,
+         BOOST_MULTI_INDEX_MEMBER(domain_object, domain_object::id_type, id)>,
+      cyberway::chaindb::ordered_unique<cyberway::chaindb::tag<by_name>,
+         BOOST_MULTI_INDEX_MEMBER(domain_object, string, name)>,
+      cyberway::chaindb::ordered_unique<cyberway::chaindb::tag<by_owner>,
+         cyberway::chaindb::composite_key<domain_object,
+            BOOST_MULTI_INDEX_MEMBER(domain_object, account_name, owner),
+            BOOST_MULTI_INDEX_MEMBER(domain_object, domain_name, name)>
+      >
+   >
+>;
+
+} } // eosio::chain
+
+CHAINBASE_SET_INDEX_TYPE(eosio::chain::domain_object, eosio::chain::domain_index)
+
+FC_REFLECT(eosio::chain::domain_object, (id)(owner)(name)(creation_date))

--- a/libraries/chain/include/eosio/chain/types.hpp
+++ b/libraries/chain/include/eosio/chain/types.hpp
@@ -4,6 +4,7 @@
  */
 #pragma once
 #include <eosio/chain/name.hpp>
+#include <eosio/chain/domain_name.hpp>
 #include <eosio/chain/chain_id_type.hpp>
 
 #include <chainbase/chainbase.hpp>
@@ -143,6 +144,7 @@ namespace eosio { namespace chain {
       permission_object_type,
       permission_usage_object_type,
       permission_link_object_type,
+      domain_object_type,
       UNUSED_action_code_object_type,
       key_value_object_type,
       index64_object_type,
@@ -180,6 +182,7 @@ namespace eosio { namespace chain {
 
    class account_object;
    class producer_object;
+   class domain_object;
 
    using block_id_type       = fc::sha256;
    using checksum_type       = fc::sha256;

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -900,6 +900,10 @@ class authorization_api : public context_aware_api {
       return context.is_account( account );
    }
 
+   bool is_domain(null_terminated_ptr ptr)const {
+      return context.is_domain(std::string(ptr));
+   }
+
 };
 
 class system_api : public context_aware_api {
@@ -1812,6 +1816,7 @@ REGISTER_INTRINSICS(authorization_api,
    (require_authorization, void(int64_t, int64_t), "require_auth2", void(authorization_api::*)(const account_name&, const permission_name& permission) )
    (has_authorization,     int(int64_t), "has_auth", bool(authorization_api::*)(const account_name&)const )
    (is_account,            int(int64_t)           )
+   (is_domain,             int(int)               )
 );
 
 REGISTER_INTRINSICS(console_api,


### PR DESCRIPTION
+ added separate type `domain_name`. now it's string alias, later it can be used in serializer/deserializer to embed restrictions
+ created base domain object (partly related to #137)
+ declared table and indices to store domain objects
+ added initialization of abi.structs and abi.tables with "domain" table info
+ added temporary test code, inserting domains on create system accounts
+ added `get_domain()`, returning domain object
+ added `is_domain()` intrinsic to check domain existence from smart-contract

note: `validate_domain_name()` is only declared now, it's not used, the implementation will be later (next PR)