### PR TITLE
Implement sending event from smart-contracts #160 #161 #214

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -373,8 +373,8 @@ bool apply_context::cancel_deferred_transaction( const uint128_t& sender_id, acc
    return gto;
 }
 
-void apply_context::push_event( event&& evt ) {
-   _events.emplace_back(evt);
+void apply_context::push_event( event evt ) {
+   _events.emplace_back(std::move(evt));
 }
 
 const table_id_object* apply_context::find_table( name code, name scope, name table ) {

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -125,6 +125,9 @@ void apply_context::finalize_trace( action_trace& trace, const fc::time_point& s
    reset_console();
 
    trace.elapsed = fc::time_point::now() - start;
+
+   trace.events = _events;
+   _events.clear();
 }
 
 void apply_context::exec( action_trace& trace )
@@ -368,6 +371,10 @@ bool apply_context::cancel_deferred_transaction( const uint128_t& sender_id, acc
       generated_transaction_idx.remove(*gto);
    }
    return gto;
+}
+
+void apply_context::push_event( event&& evt ) {
+   _events.emplace_back(evt);
 }
 
 const table_id_object* apply_context::find_table( name code, name scope, name table ) {

--- a/libraries/chain/include/eosio/chain/abi_def.hpp
+++ b/libraries/chain/include/eosio/chain/abi_def.hpp
@@ -62,6 +62,16 @@ struct action_def {
    string      ricardian_contract;
 };
 
+struct event_def {
+    event_def() = default;
+    event_def(const event_name& name, const type_name& type)
+        :name(name), type(type)
+    {}
+
+    event_name name;
+    type_name   type;
+};
+
 struct order_def {
    order_def() = default;
    order_def(const field_name& field, const type_name& order)
@@ -138,19 +148,21 @@ struct may_not_exist {
 
 struct abi_def {
    abi_def() = default;
-   abi_def(const vector<type_def>& types, const vector<struct_def>& structs, const vector<action_def>& actions, const vector<table_def>& tables, const vector<clause_pair>& clauses, const vector<error_message>& error_msgs)
+   abi_def(const vector<type_def>& types, const vector<struct_def>& structs, const vector<action_def>& actions, const vector<event_def>& events, const vector<table_def>& tables, const vector<clause_pair>& clauses, const vector<error_message>& error_msgs)
    :types(types)
    ,structs(structs)
    ,actions(actions)
+   ,events(events)
    ,tables(tables)
    ,ricardian_clauses(clauses)
    ,error_messages(error_msgs)
    {}
 
-   string                              version = "cyberway::abi/1.0";
+   string                              version = "cyberway::abi/1.1";
    vector<type_def>                    types;
    vector<struct_def>                  structs;
    vector<action_def>                  actions;
+   vector<event_def>                   events;
    vector<table_def>                   tables;
    vector<clause_pair>                 ricardian_clauses;
    vector<error_message>               error_messages;
@@ -194,11 +206,12 @@ FC_REFLECT( eosio::chain::type_def                         , (new_type_name)(typ
 FC_REFLECT( eosio::chain::field_def                        , (name)(type) )
 FC_REFLECT( eosio::chain::struct_def                       , (name)(base)(fields) )
 FC_REFLECT( eosio::chain::action_def                       , (name)(type)(ricardian_contract) )
+FC_REFLECT( eosio::chain::event_def                        , (name)(type) )
 FC_REFLECT( eosio::chain::order_def                        , (field)(order) )
 FC_REFLECT( eosio::chain::index_def                        , (name)(unique)(orders) )
 FC_REFLECT( eosio::chain::table_def                        , (name)(type)(indexes) )
 FC_REFLECT( eosio::chain::clause_pair                      , (id)(body) )
 FC_REFLECT( eosio::chain::error_message                    , (error_code)(error_msg) )
 FC_REFLECT( eosio::chain::variant_def                      , (name)(types) )
-FC_REFLECT( eosio::chain::abi_def                          , (version)(types)(structs)(actions)(tables)
+FC_REFLECT( eosio::chain::abi_def                          , (version)(types)(structs)(actions)(events)(tables)
                                                              (ricardian_clauses)(error_messages)(abi_extensions)(variants) )

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -489,6 +489,10 @@ class apply_context {
    public:
       void lazy_init_chaindb_abi(account_name code);
 
+   /// Event methods:
+   public:
+      void push_event( event&& evt );
+
    /// Authorization methods:
    public:
 
@@ -639,6 +643,7 @@ class apply_context {
       iterator_cache<key_value_object>    keyval_cache;
       vector<account_name>                _notified; ///< keeps track of new accounts to be notifed of current message
       vector<action>                      _inline_actions; ///< queued inline messages
+      vector<event>                       _events; ///< generated events
       vector<action>                      _cfa_inline_actions; ///< queued inline messages
       std::ostringstream                  _pending_console_output;
       flat_set<account_delta>             _account_ram_deltas; ///< flat_set of account_delta so json is an array of objects

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -491,7 +491,7 @@ class apply_context {
 
    /// Event methods:
    public:
-      void push_event( event&& evt );
+      void push_event( event evt );
 
    /// Authorization methods:
    public:

--- a/libraries/chain/include/eosio/chain/event.hpp
+++ b/libraries/chain/include/eosio/chain/event.hpp
@@ -7,6 +7,7 @@ namespace eosio { namespace chain {
  * @brief defines event from smart-contract
  */
 struct event {
+    account_name   account;
     event_name     name;
     bytes          data;
 
@@ -15,4 +16,4 @@ struct event {
 
 } } // namespace eosio::chain
 
-FC_REFLECT( eosio::chain::event, (name)(data))
+FC_REFLECT( eosio::chain::event, (account)(name)(data))

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -1364,6 +1364,17 @@ class transaction_api : public context_aware_api {
       }
 };
 
+class event_api : public context_aware_api {
+    public:
+        using context_aware_api::context_aware_api;
+
+        void send_event( array_ptr<char> data, size_t data_len ) {
+            event evt;
+            fc::raw::unpack<event>(data, data_len, evt);
+            context.push_event(std::move(evt));
+        }
+};
+
 
 class context_free_transaction_api : public context_aware_api {
    public:
@@ -1870,6 +1881,10 @@ REGISTER_INTRINSICS(transaction_api,
    (send_context_free_inline,  void(int, int)               )
    (send_deferred,             void(int, int64_t, int, int, int32_t) )
    (cancel_deferred,           int(int)                     )
+);
+
+REGISTER_INTRINSICS(event_api,
+   (send_event,                void(int, int)               )
 );
 
 REGISTER_INTRINSICS(context_free_api,

--- a/plugins/event_engine_plugin/include/eosio/event_engine_plugin/messages.hpp
+++ b/plugins/event_engine_plugin/include/eosio/event_engine_plugin/messages.hpp
@@ -105,7 +105,7 @@ namespace eosio {
 
 } // namespace eosio
 
-FC_REFLECT(eosio::EventData, (code)(event)(data))
+FC_REFLECT(eosio::EventData, (code)(event)(data)(args))
 FC_REFLECT(eosio::ActionData, (code)(action)(events))
 FC_REFLECT(eosio::TrxMetadata, (id)(accepted)(implicit)(scheduled))
 


### PR DESCRIPTION
1. Add section `events` into ABI-description
2. Add intrinsic to send events from smart-contracts
3. Add unpacking event arguments using ABI-description. If the unpacking fails, the packed data is added to the event. 
4. Use chain `abi_serializer_max_time` config value for limit ABI serialization work time

fixes #160 fixes #161 fixes #214