### PR TITLE
Remove ricardian contracts from abi #129

### DIFF
--- a/contracts/asserter/asserter.abi
+++ b/contracts/asserter/asserter.abi
@@ -23,15 +23,12 @@
    "actions": [
       {
          "name": "procassert",
-         "type": "assertdef",
-         "ricardian_contract": ""
+         "type": "assertdef"
       }, {
          "name": "provereset",
-         "type": "nothing",
-         "ricardian_contract": ""
+         "type": "nothing"
       }
    ],
    "tables": [],
-   "ricardian_clauses": [],
    "abi_extensions": []
 }

--- a/contracts/eosio.bios/eosio.bios.abi
+++ b/contracts/eosio.bios/eosio.bios.abi
@@ -197,67 +197,51 @@
     }],
    "actions": [{
       "name": "newaccount",
-      "type": "newaccount",
-      "ricardian_contract": ""
+      "type": "newaccount"
     },{
       "name": "setcode",
-      "type": "setcode",
-      "ricardian_contract": ""
+      "type": "setcode"
     },{
       "name": "setabi",
-      "type": "setabi",
-      "ricardian_contract": ""
+      "type": "setabi"
     },{
       "name": "updateauth",
-      "type": "updateauth",
-      "ricardian_contract": ""
+      "type": "updateauth"
     },{
       "name": "deleteauth",
-      "type": "deleteauth",
-      "ricardian_contract": ""
+      "type": "deleteauth"
     },{
       "name": "linkauth",
-      "type": "linkauth",
-      "ricardian_contract": ""
+      "type": "linkauth"
     },{
       "name": "unlinkauth",
-      "type": "unlinkauth",
-      "ricardian_contract": ""
+      "type": "unlinkauth"
     },{
       "name": "canceldelay",
-      "type": "canceldelay",
-      "ricardian_contract": ""
+      "type": "canceldelay"
     },{
       "name": "onerror",
-      "type": "onerror",
-      "ricardian_contract": ""
+      "type": "onerror"
     },{
       "name": "setalimits",
-      "type": "set_account_limits",
-      "ricardian_contract": ""
+      "type": "set_account_limits"
     },{
       "name": "setglimits",
-      "type": "set_global_limits",
-      "ricardian_contract": ""
+      "type": "set_global_limits"
     },{
        "name": "setpriv",
-       "type": "setpriv",
-      "ricardian_contract": ""
+       "type": "setpriv"
     },{
       "name": "setprods",
-      "type": "set_producers",
-      "ricardian_contract": ""
+      "type": "set_producers"
     },{
       "name": "setparams",
-      "type": "setparams",
-      "ricardian_contract": ""
+      "type": "setparams"
     },{
       "name": "reqauth",
-      "type": "require_auth",
-      "ricardian_contract": ""
+      "type": "require_auth"
     }
    ],
    "tables": [],
-   "ricardian_clauses": [],
    "abi_extensions": []
 }

--- a/contracts/eosio.msig/eosio.msig.abi
+++ b/contracts/eosio.msig/eosio.msig.abi
@@ -112,24 +112,19 @@
   ],
   "actions": [{
       "name": "propose",
-      "type": "propose",
-      "ricardian_contract": ""
+      "type": "propose"
     },{
       "name": "approve",
-      "type": "approve",
-      "ricardian_contract": ""
+      "type": "approve"
     },{
       "name": "unapprove",
-      "type": "unapprove",
-      "ricardian_contract": ""
+      "type": "unapprove"
     }, {
       "name": "cancel",
-      "type": "cancel",
-      "ricardian_contract": ""
+      "type": "cancel"
     }, {
       "name": "exec",
-      "type": "exec",
-      "ricardian_contract": ""
+      "type": "exec"
     }
 
   ],
@@ -147,6 +142,5 @@
       "key_types" : ["name"]
     }
   ],
-  "ricardian_clauses": [],
   "abi_extensions": []
 }

--- a/contracts/eosio.sudo/eosio.sudo.abi
+++ b/contracts/eosio.sudo/eosio.sudo.abi
@@ -63,11 +63,9 @@
   ],
   "actions": [{
       "name": "exec",
-      "type": "exec",
-      "ricardian_contract": ""
+      "type": "exec"
     }
   ],
   "tables": [],
-  "ricardian_clauses": [],
   "abi_extensions": []
 }

