### PR TITLE
Fix internal domain actions #205

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -236,6 +236,13 @@ struct controller_impl {
 
    SET_APP_HANDLER( eosio, eosio, providebw );
    SET_APP_HANDLER( eosio, eosio, requestbw );
+
+    // TODO: at least `newdomain` must be in cyber.domain contract, add macro for it
+    SET_APP_HANDLER(eosio, eosio, newusername);
+    SET_APP_HANDLER(eosio, eosio, newdomain);
+    SET_APP_HANDLER(eosio, eosio, passdomain);
+    SET_APP_HANDLER(eosio, eosio, linkdomain);
+    SET_APP_HANDLER(eosio, eosio, unlinkdomain);
 /*
    SET_APP_HANDLER( eosio, eosio, postrecovery );
    SET_APP_HANDLER( eosio, eosio, passrecovery );
@@ -657,7 +664,7 @@ struct controller_impl {
         "username",
         {{"id", cyberway::chaindb::tag<by_id>::get_code(), true, {{"id", "asc"}}},
          {"scopename", cyberway::chaindb::tag<by_scope_name>::get_code(), true, {{"scope", "asc"},{"name", "asc"}}},
-         {"owner", cyberway::chaindb::tag<by_owner>::get_code(), true, {{"owner", "asc"}}}}
+         {"owner", cyberway::chaindb::tag<by_owner>::get_code(), true, {{"owner","asc"},{"scope","asc"},{"name","asc"}}}}
       });
 
    }
@@ -2230,7 +2237,7 @@ const username_object& controller::get_username(account_name scope, const userna
     const auto* user = my->db.find<username_object, by_scope_name>(boost::make_tuple(scope,name));
     EOS_ASSERT(user != nullptr, username_query_exception,
         "username `${name}` not found in scope `${scope}`", ("name",name)("scope",scope));
-   return *user;
+    return *user;
 } FC_CAPTURE_AND_RETHROW((scope)(name)) }
 
 vector<transaction_metadata_ptr> controller::get_unapplied_transactions() const {

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -420,7 +420,8 @@ void apply_eosio_linkdomain(apply_context& context) {
       context.require_authorization(op.owner);
       validate_domain_name(op.name);
       const auto& domain = context.control.get_domain(op.name);
-      EOS_ASSERT(op.owner == domain.owner, action_validate_exception, "Domain link wrong `owner`");
+      EOS_ASSERT(op.owner == domain.owner, action_validate_exception, "Only owner can change domain link");
+      EOS_ASSERT(op.to != domain.linked_to, action_validate_exception, "Domain name already linked to the same account");
       auto& db = context.db;
       db.modify(domain, [&](auto& d) {
          d.linked_to = op.to;
@@ -428,13 +429,14 @@ void apply_eosio_linkdomain(apply_context& context) {
       // ram usage unchanged
 } FC_CAPTURE_AND_RETHROW((op)) }
 
-void apply_eosio_unlnkdomain(apply_context& context) {
-   auto op = context.act.data_as<unlnkdomain>();
+void apply_eosio_unlinkdomain(apply_context& context) {
+   auto op = context.act.data_as<unlinkdomain>();
    try {
       context.require_authorization(op.owner);
       validate_domain_name(op.name);
       const auto& domain = context.control.get_domain(op.name);
-      EOS_ASSERT(op.owner == domain.owner, action_validate_exception, "Domain unlink wrong `owner`");
+      EOS_ASSERT(op.owner == domain.owner, action_validate_exception, "Only owner can unlink domain");
+      EOS_ASSERT(domain.linked_to != account_name(), action_validate_exception, "Domain name already unlinked");
       auto& db = context.db;
       db.modify(domain, [&](auto& d) {
          d.linked_to = account_name();
@@ -445,15 +447,17 @@ void apply_eosio_unlnkdomain(apply_context& context) {
 void apply_eosio_newusername(apply_context& context) {
    auto op = context.act.data_as<newusername>();
    try {
-      context.require_authorization(op.owner);
+      context.require_authorization(op.creator);
       validate_username(op.name);               // TODO: can move validation to username deserializer
       auto& db = context.db;
+      auto owner = db.find<account_object, by_name>(op.owner);
+      EOS_ASSERT(owner, account_name_exists_exception, "Username owner (${o}) must exist", ("o", op.owner));
       db.create<username_object>([&](auto& d) {
          d.owner = op.owner;
-         d.scope = op.scope;
+         d.scope = op.creator;
          d.name = op.name;
       });
-      context.add_ram_usage(op.owner, sizeof(username_object) + op.name.size());     // TODO: fix
+      context.add_ram_usage(op.creator, sizeof(username_object) + op.name.size());     // TODO: fix
 } FC_CAPTURE_AND_RETHROW((op)) }
 
 

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -200,6 +200,40 @@ abi_def eosio_contract_abi(const abi_def& eosio_system_abi)
       }
    });
 
+   eos_abi.structs.emplace_back(struct_def {
+      "newusername", "", {
+         {"creator", "account_name"},
+         {"owner",   "account_name"},
+         {"name",    "string"},
+      }
+   });
+   eos_abi.structs.emplace_back(struct_def {
+      "newdomain", "", {
+         {"creator", "account_name"},
+         {"name",    "string"},
+      }
+   });
+   eos_abi.structs.emplace_back(struct_def {
+      "passdomain", "", {
+         {"from", "account_name"},
+         {"to",   "account_name"},
+         {"name", "string"},
+      }
+   });
+   eos_abi.structs.emplace_back(struct_def {
+      "linkdomain", "", {
+         {"owner", "account_name"},
+         {"to",    "account_name"},
+         {"name",  "string"},
+      }
+   });
+   eos_abi.structs.emplace_back(struct_def {
+      "unlinkdomain", "", {
+         {"owner", "account_name"},
+         {"name",  "string"},
+      }
+   });
+
    eos_abi.structs.emplace_back( struct_def {
       "requestbw", "", {
          {"provider", "account_name"},
@@ -240,6 +274,12 @@ abi_def eosio_contract_abi(const abi_def& eosio_system_abi)
    eos_abi.actions.push_back( action_def{name("canceldelay"), "canceldelay",""} );
    eos_abi.actions.push_back( action_def{name("onerror"), "onerror",""} );
    eos_abi.actions.push_back( action_def{name("onblock"), "onblock",""} );
+
+    eos_abi.actions.push_back(action_def{name("newusername"), "newusername",""});
+    eos_abi.actions.push_back(action_def{name("newdomain"), "newdomain",""});
+    eos_abi.actions.push_back(action_def{name("passdomain"), "passdomain",""});
+    eos_abi.actions.push_back(action_def{name("linkdomain"), "linkdomain",""});
+    eos_abi.actions.push_back(action_def{name("unlinkdomain"), "unlinkdomain",""});
 
    return eos_abi;
 }

--- a/libraries/chain/include/eosio/chain/contract_types.hpp
+++ b/libraries/chain/include/eosio/chain/contract_types.hpp
@@ -198,14 +198,14 @@ SYS_ACTION_STRUCT(linkdomain)
    domain_name name;
 SYS_ACTION_STRUCT_END;
 
-SYS_ACTION_STRUCT(unlnkdomain)
+SYS_ACTION_STRUCT(unlinkdomain)
    account_name owner;
    domain_name name;
 SYS_ACTION_STRUCT_END;
 
 SYS_ACTION_STRUCT(newusername)
+   account_name creator;
    account_name owner;
-   account_name scope;
    username name;
 SYS_ACTION_STRUCT_END;
 
@@ -264,5 +264,5 @@ FC_REFLECT( eosio::chain::onerror                          , (sender_id)(sent_tr
 FC_REFLECT(eosio::chain::newdomain,    (creator)(name))
 FC_REFLECT(eosio::chain::passdomain,   (from)(to)(name))
 FC_REFLECT(eosio::chain::linkdomain,   (owner)(to)(name))
-FC_REFLECT(eosio::chain::unlnkdomain,  (owner)(name))
-FC_REFLECT(eosio::chain::newusername,  (owner)(scope)(name))
+FC_REFLECT(eosio::chain::unlinkdomain, (owner)(name))
+FC_REFLECT(eosio::chain::newusername,  (creator)(owner)(name))

--- a/libraries/chain/include/eosio/chain/eosio_contract.hpp
+++ b/libraries/chain/include/eosio/chain/eosio_contract.hpp
@@ -28,7 +28,7 @@ namespace eosio { namespace chain {
    void apply_eosio_newdomain(apply_context&);
    void apply_eosio_passdomain(apply_context&);
    void apply_eosio_linkdomain(apply_context&);
-   void apply_eosio_freedomain(apply_context&);
+   void apply_eosio_unlinkdomain(apply_context&);
    void apply_eosio_newusername(apply_context&);
 
    /*


### PR DESCRIPTION
+ `newusername` now allows to create username only in `creator`'s scope
+ `newusername` now checks that owner account exists
+ fixed multiple different names of `unlinkdomain`
+ added contract handlers and abi structs
+ better error handling in link/unlink domain
