### PR TITLE
Add api method to resolve domain_names & usernames #175

### DIFF
--- a/libraries/chain/domain_name.cpp
+++ b/libraries/chain/domain_name.cpp
@@ -33,6 +33,7 @@ inline bool is_valid_char(char c) {
 
 enum name_error {
    valid = 0,
+   name_empty,
    name_too_long,
    part_too_short,
    part_too_long,
@@ -51,6 +52,7 @@ name_error validate_part(const string& n, size_t min_size, size_t max_size) {
 }
 
 name_error validate_domain_name(const string& d, size_t max_size, size_t min_part, size_t max_part, bool strict_tld) {
+   if (!d.size()) return name_empty;
    if (d.size() > max_size) return name_too_long;
    if (!std::all_of(d.begin(), d.end(), is_valid_char)) return bad_char;
    std::vector<std::string> parts;
@@ -71,6 +73,7 @@ void validate_domain_name(const domain_name& n) {
    auto r = validate_domain_name(n, domain_max_size, domain_min_part_size, domain_max_part_size, true);
    static const std::vector<string> err = {
       "",
+      "Domain name is empty",
       "Domain name is too long",
       "Domain label is too short",
       "Domain label is too long",
@@ -85,6 +88,7 @@ void validate_username(const username& n) {
    auto r = validate_domain_name(n, username_max_size, username_min_part_size, username_max_part_size, false);
    static const std::vector<string> err = {
       "",
+      "Username is empty",
       "Username is too long",
       "Username part is too short",
       "Username part is too long",

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -905,19 +905,19 @@ class domain_api : public context_aware_api {
    public:
       using context_aware_api::context_aware_api;
 
-   bool is_domain(null_terminated_ptr ptr)const {
+   bool is_domain(null_terminated_ptr ptr) const {
       return context.is_domain(std::string(ptr));
    }
-   bool is_username(const account_name& scope, null_terminated_ptr ptr)const {
+   bool is_username(const account_name& scope, null_terminated_ptr ptr) const {
       return context.is_username(scope, std::string(ptr));
    }
-   account_name get_domain_owner(null_terminated_ptr ptr)const {
+   account_name get_domain_owner(null_terminated_ptr ptr) const {
       return context.get_domain_owner(std::string(ptr));
    }
-   account_name resolve_domain(null_terminated_ptr ptr)const {
+   account_name resolve_domain(null_terminated_ptr ptr) const {
       return context.resolve_domain(std::string(ptr));
    }
-   account_name resolve_username(const account_name& scope, null_terminated_ptr ptr)const {
+   account_name resolve_username(const account_name& scope, null_terminated_ptr ptr) const {
       return context.resolve_username(scope, std::string(ptr));
    }
 };

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -103,6 +103,7 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RO_CALL(abi_bin_to_json, 200),
       CHAIN_RO_CALL(get_required_keys, 200),
       CHAIN_RO_CALL(get_transaction_id, 200),
+      CHAIN_RO_CALL(resolve_names, 200),
       CHAIN_RW_CALL_ASYNC(push_block, chain_apis::read_write::push_block_results, 202),
       CHAIN_RW_CALL_ASYNC(push_transaction, chain_apis::read_write::push_transaction_results, 202),
       CHAIN_RW_CALL_ASYNC(push_transactions, chain_apis::read_write::push_transactions_results, 202)

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1772,6 +1772,47 @@ read_only::get_account_results read_only::get_account( const get_account_params&
    return result;
 }
 
+
+read_only::resolve_names_results read_only::resolve_names(const resolve_names_params& p) const {
+    resolve_names_results r;
+
+    auto set_domain = [&](const auto& n, resolve_names_item& item) {
+        validate_domain_name(n);
+        item.resolved_domain = db.get_domain(n).linked_to;
+    };
+
+    // don't limit names count, but prevent from running too long
+    auto timeout = fc::time_point::now() + fc::microseconds(1000 * 10); // 10ms max time
+
+    for (const auto& n: p) { try {
+        resolve_names_item item; // TODO: restrict doubles or cache names
+        auto at = n.find('@');
+        if (at == string::npos) {
+            set_domain(n, item);
+        } else {
+            auto at2 = n.find('@', at + 1);
+            bool at_acc = at2 == at + 1;
+            EOS_ASSERT(at_acc || at2 == string::npos, name_type_exception, "Unknown name format: several `@` symbols");
+            auto username = n.substr(0, at - 1);
+            validate_username(username);
+
+            at += at_acc ? 2 : 1;    // move split position to point after `@` symbol
+            auto tail = n.substr(at, n.length() - at);
+            if (!at_acc) {
+                set_domain(tail, item);
+            }
+            auto scope = at_acc ? name(tail) : *item.resolved_domain;
+            item.resolved_username = db.get_username(scope, username).owner;
+        }
+        r.push_back(item);
+        if (fc::time_point::now() > timeout) {
+            break;   // early exit if takes too much time
+        }
+    } EOS_RETHROW_EXCEPTIONS(name_type_exception, "Can't resolve name: ${n}", ("n", n)) }
+    return r;
+}
+
+
 static variant action_abi_to_variant( const abi_def& abi, type_name action_type ) {
    variant v;
    auto it = std::find_if(abi.structs.begin(), abi.structs.end(), [&](auto& x){return x.name == action_type;});

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -205,6 +205,27 @@ public:
    get_raw_abi_results get_raw_abi( const get_raw_abi_params& params)const;
 
 
+    /*
+     * each name can be either domain name or full name.
+     * full name can be in 2 forms: username@domain and username@@account (note double @)
+     */
+
+    /*
+     * 1. throws if any name is invalid or can't be resolved
+     * 2. domain resolves either to {resolved_domain: account}, or {resolved_domain: 0} if unlinked
+     * 3. username@domain resolves to {resolved_domain: accountD, resolved_username: accountU}
+     * 4. username@@account resolves to {resolved_username: account}
+     */
+    struct resolve_names_item {
+        optional<name> resolved_domain;
+        optional<name> resolved_username;
+    };
+    using resolve_names_results = vector<resolve_names_item>;
+    using resolve_names_params = vector<string>;
+
+    resolve_names_results resolve_names(const resolve_names_params& params) const;
+
+
 
    struct abi_json_to_bin_params {
       name         code;
@@ -714,3 +735,5 @@ FC_REFLECT( eosio::chain_apis::read_only::abi_bin_to_json_params, (code)(action)
 FC_REFLECT( eosio::chain_apis::read_only::abi_bin_to_json_result, (args) )
 FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_params, (transaction)(available_keys) )
 FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_result, (required_keys) )
+
+FC_REFLECT(eosio::chain_apis::read_only::resolve_names_item, (resolved_domain)(resolved_username))


### PR DESCRIPTION
+ added `resolve_names` api method to chain plugin
+ domain_name/username validation: proper error on empty name

Method accepts array of strings, each string is a name to be resolved. It can be in one of 3 forms:
1. domain
2. username@domain
3. username@@account

The result is array of objects with the following structure:
```
{
    resolved_domain: account,
    resolved_username: account
}
```

Both fields are optional, but at least one of them exists in an object:
1. `domain` name maps to `{resolved_domain: account}`, where `account` can be empty if domain is not currently linked
2. `username@domain` name maps `{resolved_domain: accountD, resolved_username: accountU}`, both values can't be empty
3. `username@@account` name maps to `{resolved_username: account}`, `account` can't be empty

Method fails is any of names provided to it is invalid or can't be resolved.

Note: method can exit early if it takes too much time (>10ms), in this case results array will be shorter than names array.

Sample usage:
```
curl --request POST --data '["eosio","aq.aa@@z.a123"]'  http://localhost:8888/v1/chain/resolve_names
```