--- a/contracts/eosio.system/eosio.system.abi
+++ b/contracts/eosio.system/eosio.system.abi
@@ -408,120 +408,91 @@
    ],
    "actions": [{
      "name": "newaccount",
-     "type": "newaccount",
-     "ricardian_contract": ""
+     "type": "newaccount"
    },{
      "name": "setcode",
-     "type": "setcode",
-     "ricardian_contract": ""
+     "type": "setcode"
    },{
      "name": "setabi",
-     "type": "setabi",
-     "ricardian_contract": ""
+     "type": "setabi"
    },{
      "name": "updateauth",
-     "type": "updateauth",
-     "ricardian_contract": ""
+     "type": "updateauth"
    },{
      "name": "deleteauth",
-     "type": "deleteauth",
-     "ricardian_contract": ""
+     "type": "deleteauth"
    },{
      "name": "linkauth",
-     "type": "linkauth",
-     "ricardian_contract": ""
+     "type": "linkauth"
    },{
      "name": "unlinkauth",
-     "type": "unlinkauth",
-     "ricardian_contract": ""
+     "type": "unlinkauth"
    },{
      "name": "canceldelay",
-     "type": "canceldelay",
-     "ricardian_contract": ""
+     "type": "canceldelay"
    },{
      "name": "onerror",
-     "type": "onerror",
-     "ricardian_contract": ""
+     "type": "onerror"
    },{
       "name": "buyrambytes",
-      "type": "buyrambytes",
-      "ricardian_contract": ""
+      "type": "buyrambytes"
    },{
       "name": "buyram",
-      "type": "buyram",
-      "ricardian_contract": ""
+      "type": "buyram"
    },{
       "name": "sellram",
-      "type": "sellram",
-      "ricardian_contract": ""
+      "type": "sellram"
    },{
       "name": "delegatebw",
-      "type": "delegatebw",
-      "ricardian_contract": ""
+      "type": "delegatebw"
    },{
       "name": "undelegatebw",
-      "type": "undelegatebw",
-      "ricardian_contract": ""
+      "type": "undelegatebw"
    },{
       "name": "refund",
-      "type": "refund",
-      "ricardian_contract": ""
+      "type": "refund"
    },{
       "name": "regproducer",
-      "type": "regproducer",
-      "ricardian_contract": ""
+      "type": "regproducer"
    },{
       "name": "setram",
-      "type": "setram",
-      "ricardian_contract": ""
+      "type": "setram"
    },{
       "name": "bidname",
-      "type": "bidname",
-      "ricardian_contract": ""
+      "type": "bidname"
    },{
       "name": "unregprod",
-      "type": "unregprod",
-      "ricardian_contract": ""
+      "type": "unregprod"
    },{
       "name": "regproxy",
-      "type": "regproxy",
-      "ricardian_contract": ""
+      "type": "regproxy"
    },{
       "name": "voteproducer",
-      "type": "voteproducer",
-      "ricardian_contract": ""
+      "type": "voteproducer"
    },{
       "name": "claimrewards",
-      "type": "claimrewards",
-      "ricardian_contract": ""
+      "type": "claimrewards"
    },{
       "name": "setpriv",
-      "type": "setpriv",
-      "ricardian_contract": ""
+      "type": "setpriv"
    },{
       "name": "rmvproducer",
-      "type": "rmvproducer",
-      "ricardian_contract": ""
+      "type": "rmvproducer"
    },{
       "name": "setalimits",
-      "type": "set_account_limits",
-      "ricardian_contract": ""
+      "type": "set_account_limits"
     },{
       "name": "setglimits",
-      "type": "set_global_limits",
-      "ricardian_contract": ""
+      "type": "set_global_limits"
     },{
       "name": "setprods",
-      "type": "set_producers",
-      "ricardian_contract": ""
+      "type": "set_producers"
     },{
       "name": "reqauth",
-      "type": "require_auth",
-      "ricardian_contract": ""
+      "type": "require_auth"
     },{
       "name": "setparams",
-      "type": "setparams",
-      "ricardian_contract": ""
+      "type": "setparams"
     }],
    "tables": [{
       "name": "producers",
@@ -573,6 +544,5 @@
        "key_types" : ["account_name"]
     }
    ],
-   "ricardian_clauses": [],
    "abi_extensions": []
 }

--- a/contracts/eosio.token/eosio.token.abi
+++ b/contracts/eosio.token/eosio.token.abi
@@ -46,16 +46,13 @@
   ],
   "actions": [{
       "name": "transfer",
-      "type": "transfer",
-      "ricardian_contract": ""
+      "type": "transfer"
     },{
       "name": "issue",
-      "type": "issue",
-      "ricardian_contract": ""
+      "type": "issue"
     }, {
       "name": "create",
-      "type": "create",
-      "ricardian_contract": ""
+      "type": "create"
     }
 
   ],
@@ -73,6 +70,5 @@
       "key_types" : ["uint64"]
     }
   ],
-  "ricardian_clauses": [],
   "abi_extensions": []
 }

--- a/contracts/hello/hello.abi
+++ b/contracts/hello/hello.abi
@@ -14,52 +14,10 @@
   ],
   "actions": [{
       "name": "hi",
-      "type": "hi",
-      "ricardian_contract": "# CONTRACT FOR hello::hi## ACTION NAME: hi\n### Parameters### Parameters\nInput parameters:Input parameters:\n\n* `user` (string to include in the output)* `user` (string to include in the output)\n\nImplied parameters: Implied parameters: \n\n* `account_name` (name of the party invoking and signing the contract)* `account_name` (name of the party invoking and signing the contract)\n\n### Intent### Intent\nINTENT. The intention of the author and the invoker of this contract is to print output. It shall have no other effect.INTENT. The intention of the author and the invoker of this contract is to print output. It shall have no other effect.\n\n### Term### Term\nTERM. This Contract expires at the conclusion of code execution.TERM. This Contract expires at the conclusion of code execution.\n"
+      "type": "hi"
     }
   ],
   "tables": [],
