### PR TITLE
Add `resolve name` command to cleos #158

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2169,14 +2169,15 @@ const account_object& controller::get_account( account_name name )const
 } FC_CAPTURE_AND_RETHROW( (name) ) }
 
 const domain_object& controller::get_domain(const domain_name& name) const { try {
-   return my->db.get<domain_object, by_name>(name);
+    const auto* d = my->db.find<domain_object, by_name>(name);
+    EOS_ASSERT(d != nullptr, chain::domain_query_exception, "domain `${name}` not found", ("name", name));
+    return *d;
 } FC_CAPTURE_AND_RETHROW((name)) }
 
 const username_object& controller::get_username(account_name scope, const username& name) const { try {
-   // return my->db.get<username_object, by_scope_name>(boost::make_tuple(scope,name));   // can't compile for some reason
-   const auto* user = my->db.find<username_object, by_scope_name>(boost::make_tuple(scope,name));
-   EOS_ASSERT(user != nullptr, transaction_exception,
-      "username '${name}' not found in scope '${scope}'", ("name",name)("scope",scope));
+    const auto* user = my->db.find<username_object, by_scope_name>(boost::make_tuple(scope,name));
+    EOS_ASSERT(user != nullptr, username_query_exception,
+        "username `${name}` not found in scope `${scope}`", ("name",name)("scope",scope));
    return *user;
 } FC_CAPTURE_AND_RETHROW((scope)(name)) }
 

--- a/libraries/chain/domain_name.cpp
+++ b/libraries/chain/domain_name.cpp
@@ -14,7 +14,7 @@ constexpr size_t domain_max_part_size = 63;
 
 constexpr size_t username_max_size = 32;        // it's 16 in Golos
 constexpr size_t username_min_part_size = 1;    // it's 3 in Golos
-constexpr size_t username_max_part_size = 32;
+constexpr size_t username_max_part_size = username_max_size;
 
 
 //
@@ -81,7 +81,7 @@ void validate_domain_name(const domain_name& n) {
       "Domain name contains bad symbol",
       "Top-level name is all-numeric"
    };
-   EOS_ASSERT(r == valid, name_type_exception, err[r]);  // TODO: proper exception type
+   EOS_ASSERT(r == valid, domain_name_type_exception, err[r]);
 }
 
 void validate_username(const username& n) {
@@ -95,7 +95,7 @@ void validate_username(const username& n) {
       "Username part can't start or end with '-'",
       "Username contains bad symbol"
    };
-   EOS_ASSERT(r == valid, name_type_exception, err[r]);  // TODO: proper exception type
+   EOS_ASSERT(r == valid, username_type_exception, err[r]);
 }
 
 

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -129,6 +129,9 @@ namespace eosio { namespace chain {
       FC_DECLARE_DERIVED_EXCEPTION( symbol_type_exception,           chain_type_exception,
                                     3010014, "Invalid symbol" )
 
+        FC_DECLARE_DERIVED_EXCEPTION(domain_name_type_exception, chain_type_exception, 3010015, "Invalid domain name")
+        FC_DECLARE_DERIVED_EXCEPTION(username_type_exception,    chain_type_exception, 3010016, "Invalid username")
+
 
    FC_DECLARE_DERIVED_EXCEPTION( fork_database_exception, chain_exception,
                                  3020000, "Fork database exception" )
@@ -228,6 +231,10 @@ namespace eosio { namespace chain {
                                     3060003, "Contract Table Query Exception" )
       FC_DECLARE_DERIVED_EXCEPTION( contract_query_exception,       database_exception,
                                     3060004, "Contract Query Exception" )
+
+        FC_DECLARE_DERIVED_EXCEPTION(domain_query_exception,   database_exception, 3060005, "Domain Query Exception")
+        FC_DECLARE_DERIVED_EXCEPTION(username_query_exception, database_exception, 3060006, "Username Query Exception")
+
 
    FC_DECLARE_DERIVED_EXCEPTION( guard_exception, database_exception,
                                  3060100, "Guard Exception" )

--- a/programs/cleos/httpc.hpp
+++ b/programs/cleos/httpc.hpp
@@ -100,6 +100,7 @@ namespace eosio { namespace client { namespace http {
    const string get_producers_func = chain_func_base + "/get_producers";
    const string get_schedule_func = chain_func_base + "/get_producer_schedule";
    const string get_required_keys = chain_func_base + "/get_required_keys";
+   const string resolve_names_func = chain_func_base + "/resolve_names";
 
 
    const string history_func_base = "/v1/history";

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -1496,6 +1496,21 @@ struct canceldelay_subcommand {
    }
 };
 
+void resolve_name(const string& textual_name) {
+    vector<string> names{textual_name};
+    fc::variant json = call(resolve_names_func, names);
+    auto res = json.as<eosio::chain_apis::read_only::resolve_names_results>();
+    auto n = res[0];
+    std::cout << '"' << textual_name << "\" resolves to:" << std::endl;
+    if (n.resolved_domain) {
+        const auto& d = *n.resolved_domain;
+        std::cout << "  Domain:   " << (d != name() ? d.to_string() : "(not linked)") << std::endl;
+    }
+    if (n.resolved_username) {
+        std::cout << "  Username: " << *n.resolved_username << std::endl;
+    }
+}
+
 void get_account( const string& accountName, const string& coresym, bool json_format ) {
    fc::variant json;
    if (coresym.empty()) {
@@ -1921,6 +1936,17 @@ int main( int argc, char** argv ) {
       fc::variant unpacked_action_data_json = bin_to_variant(packed_action_data_account_string, packed_action_data_name_string, packed_action_data_blob);
       std::cout << fc::json::to_pretty_string(unpacked_action_data_json) << std::endl;
    });
+
+   // Resolve subcommand
+   auto resolve = app.add_subcommand("resolve", localized("Resolve domain names and usernames to account"), false);
+   resolve->require_subcommand();
+
+   // resolve name
+   string textual_name;
+   auto resolve_name_cmd = resolve->add_subcommand("name", localized("Resolve textual name account_name"), false);
+   resolve_name_cmd->add_option("name", textual_name, localized("The textual name to resolve (\"domain\", \"username@domain\" or \"username@@account\")"))->required();
+   resolve_name_cmd->set_callback([&]() { resolve_name(textual_name); });
+
 
    // Get subcommand
    auto get = app.add_subcommand("get", localized("Retrieve various items and information from the blockchain"), false);


### PR DESCRIPTION
+ `resolve name` cleos command accepts name in one of forms described in #177 and returns resolved domain and/or resolved username
+ added proper exception types for domains/usernames
+ better error handling in chain api `resolve_names`
