### PR TITLE
Update serializer with new ABI-description on setabi #223

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -175,6 +175,10 @@ struct controller_impl {
     */
    map<digest_type, transaction_metadata_ptr>     unapplied_transactions;
 
+   void set_abi(name account, const abi_def& abi) {
+       emit(self.setabi, std::make_tuple(account, std::ref(abi)));
+   }
+
    void pop_block() {
       auto prev = fork_db.get_block( head->header.previous );
       EOS_ASSERT( prev, block_validate_exception, "attempt to pop beyond last irreversible block" );
@@ -242,6 +246,10 @@ struct controller_impl {
    fork_db.irreversible.connect( [&]( auto b ) {
                                  on_irreversible(b);
                                  });
+
+   self.setabi.connect( [&]( auto b ) {
+       chaindb.add_abi( std::get<0>(b), std::get<1>(b) );
+   });
 
    }
 
@@ -2150,6 +2158,10 @@ db_read_mode controller::get_read_mode()const {
 
 validation_mode controller::get_validation_mode()const {
    return my->conf.block_validation_mode;
+}
+
+void controller::set_abi(name account, const abi_def &abi) {
+    my->set_abi(account, abi);
 }
 
 const apply_handler* controller::find_apply_handler( account_name receiver, account_name scope, action_name act ) const

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -197,8 +197,7 @@ void apply_eosio_setabi(apply_context& context) {
       aso.abi_sequence += 1;
    });
 
-   // context.chaindb.remove_abi(act.account);
-   context.chaindb.add_abi(act.account, account.get_abi());
+   context.control.set_abi(act.account, account.get_abi());
 
    if (new_size != old_size) {
       context.add_ram_usage( act.account, new_size - old_size );

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -269,6 +269,8 @@ namespace eosio { namespace chain {
          signal<void(const header_confirmation&)>      accepted_confirmation;
          signal<void(const int&)>                      bad_alloc;
 
+         signal<void(const std::tuple<name,const abi_def&>&)> setabi;
+
          /*
          signal<void()>                                  pre_apply_block;
          signal<void()>                                  post_apply_block;
@@ -279,6 +281,7 @@ namespace eosio { namespace chain {
          signal<void(const transaction_trace_ptr&)>  post_apply_action;
          */
 
+         void set_abi(name account, const abi_def& abi);
          const apply_handler* find_apply_handler( account_name contract, scope_name scope, action_name act )const;
          wasm_interface& get_wasm_interface();
 


### PR DESCRIPTION
Added event `setabi` into controller
Event  is emited in `apply_eosio_setabi`
Controller adds handler to `setabi` signal and calls `chaindb.add_abi()`
Event engine plugin process event and update cached ABI

Fixes #223 