-  "ricardian_clauses": [{
-      "id": "Warranty",
-      "body": "WARRANTY. The invoker of the contract action shall uphold its Obligations under this Contract in a timely and workmanlike manner, using knowledge and recommendations for performing the services which meet generally acceptable standards set forth by EOS.IO Blockchain Block Producers.\n\n"
-    },{
-      "id": "Default",
-      "body": "DEFAULT. The occurrence of any of the following shall constitute a material default under this Contract: \n\n"
-    },{
-      "id": "Remedies",
-      "body": "REMEDIES. In addition to any and all other rights a party may have available according to law, if a party defaults by failing to substantially perform any provision, term or condition of this Contract, the other party may terminate the Contract by providing written notice to the defaulting party. This notice shall describe with sufficient detail the nature of the default. The party receiving such notice shall promptly be removed from being a Block Producer and this Contract shall be automatically terminated. \n  \n"
-    },{
-      "id": "Force Majeure",
-      "body": "FORCE MAJEURE. If performance of this Contract or any obligation under this Contract is prevented, restricted, or interfered with by causes beyond either party's reasonable control (\"Force Majeure\"), and if the party unable to carry out its obligations gives the other party prompt written notice of such event, then the obligations of the party invoking this provision shall be suspended to the extent necessary by such event. The term Force Majeure shall include, without limitation, acts of God, fire, explosion, vandalism, storm or other similar occurrence, orders or acts of military or civil authority, or by national emergencies, insurrections, riots, or wars, or strikes, lock-outs, work stoppages, or supplier failures. The excused party shall use reasonable efforts under the circumstances to avoid or remove such causes of non-performance and shall proceed to perform with reasonable dispatch whenever such causes are removed or ceased. An act or omission shall be deemed within the reasonable control of a party if committed, omitted, or caused by such party, or its employees, officers, agents, or affiliates. \n  \n"
-    },{
-      "id": "Dispute Resolution",
-      "body": "DISPUTE RESOLUTION. Any controversies or disputes arising out of or relating to this Contract will be resolved by binding arbitration under the default rules set forth by the EOS.IO Blockchain. The arbitrator's award will be final, and judgment may be entered upon it by any court having proper jurisdiction. \n  \n"
-    },{
-      "id": "Entire Agreement",
-      "body": "ENTIRE AGREEMENT. This Contract contains the entire agreement of the parties, and there are no other promises or conditions in any other agreement whether oral or written concerning the subject matter of this Contract. This Contract supersedes any prior written or oral agreements between the parties. \n\n"
-    },{
-      "id": "Severability",
-      "body": "SEVERABILITY. If any provision of this Contract will be held to be invalid or unenforceable for any reason, the remaining provisions will continue to be valid and enforceable. If a court finds that any provision of this Contract is invalid or unenforceable, but that by limiting such provision it would become valid and enforceable, then such provision will be deemed to be written, construed, and enforced as so limited. \n\n"
-    },{
-      "id": "Amendment",
-      "body": "AMENDMENT. This Contract may be modified or amended in writing by mutual agreement between the parties, if the writing is signed by the party obligated under the amendment. \n\n"
-    },{
-      "id": "Governing Law",
-      "body": "GOVERNING LAW. This Contract shall be construed in accordance with the Maxims of Equity. \n\n"
-    },{
-      "id": "Notice",
-      "body": "NOTICE. Any notice or communication required or permitted under this Contract shall be sufficiently given if delivered to a verifiable email address or to such other email address as one party may have publicly furnished in writing, or published on a broadcast contract provided by this blockchain for purposes of providing notices of this type. \n"
-    },{
-      "id": "Waiver of Contractual Right",
-      "body": "WAIVER OF CONTRACTUAL RIGHT. The failure of either party to enforce any provision of this Contract shall not be construed as a waiver or limitation of that party's right to subsequently enforce and compel strict compliance with every provision of this Contract. \n\n"
-    },{
-      "id": "Arbitrator's Fees to Prevailing Party",
-      "body": "ARBITRATOR'S FEES TO PREVAILING PARTY. In any action arising hereunder or any separate action pertaining to the validity of this Agreement, both sides shall pay half the initial cost of arbitration, and the prevailing party shall be awarded reasonable arbitrator's fees and costs.\n  \n"
-    },{
-      "id": "Construction and Interpretation",
-      "body": "CONSTRUCTION AND INTERPRETATION. The rule requiring construction or interpretation against the drafter is waived. The document shall be deemed as if it were drafted by both parties in a mutual effort. \n  \n"
-    }
-  ],
   "error_messages": [],
   "abi_extensions": []
 }

--- a/contracts/identity/identity.abi
+++ b/contracts/identity/identity.abi
@@ -73,16 +73,13 @@
   ],
   "actions": [{
       "name": "create",
-      "type": "create",
-      "ricardian_contract": ""
+      "type": "create"
     },{
       "name": "certprop",
-      "type": "certprop",
-      "ricardian_contract": ""
+      "type": "certprop"
     },{
       "name": "settrust",
-      "type": "settrust",
-      "ricardian_contract": ""
+      "type": "settrust"
     }
   ],
   "tables": [{
@@ -113,6 +110,5 @@
       "key_types": [ "account_name" ]
     }
   ],
-  "ricardian_clauses": [],
   "abi_extensions": []
 }

--- a/contracts/integration_test/integration_test.abi
+++ b/contracts/integration_test/integration_test.abi
@@ -23,8 +23,7 @@
   ],
   "actions": [{
       "name": "store",
-      "type": "store",
-      "ricardian_contract": ""
+      "type": "store"
     }
 
   ],
@@ -36,6 +35,5 @@
       "key_types" : ["uint64"]
     }
   ],
-  "ricardian_clauses": [],
   "abi_extensions": []
 }

--- a/contracts/multi_index_test/multi_index_test.abi
+++ b/contracts/multi_index_test/multi_index_test.abi
@@ -16,6 +16,5 @@
     }
   ],
   "tables": [],
-  "ricardian_clauses": [],
   "abi_extensions": []
 }

--- a/contracts/noop/noop.abi
+++ b/contracts/noop/noop.abi
@@ -17,11 +17,9 @@
   ],
   "actions": [{
   "name":"anyaction",
-  "type":"anyaction",
-  "ricardian_contract": ""
+  "type":"anyaction"
   }
 ],
   "tables": [],
-  "ricardian_clauses": [],
   "abi_extensions": []
 }

--- a/contracts/payloadless/payloadless.abi
+++ b/contracts/payloadless/payloadless.abi
@@ -10,50 +10,8 @@
   ],
   "actions": [{
       "name": "doit",
-      "type": "doit",
-      "ricardian_contract": "# CONTRACT FOR payloadless::doit## ACTION NAME: doit\n### Parameters### Parameters\nInput paramters:Input paramters:\n\nImplied parameters: Implied parameters: \n\n### Intent### Intent\nINTENT. The intention of the author and the invoker of this contract is to print output. It shall have no other effect.INTENT. The intention of the author and the invoker of this contract is to print output. It shall have no other effect.\n\n### Term### Term\nTERM. This Contract expires at the conclusion of code execution.TERM. This Contract expires at the conclusion of code execution.\n"
+      "type": "doit"
     }
   ],
