### PR TITLE
Move internal domain actions to cyber.domain #232

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -236,13 +236,6 @@ struct controller_impl {
 
    SET_APP_HANDLER( eosio, eosio, providebw );
    SET_APP_HANDLER( eosio, eosio, requestbw );
-
-    // TODO: at least `newdomain` must be in cyber.domain contract, add macro for it
-    SET_APP_HANDLER(eosio, eosio, newusername);
-    SET_APP_HANDLER(eosio, eosio, newdomain);
-    SET_APP_HANDLER(eosio, eosio, passdomain);
-    SET_APP_HANDLER(eosio, eosio, linkdomain);
-    SET_APP_HANDLER(eosio, eosio, unlinkdomain);
 /*
    SET_APP_HANDLER( eosio, eosio, postrecovery );
    SET_APP_HANDLER( eosio, eosio, passrecovery );
@@ -250,6 +243,17 @@ struct controller_impl {
 */
 
    SET_APP_HANDLER( eosio, eosio, canceldelay );
+
+#define SET_CONTRACT_HANDLER(contract, action, function) set_apply_handler(contract, contract, #action, function);
+#define SET_DOTCONTRACT_HANDLER(base, sub, action) SET_CONTRACT_HANDLER(#base "." #sub, action, \
+    &BOOST_PP_CAT(apply_, BOOST_PP_CAT(base, BOOST_PP_CAT(_, BOOST_PP_CAT(sub, BOOST_PP_CAT(_,action))))))
+#define SET_CYBER_DOMAIN_HANDLER(action) SET_DOTCONTRACT_HANDLER(cyber, domain, action)
+
+    SET_CYBER_DOMAIN_HANDLER(newusername);
+    SET_CYBER_DOMAIN_HANDLER(newdomain);
+    SET_CYBER_DOMAIN_HANDLER(passdomain);
+    SET_CYBER_DOMAIN_HANDLER(linkdomain);
+    SET_CYBER_DOMAIN_HANDLER(unlinkdomain);
 
    fork_db.irreversible.connect( [&]( auto b ) {
                                  on_irreversible(b);
@@ -814,8 +818,10 @@ struct controller_impl {
          a.creation_date = conf.genesis.initial_timestamp;
          a.privileged = is_privileged;
 
-         if( name == config::system_account_name ) {
+         if (name == config::system_account_name) {
             a.set_abi(eosio_contract_abi(abi_def()));
+         } else if (name == config::domain_account_name ) {
+            a.set_abi(domain_contract_abi(abi_def()));
          }
       });
       db.create<account_sequence_object>([&](auto & a) {
@@ -865,6 +871,7 @@ struct controller_impl {
 
       authority system_auth(conf.genesis.initial_key);
       create_native_account( config::system_account_name, system_auth, system_auth, true );
+      create_native_account(config::domain_account_name, system_auth, system_auth);
 
       auto empty_authority = authority(1, {}, {});
       auto active_producers_authority = authority(1, {}, {});

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -386,7 +386,7 @@ void apply_eosio_canceldelay(apply_context& context) {
 }
 
 
-void apply_eosio_newdomain(apply_context& context) {
+void apply_cyber_domain_newdomain(apply_context& context) {
    auto op = context.act.data_as<newdomain>();
    try {
       context.require_authorization(op.creator);
@@ -400,7 +400,7 @@ void apply_eosio_newdomain(apply_context& context) {
       context.add_ram_usage(op.creator, sizeof(domain_object) + op.name.size());    // TODO: fix
 } FC_CAPTURE_AND_RETHROW((op)) }
 
-void apply_eosio_passdomain(apply_context& context) {
+void apply_cyber_domain_passdomain(apply_context& context) {
    auto op = context.act.data_as<passdomain>();
    try {
       context.require_authorization(op.from);   // TODO: special case if nobody owns domain
@@ -414,7 +414,7 @@ void apply_eosio_passdomain(apply_context& context) {
       // TODO: move ram usage to new owner
 } FC_CAPTURE_AND_RETHROW((op)) }
 
-void apply_eosio_linkdomain(apply_context& context) {
+void apply_cyber_domain_linkdomain(apply_context& context) {
    auto op = context.act.data_as<linkdomain>();
    try {
       context.require_authorization(op.owner);
@@ -429,7 +429,7 @@ void apply_eosio_linkdomain(apply_context& context) {
       // ram usage unchanged
 } FC_CAPTURE_AND_RETHROW((op)) }
 
-void apply_eosio_unlinkdomain(apply_context& context) {
+void apply_cyber_domain_unlinkdomain(apply_context& context) {
    auto op = context.act.data_as<unlinkdomain>();
    try {
       context.require_authorization(op.owner);
@@ -444,7 +444,7 @@ void apply_eosio_unlinkdomain(apply_context& context) {
       // ram usage unchanged
 } FC_CAPTURE_AND_RETHROW((op)) }
 
-void apply_eosio_newusername(apply_context& context) {
+void apply_cyber_domain_newusername(apply_context& context) {
    auto op = context.act.data_as<newusername>();
    try {
       context.require_authorization(op.creator);

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -200,40 +200,6 @@ abi_def eosio_contract_abi(const abi_def& eosio_system_abi)
       }
    });
 
-   eos_abi.structs.emplace_back(struct_def {
-      "newusername", "", {
-         {"creator", "account_name"},
-         {"owner",   "account_name"},
-         {"name",    "string"},
-      }
-   });
-   eos_abi.structs.emplace_back(struct_def {
-      "newdomain", "", {
-         {"creator", "account_name"},
-         {"name",    "string"},
-      }
-   });
-   eos_abi.structs.emplace_back(struct_def {
-      "passdomain", "", {
-         {"from", "account_name"},
-         {"to",   "account_name"},
-         {"name", "string"},
-      }
-   });
-   eos_abi.structs.emplace_back(struct_def {
-      "linkdomain", "", {
-         {"owner", "account_name"},
-         {"to",    "account_name"},
-         {"name",  "string"},
-      }
-   });
-   eos_abi.structs.emplace_back(struct_def {
-      "unlinkdomain", "", {
-         {"owner", "account_name"},
-         {"name",  "string"},
-      }
-   });
-
    eos_abi.structs.emplace_back( struct_def {
       "requestbw", "", {
          {"provider", "account_name"},
@@ -275,13 +241,49 @@ abi_def eosio_contract_abi(const abi_def& eosio_system_abi)
    eos_abi.actions.push_back( action_def{name("onerror"), "onerror",""} );
    eos_abi.actions.push_back( action_def{name("onblock"), "onblock",""} );
 
-    eos_abi.actions.push_back(action_def{name("newusername"), "newusername",""});
-    eos_abi.actions.push_back(action_def{name("newdomain"), "newdomain",""});
-    eos_abi.actions.push_back(action_def{name("passdomain"), "passdomain",""});
-    eos_abi.actions.push_back(action_def{name("linkdomain"), "linkdomain",""});
-    eos_abi.actions.push_back(action_def{name("unlinkdomain"), "unlinkdomain",""});
-
    return eos_abi;
+}
+
+
+abi_def domain_contract_abi(const abi_def& cyber_domain_abi) {
+    abi_def abi(cyber_domain_abi);
+    if (abi.version.size() == 0) {
+        abi.version = "cyberway::abi/1.0";
+    }
+    fc::move_append(abi.types, common_type_defs());
+
+    abi.structs.emplace_back(struct_def {"newusername", "", {
+        {"creator", "name"},
+        {"owner",   "name"},
+        {"name",    "string"}}
+    });
+    abi.structs.emplace_back(struct_def {"newdomain", "", {
+        {"creator", "name"},
+        {"name",    "string"}}
+    });
+    abi.structs.emplace_back(struct_def {"passdomain", "", {
+        {"from", "name"},
+        {"to",   "account_name"},
+        {"name", "string"}}
+    });
+    abi.structs.emplace_back(struct_def {"linkdomain", "", {
+        {"owner", "name"},
+        {"to",    "name"},
+        {"name",  "string"}}
+    });
+    abi.structs.emplace_back(struct_def {"unlinkdomain", "", {
+        {"owner", "name"},
+        {"name",  "string"}}
+    });
+
+    // TODO add ricardian contracts
+    abi.actions.push_back(action_def{name("newusername"), "newusername",""});
+    abi.actions.push_back(action_def{name("newdomain"), "newdomain",""});
+    abi.actions.push_back(action_def{name("passdomain"), "passdomain",""});
+    abi.actions.push_back(action_def{name("linkdomain"), "linkdomain",""});
+    abi.actions.push_back(action_def{name("unlinkdomain"), "unlinkdomain",""});
+
+    return abi;
 }
 
 } } /// eosio::chain

--- a/libraries/chain/include/eosio/chain/abi_def.hpp
+++ b/libraries/chain/include/eosio/chain/abi_def.hpp
@@ -172,6 +172,7 @@ struct abi_def {
 };
 
 abi_def eosio_contract_abi(const abi_def& eosio_system_abi);
+abi_def domain_contract_abi(const abi_def& eosio_system_abi);
 vector<type_def> common_type_defs();
 
 } } /// namespace eosio::chain

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -26,6 +26,7 @@ const static auto default_state_guard_size      =    128*1024*1024ll;
 const static uint64_t system_account_name    = N(eosio);
 const static uint64_t null_account_name      = N(eosio.null);
 const static uint64_t producers_account_name = N(eosio.prods);
+const static uint64_t domain_account_name    = N(cyber.domain);
 
 // Active permission of producers account requires greater than 2/3 of the producers to authorize
 const static uint64_t majority_producers_permission_name = N(prod.major); // greater than 1/2 of producers needed to authorize

--- a/libraries/chain/include/eosio/chain/contract_types.hpp
+++ b/libraries/chain/include/eosio/chain/contract_types.hpp
@@ -177,7 +177,7 @@ struct requestbw {
 // it's ugly, but removes boilerplate. TODO: write better
 #define SYS_ACTION_STRUCT(NAME) struct NAME { \
     NAME() = default; \
-    static account_name get_account() { return config::system_account_name; } \
+    static account_name get_account() { return config::domain_account_name; } \
     static action_name get_name()     { return N(NAME); }
 #define SYS_ACTION_STRUCT_END };
 

--- a/libraries/chain/include/eosio/chain/eosio_contract.hpp
+++ b/libraries/chain/include/eosio/chain/eosio_contract.hpp
@@ -25,11 +25,11 @@ namespace eosio { namespace chain {
 
    void apply_eosio_requestbw(apply_context&);
 
-   void apply_eosio_newdomain(apply_context&);
-   void apply_eosio_passdomain(apply_context&);
-   void apply_eosio_linkdomain(apply_context&);
-   void apply_eosio_unlinkdomain(apply_context&);
-   void apply_eosio_newusername(apply_context&);
+   void apply_cyber_domain_newdomain(apply_context&);
+   void apply_cyber_domain_passdomain(apply_context&);
+   void apply_cyber_domain_linkdomain(apply_context&);
+   void apply_cyber_domain_unlinkdomain(apply_context&);
+   void apply_cyber_domain_newusername(apply_context&);
 
    /*
    void apply_eosio_postrecovery(apply_context&);

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -141,7 +141,7 @@ using namespace boost::filesystem;
 static const auto wrap_contract = N(cyber.wrap);
 static const auto msig_contract = N(cyber.msig);
 static const auto token_contract = N(cyber.token);
-static const auto domain_contract = N(cyber.domain);
+static const auto domain_contract = config::domain_account_name;
 static const auto declare_names_action = N(declarenames);
 
 FC_DECLARE_EXCEPTION( explained_exception, 9000000, "explained exception, see error log" );
@@ -415,7 +415,7 @@ fc::variant push_transaction( signed_transaction& trx, int32_t extra_kcpu = 1000
         if (declare_names) {
             FC_ASSERT(have_domain_contract(),
                 "Can't declare resolved names. Either install ${c} contract, or use --dont-declare-names option",
-                ("c", domain_contract));
+                ("c", name{domain_contract}.to_string()));
             std::sort(tx_resolved_names.begin(), tx_resolved_names.end(), [](const auto& a, const auto& b) {
                 return a.domain < b.domain || (a.domain == b.domain && a.account < b.account);
             });


### PR DESCRIPTION
1. Five internal domain actions (`newusername`, `newdomain`, `passdomain`, `linkdomain`, `unlinkdomain`) moved to `cyber.domain` contract (were in `eosio`)
2. Domain contract account name (`cyber.domain`) added to config
3. `cyber.domain` account is now created at `initialize_database` to add abi, to allow usage of internal actions
4. cleos now gets domain contract name from config instead of hardcoded value