-  "tables": [],
-  "ricardian_clauses": [{
-      "id": "Warranty",
-      "body": "WARRANTY. The invoker of the contract action shall uphold its Obligations under this Contract in a timely and workmanlike manner, using knowledge and recommendations for performing the services which meet generally acceptable standards set forth by EOS.IO Blockchain Block Producers.\n\n"
-    },{
-      "id": "Default",
-      "body": "DEFAULT. The occurrence of any of the following shall constitute a material default under this Contract: \n\n"
-    },{
-      "id": "Remedies",
-      "body": "REMEDIES. In addition to any and all other rights a party may have available according to law, if a party defaults by failing to substantially perform any provision, term or condition of this Contract, the other party may terminate the Contract by providing written notice to the defaulting party. This notice shall describe with sufficient detail the nature of the default. The party receiving such notice shall promptly be removed from being a Block Producer and this Contract shall be automatically terminated. \n  \n"
-    },{
-      "id": "Force Majeure",
-      "body": "FORCE MAJEURE. If performance of this Contract or any obligation under this Contract is prevented, restricted, or interfered with by causes beyond either party's reasonable control (\"Force Majeure\"), and if the party unable to carry out its obligations gives the other party prompt written notice of such event, then the obligations of the party invoking this provision shall be suspended to the extent necessary by such event. The term Force Majeure shall include, without limitation, acts of God, fire, explosion, vandalism, storm or other similar occurrence, orders or acts of military or civil authority, or by national emergencies, insurrections, riots, or wars, or strikes, lock-outs, work stoppages, or supplier failures. The excused party shall use reasonable efforts under the circumstances to avoid or remove such causes of non-performance and shall proceed to perform with reasonable dispatch whenever such causes are removed or ceased. An act or omission shall be deemed within the reasonable control of a party if committed, omitted, or caused by such party, or its employees, officers, agents, or affiliates. \n  \n"
-    },{
-      "id": "Dispute Resolution",
-      "body": "DISPUTE RESOLUTION. Any controversies or disputes arising out of or relating to this Contract will be resolved by binding arbitration under the default rules set forth by the EOS.IO Blockchain. The arbitrator's award will be final, and judgment may be entered upon it by any court having proper jurisdiction. \n  \n"
-    },{
-      "id": "Entire Agreement",
-      "body": "ENTIRE AGREEMENT. This Contract contains the entire agreement of the parties, and there are no other promises or conditions in any other agreement whether oral or written concerning the subject matter of this Contract. This Contract supersedes any prior written or oral agreements between the parties. \n\n"
-    },{
-      "id": "Severability",
-      "body": "SEVERABILITY. If any provision of this Contract will be held to be invalid or unenforceable for any reason, the remaining provisions will continue to be valid and enforceable. If a court finds that any provision of this Contract is invalid or unenforceable, but that by limiting such provision it would become valid and enforceable, then such provision will be deemed to be written, construed, and enforced as so limited. \n\n"
-    },{
-      "id": "Amendment",
-      "body": "AMENDMENT. This Contract may be modified or amended in writing by mutual agreement between the parties, if the writing is signed by the party obligated under the amendment. \n\n"
-    },{
-      "id": "Governing Law",
-      "body": "GOVERNING LAW. This Contract shall be construed in accordance with the Maxims of Equity. \n\n"
-    },{
-      "id": "Notice",
-      "body": "NOTICE. Any notice or communication required or permitted under this Contract shall be sufficiently given if delivered to a verifiable email address or to such other email address as one party may have publicly furnished in writing, or published on a broadcast contract provided by this blockchain for purposes of providing notices of this type. \n"
-    },{
-      "id": "Waiver of Contractual Right",
-      "body": "WAIVER OF CONTRACTUAL RIGHT. The failure of either party to enforce any provision of this Contract shall not be construed as a waiver or limitation of that party's right to subsequently enforce and compel strict compliance with every provision of this Contract. \n\n"
-    },{
-      "id": "Arbitrator's Fees to Prevailing Party",
-      "body": "ARBITRATOR'S FEES TO PREVAILING PARTY. In any action arising hereunder or any separate action pertaining to the validity of this Agreement, both sides shall pay half the initial cost of arbitration, and the prevailing party shall be awarded reasonable arbitrator's fees and costs.\n  \n"
-    },{
-      "id": "Construction and Interpretation",
-      "body": "CONSTRUCTION AND INTERPRETATION. The rule requiring construction or interpretation against the drafter is waived. The document shall be deemed as if it were drafted by both parties in a mutual effort. \n  \n"
-    }
-  ]
+  "tables": []
 }

--- a/contracts/proxy/proxy.abi
+++ b/contracts/proxy/proxy.abi
@@ -24,8 +24,7 @@
   ],
   "actions": [{
       "name": "setowner",
-      "type": "setowner",
-      "ricardian_contract": ""
+      "type": "setowner"
     }
   ],
   "tables": [{
@@ -36,6 +35,5 @@
       "key_types" : ["name"]
     }
   ],
-  "ricardian_clauses": [],
   "abi_extensions": []
 }

--- a/contracts/snapshot_test/snapshot_test.abi
+++ b/contracts/snapshot_test/snapshot_test.abi
@@ -16,6 +16,5 @@
     }
   ],
   "tables": [],
-  "ricardian_clauses": [],
   "abi_extensions": []
 }

--- a/contracts/stltest/stltest.abi
+++ b/contracts/stltest/stltest.abi
@@ -24,8 +24,7 @@
   ],
   "actions": [{
       "name": "message",
-      "type": "message",
-      "ricardian_contract": ""
+      "type": "message"
     }
   ],
   "tables": [{
@@ -42,6 +41,5 @@
       "key_types" : ["my_account_name"]
     }
   ],
-  "ricardian_clauses": [],
   "abi_extensions": []
 }

--- a/contracts/test_ram_limit/test_ram_limit.abi
+++ b/contracts/test_ram_limit/test_ram_limit.abi
@@ -59,16 +59,13 @@
   ],
   "actions": [{
       "name": "setentry",
-      "type": "setentry",
-      "ricardian_contract": ""
+      "type": "setentry"
     },{
       "name": "rmentry",
-      "type": "rmentry",
-      "ricardian_contract": ""
+      "type": "rmentry"
     },{
       "name": "printentry",
-      "type": "printentry",
-      "ricardian_contract": ""
+      "type": "printentry"
     }
   ],
   "tables": [{
@@ -82,6 +79,5 @@
       ],
       "type": "test"
     }
-  ],
-  "ricardian_clauses": []
+  ]
 }

--- a/contracts/tic_tac_toe/tic_tac_toe.abi
+++ b/contracts/tic_tac_toe/tic_tac_toe.abi
@@ -82,20 +82,16 @@
   ],
   "actions": [{
       "name": "create",
-      "type": "create",
-      "ricardian_contract": ""
+      "type": "create"
     },{
       "name": "restart",
-      "type": "restart",
-      "ricardian_contract": ""
+      "type": "restart"
     },{
       "name": "close",
-      "type": "close",
-      "ricardian_contract": ""
+      "type": "close"
     },{
       "name": "move",
-      "type": "move",
-      "ricardian_contract": ""
+      "type": "move"
     }
   ],
   "tables": [{
@@ -110,7 +106,6 @@
       "type": "game"
     }
   ],
-  "ricardian_clauses": [],
   "error_messages": [],
   "abi_extensions": []
 }

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -485,8 +485,6 @@ abi_def eosio_contract_abi(abi_def eos_abi)
       }
    });
 
-   // TODO add any ricardian_clauses
-   //
    // ACTION PAYLOADS
 
    eos_abi.structs.emplace_back( struct_def {
@@ -581,19 +579,18 @@ abi_def eosio_contract_abi(abi_def eos_abi)
       }
    });
 
-   // TODO add ricardian contracts
-   eos_abi.actions.push_back( action_def{name("newaccount"), "newaccount",""} );
-   eos_abi.actions.push_back( action_def{name("setcode"), "setcode",""} );
-   eos_abi.actions.push_back( action_def{name("setabi"), "setabi",""} );
-   eos_abi.actions.push_back( action_def{name("updateauth"), "updateauth",""} );
-   eos_abi.actions.push_back( action_def{name("deleteauth"), "deleteauth",""} );
-   eos_abi.actions.push_back( action_def{name("linkauth"), "linkauth",""} );
-   eos_abi.actions.push_back( action_def{name("unlinkauth"), "unlinkauth",""} );
-   eos_abi.actions.push_back( action_def{name("providebw"), "providebw",""} );
-   eos_abi.actions.push_back( action_def{name("requestbw"), "requestbw",""} );
-   eos_abi.actions.push_back( action_def{name("canceldelay"), "canceldelay",""} );
-   eos_abi.actions.push_back( action_def{name("onerror"), "onerror",""} );
-   eos_abi.actions.push_back( action_def{name("onblock"), "onblock",""} );
+   eos_abi.actions.push_back( action_def{name("newaccount"), "newaccount"} );
+   eos_abi.actions.push_back( action_def{name("setcode"), "setcode"} );
+   eos_abi.actions.push_back( action_def{name("setabi"), "setabi"} );
+   eos_abi.actions.push_back( action_def{name("updateauth"), "updateauth"} );
+   eos_abi.actions.push_back( action_def{name("deleteauth"), "deleteauth"} );
+   eos_abi.actions.push_back( action_def{name("linkauth"), "linkauth"} );
+   eos_abi.actions.push_back( action_def{name("unlinkauth"), "unlinkauth"} );
+   eos_abi.actions.push_back( action_def{name("providebw"), "providebw"} );
+   eos_abi.actions.push_back( action_def{name("requestbw"), "requestbw"} );
+   eos_abi.actions.push_back( action_def{name("canceldelay"), "canceldelay"} );
+   eos_abi.actions.push_back( action_def{name("onerror"), "onerror"} );
+   eos_abi.actions.push_back( action_def{name("onblock"), "onblock"} );
 
    return eos_abi;
 }
@@ -629,12 +626,11 @@ abi_def domain_contract_abi(abi_def abi) {
         {"name",  "string"}}
     });
 
-    // TODO add ricardian contracts
-    abi.actions.push_back(action_def{name("newusername"), "newusername",""});
-    abi.actions.push_back(action_def{name("newdomain"), "newdomain",""});
-    abi.actions.push_back(action_def{name("passdomain"), "passdomain",""});
-    abi.actions.push_back(action_def{name("linkdomain"), "linkdomain",""});
-    abi.actions.push_back(action_def{name("unlinkdomain"), "unlinkdomain",""});
+    abi.actions.push_back(action_def{name("newusername"), "newusername"});
+    abi.actions.push_back(action_def{name("newdomain"), "newdomain"});
+    abi.actions.push_back(action_def{name("passdomain"), "passdomain"});
+    abi.actions.push_back(action_def{name("linkdomain"), "linkdomain"});
+    abi.actions.push_back(action_def{name("unlinkdomain"), "unlinkdomain"});
 
     return abi;
 }

--- a/libraries/chain/include/eosio/chain/abi_def.hpp
+++ b/libraries/chain/include/eosio/chain/abi_def.hpp
@@ -52,13 +52,12 @@ struct struct_def {
 
 struct action_def {
    action_def() = default;
-   action_def(const action_name& name, const type_name& type, const string& ricardian_contract)
-   :name(name), type(type), ricardian_contract(ricardian_contract)
+   action_def(const action_name& name, const type_name& type)
+   :name(name), type(type)
    {}
 
    action_name name;
    type_name   type;
-   string      ricardian_contract;
 };
 
 struct event_def {
@@ -106,16 +105,6 @@ struct table_def {
    vector<index_def>  indexes;     //
 };
 
-struct clause_pair {
-   clause_pair() = default;
-   clause_pair( const string& id, const string& body )
-   : id(id), body(body)
-   {}
-
-   string id;
-   string body;
-};
-
 struct error_message {
    error_message() = default;
    error_message( uint64_t error_code, const string& error_msg )
@@ -138,13 +127,12 @@ struct may_not_exist {
 
 struct abi_def {
    abi_def() = default;
-   abi_def(const vector<type_def>& types, const vector<struct_def>& structs, const vector<action_def>& actions, const vector<event_def>& events, const vector<table_def>& tables, const vector<clause_pair>& clauses, const vector<error_message>& error_msgs)
+   abi_def(const vector<type_def>& types, const vector<struct_def>& structs, const vector<action_def>& actions, const vector<event_def>& events, const vector<table_def>& tables, const vector<error_message>& error_msgs)
    :types(types)
    ,structs(structs)
    ,actions(actions)
    ,events(events)
    ,tables(tables)
-   ,ricardian_clauses(clauses)
    ,error_messages(error_msgs)
    {}
 
@@ -154,7 +142,6 @@ struct abi_def {
    vector<action_def>                  actions;
    vector<event_def>                   events;
    vector<table_def>                   tables;
-   vector<clause_pair>                 ricardian_clauses;
    vector<error_message>               error_messages;
    extensions_type                     abi_extensions;
    may_not_exist<vector<variant_def>>  variants;
@@ -196,13 +183,12 @@ void from_variant(const fc::variant& v, eosio::chain::may_not_exist<T>& e) {
 FC_REFLECT( eosio::chain::type_def                         , (new_type_name)(type) )
 FC_REFLECT( eosio::chain::field_def                        , (name)(type) )
 FC_REFLECT( eosio::chain::struct_def                       , (name)(base)(fields) )
-FC_REFLECT( eosio::chain::action_def                       , (name)(type)(ricardian_contract) )
+FC_REFLECT( eosio::chain::action_def                       , (name)(type) )
 FC_REFLECT( eosio::chain::event_def                        , (name)(type) )
 FC_REFLECT( eosio::chain::order_def                        , (field)(order) )
 FC_REFLECT( eosio::chain::index_def                        , (name)(unique)(orders) )
 FC_REFLECT( eosio::chain::table_def                        , (name)(type)(indexes) )
-FC_REFLECT( eosio::chain::clause_pair                      , (id)(body) )
 FC_REFLECT( eosio::chain::error_message                    , (error_code)(error_msg) )
 FC_REFLECT( eosio::chain::variant_def                      , (name)(types) )
 FC_REFLECT( eosio::chain::abi_def                          , (version)(types)(structs)(actions)(events)(tables)
-                                                             (ricardian_clauses)(error_messages)(abi_extensions)(variants) )
+                                                             (error_messages)(abi_extensions)(variants) )

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -381,10 +381,9 @@ namespace eosio { namespace chain {
                                  3015000, "ABI exception" )
       FC_DECLARE_DERIVED_EXCEPTION( abi_not_found_exception,              abi_exception,
                                     3015001, "No ABI found" )
-      FC_DECLARE_DERIVED_EXCEPTION( invalid_ricardian_clause_exception,   abi_exception,
-                                    3015002, "Invalid Ricardian Clause" )
-      FC_DECLARE_DERIVED_EXCEPTION( invalid_ricardian_action_exception,   abi_exception,
-                                    3015003, "Invalid Ricardian Action" )
+
+// CYBERWAY: ricardian exceptions (3015002, 3015003) removed
+
       FC_DECLARE_DERIVED_EXCEPTION( invalid_type_inside_abi,           abi_exception,
                                     3015004, "The type defined in the ABI is invalid" ) // Not to be confused with abi_type_exception
       FC_DECLARE_DERIVED_EXCEPTION( duplicate_abi_type_def_exception,     abi_exception,

--- a/programs/cleos/help_text.cpp
+++ b/programs/cleos/help_text.cpp
@@ -157,8 +157,7 @@ const char* error_advice_abi_type_exception =  R"=====(Ensure that your abi JSON
     "key_names":[ "field_name" ],
     "key_types":[ "type_name" ],
     "type":"type_name" "
-  }],
-  "ricardian_clauses": [{ "id": "string", "body": "string" }]
+  }]
 }
 e.g.
 {
@@ -174,8 +173,7 @@ e.g.
     "key_names":[ "by" ],
     "key_types":[ "account_name" ],
     "type":"foobar"
-  }],
-  "ricardian_clauses": [{ "id": "foo", "body": "bar" }]
+  }]
 })=====";
 const char* error_advice_block_id_type_exception =  "Ensure that the block ID is a SHA-256 hexadecimal string!";
 const char* error_advice_transaction_id_type_exception =  "Ensure that the transaction ID is a SHA-256 hexadecimal string!";

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -165,9 +165,6 @@ fc::variant verify_type_round_trip_conversion( const abi_serializer& abis, const
       },{
          "name": "type",
          "type": "type_name"
-      },{
-         "name": "ricardian_contract",
-         "type": "string"
       }]
    },{
       "name": "table_def",
@@ -189,16 +186,6 @@ fc::variant verify_type_round_trip_conversion( const abi_serializer& abis, const
          "type": "type_name"
       }]
    },{
-     "name": "clause_pair",
-     "base": "",
-     "fields": [{
-         "name": "id",
-         "type": "string"
-     },{
-         "name": "body",
-         "type": "string"
-     }]
-   },{
       "name": "abi_def",
       "base": "",
       "fields": [{
@@ -216,9 +203,6 @@ fc::variant verify_type_round_trip_conversion( const abi_serializer& abis, const
       },{
          "name": "tables",
          "type": "table_def[]"
-      },{
-         "name": "ricardian_clauses",
-         "type": "clause_pair[]"
       },{
          "name": "abi_extensions",
          "type": "abi_extension[]"
@@ -483,8 +467,6 @@ fc::variant verify_type_round_trip_conversion( const abi_serializer& abis, const
   ],
   "actions": [],
   "tables": [],
-  "ricardian_clauses": [{"id":"clause A","body":"clause body A"},
-              {"id":"clause B","body":"clause body B"}],
   "abi_extensions": []
 }
 )=====";
@@ -514,8 +496,7 @@ BOOST_AUTO_TEST_CASE(uint_types)
            }]
        }],
        "actions": [],
-       "tables": [],
-       "ricardian_clauses": []
+       "tables": []
    }
    )=====";
 
@@ -705,8 +686,8 @@ BOOST_AUTO_TEST_CASE(general)
        }],
       "typedef" : {"new_type_name":"new", "type":"old"},
       "typedef_arr": [{"new_type_name":"new", "type":"old"},{"new_type_name":"new", "type":"old"}],
-      "actiondef"       : {"name":"actionname1", "type":"type1", "ricardian_contract":"ricardian1"},
-      "actiondef_arr"   : [{"name":"actionname1", "type":"type1","ricardian_contract":"ricardian1"},{"name":"actionname2", "type":"type2","ricardian_contract":"ricardian2"}],
+      "actiondef"       : {"name":"actionname1", "type":"type1"},
+      "actiondef_arr"   : [{"name":"actionname1", "type":"type1"},{"name":"actionname2", "type":"type2"}],
       "tabledef": {"name":"table1","index_type":"indextype1","key_names":["keyname1"],"key_types":["typename1"],"type":"type1"},
       "tabledef_arr": [
          {"name":"table1","index_type":"indextype1","key_names":["keyname1"],"key_types":["typename1"],"type":"type1"},
@@ -716,26 +697,23 @@ BOOST_AUTO_TEST_CASE(general)
         "version": "cyberway::abi/1.0",
         "types" : [{"new_type_name":"new", "type":"old"}],
         "structs" : [{"name":"struct1", "base":"base1", "fields": [{"name":"name1", "type": "type1"}, {"name":"name2", "type": "type2"}] }],
-        "actions" : [{"name":"action1","type":"type1", "ricardian_contract":""}],
+        "actions" : [{"name":"action1","type":"type1"}],
         "tables" : [{"name":"table1","index_type":"indextype1","key_names":["keyname1"],"key_types":["typename1"],"type":"type1"}],
-        "ricardian_clauses": [],
         "abi_extensions": []
       },
       "abidef_arr": [{
         "version": "cyberway::abi/1.0",
         "types" : [{"new_type_name":"new", "type":"old"}],
         "structs" : [{"name":"struct1", "base":"base1", "fields": [{"name":"name1", "type": "type1"}, {"name":"name2", "type": "type2"}] }],
-        "actions" : [{"name":"action1","type":"type1", "ricardian_contract":""}],
+        "actions" : [{"name":"action1","type":"type1"}],
         "tables" : [{"name":"table1","index_type":"indextype1","key_names":["keyname1"],"key_types":["typename1"],"type":"type1"}],
-        "ricardian_clauses": [],
         "abi_extensions": []
       },{
         "version": "cyberway::abi/1.0",
         "types" : [{"new_type_name":"new", "type":"old"}],
         "structs" : [{"name":"struct1", "base":"base1", "fields": [{"name":"name1", "type": "type1"}, {"name":"name2", "type": "type2"}] }],
-        "actions" : [{"name":"action1","type":"type1", "ricardian_contract": ""}],
+        "actions" : [{"name":"action1","type":"type1"}],
         "tables" : [{"name":"table1","index_type":"indextype1","key_names":["keyname1"],"key_types":["typename1"],"type":"type1"}],
-        "ricardian_clauses": [],
         "abi_extensions": []
       }]
     }
@@ -760,8 +738,7 @@ BOOST_AUTO_TEST_CASE(abi_cycle)
         }],
        "structs": [],
        "actions": [],
-       "tables": [],
-       "ricardian_clauses": []
+       "tables": []
    }
    )=====";
 
@@ -783,8 +760,7 @@ BOOST_AUTO_TEST_CASE(abi_cycle)
          "fields": []
        }],
        "actions": [],
-       "tables": [],
-       "ricardian_clauses": []
+       "tables": []
    }
    )=====";
 
@@ -1200,9 +1176,6 @@ BOOST_AUTO_TEST_CASE(setabi_test)
                },{
                   "name": "type",
                   "type": "type_name"
-               },{
-                  "name": "ricardian_contract",
-                  "type": "string"
                }]
          },{
                "name": "table_def",
@@ -1224,16 +1197,6 @@ BOOST_AUTO_TEST_CASE(setabi_test)
                   "type": "type_name"
                }]
          },{
-            "name": "clause_pair",
-            "base": "",
-            "fields": [{
-               "name": "id",
-               "type": "string"
-            },{
-               "name": "body",
-               "type": "string"
-            }]
-         },{
                "name": "abi_def",
                "base": "",
                "fields": [{
@@ -1252,16 +1215,12 @@ BOOST_AUTO_TEST_CASE(setabi_test)
                   "name": "tables",
                   "type": "table_def[]"
                },{
-                  "name": "ricardian_clauses",
-                  "type": "clause_pair[]"
-               },{
                   "name": "abi_extensions",
                   "type": "abi_extension[]"
                }]
          }],
          "actions": [],
          "tables": [],
-         "ricardian_clauses": [],
          "abi_extensions": []
       }
    )=====";
@@ -1312,8 +1271,7 @@ BOOST_AUTO_TEST_CASE(setabi_test)
         ],
         "actions": [{
             "name": "transfer",
-            "type": "transfer",
-            "ricardian_contract": "transfer contract"
+            "type": "transfer"
           }
         ],
         "tables": [{
@@ -1324,7 +1282,6 @@ BOOST_AUTO_TEST_CASE(setabi_test)
             "key_types" : ["name"]
           }
         ],
-       "ricardian_clauses": [],
        "abi_extensions": []
       }
    )=====";
@@ -1587,8 +1544,7 @@ BOOST_AUTO_TEST_CASE(packed_transaction)
            "type": "action2"
          }
        ],
-       "tables": [],
-       "ricardian_clauses": []
+       "tables": []
    }
    )=====";
    fc::variant var;
@@ -1663,8 +1619,7 @@ BOOST_AUTO_TEST_CASE(abi_type_repeat)
          "key_names" : ["account"],
          "key_types" : ["name"]
        }
-     ],
-    "ricardian_clauses": []
+     ]
    }
    )=====";
 
@@ -1721,8 +1676,7 @@ BOOST_AUTO_TEST_CASE(abi_struct_repeat)
          "key_names" : ["account"],
          "key_types" : ["name"]
        }
-     ],
-     "ricardian_clauses": []
+     ]
    }
    )=====";
 
@@ -1781,8 +1735,7 @@ BOOST_AUTO_TEST_CASE(abi_action_repeat)
          "key_names" : ["account"],
          "key_types" : ["name"]
        }
-     ],
-    "ricardian_clauses": []
+     ]
    }
    )=====";
 
@@ -1828,8 +1781,7 @@ BOOST_AUTO_TEST_CASE(abi_table_repeat)
      ],
      "actions": [{
          "name": "transfer",
-         "type": "transfer",
-         "ricardian_contract": "transfer contract"
+         "type": "transfer"
        }
      ],
      "tables": [{
@@ -1881,8 +1833,7 @@ BOOST_AUTO_TEST_CASE(abi_type_def)
      ],
      "actions": [{
          "name": "transfer",
-         "type": "transfer",
-         "ricardian_contract": "transfer contract"
+         "type": "transfer"
        }
      ],
      "tables": []
@@ -1937,8 +1888,7 @@ BOOST_AUTO_TEST_CASE(abi_type_loop)
      ],
      "actions": [{
          "name": "transfer",
-         "type": "transfer",
-         "ricardian_contract": "transfer contract"
+         "type": "transfer"
        }
      ],
      "tables": []
@@ -1978,8 +1928,7 @@ BOOST_AUTO_TEST_CASE(abi_type_redefine)
      ],
      "actions": [{
          "name": "transfer",
-         "type": "transfer",
-         "ricardian_contract": "transfer contract"
+         "type": "transfer"
        }
      ],
      "tables": []
@@ -2067,8 +2016,7 @@ BOOST_AUTO_TEST_CASE(abi_account_name_in_eosio_abi)
      ],
      "actions": [{
          "name": "transfer",
-         "type": "transfer",
-         "ricardian_contract": "transfer contract"
+         "type": "transfer"
        }
      ],
      "tables": []
@@ -2098,8 +2046,7 @@ BOOST_AUTO_TEST_CASE(abi_large_array)
        ],
        "actions": [{
            "name": "hi",
-           "type": "hi[]",
-           "ricardian_contract": ""
+           "type": "hi[]"
          }
        ],
        "tables": []
@@ -2150,8 +2097,7 @@ BOOST_AUTO_TEST_CASE(abi_is_type_recursion)
         ],
         "actions": [{
             "name": "hi",
-            "type": "hi",
-            "ricardian_contract": ""
+            "type": "hi"
           }
         ],
         "tables": []
@@ -2217,8 +2163,7 @@ BOOST_AUTO_TEST_CASE(abi_recursive_structs)
         ],
         "actions": [{
             "name": "hi",
-            "type": "hi",
-            "ricardian_contract": ""
+            "type": "hi"
           }
         ],
         "tables": []

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -2129,7 +2129,6 @@ BOOST_FIXTURE_TEST_CASE(eosio_assert_code_tests, TESTER) { try {
    "structs": [],
    "actions": [],
    "tables": [],
-   "ricardian_clauses": [],
    "error_messages": [
       {"error_code": 1, "error_msg": "standard error message" },
       {"error_code": 42, "error_msg": "The answer to life, the universe, and everything."}

--- a/unittests/contracts/deferred_test/deferred_test.abi
+++ b/unittests/contracts/deferred_test/deferred_test.abi
@@ -42,20 +42,16 @@
   ],
   "actions": [{
       "name": "defercall",
-      "type": "defercall",
-      "ricardian_contract": ""
+      "type": "defercall"
     },{
       "name": "deferfunc",
-      "type": "deferfunc",
-      "ricardian_contract": ""
+      "type": "deferfunc"
     },{
       "name": "inlinecall",
-      "type": "inlinecall",
-      "ricardian_contract": ""
+      "type": "inlinecall"
     }
   ],
   "tables": [],
-  "ricardian_clauses": [],
   "error_messages": [],
   "abi_extensions": []
 }


### PR DESCRIPTION
Note: `abi_def` changed so abi serialisation changed too. Nothing changes if working with `cleos`, but external libs (js, etc) may require to update serialisation for `setabi` action