### PR TITLE
Rename "eosio" account name to "cyber" #251

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,7 +226,7 @@ if ("${EOSIO_ROOT_KEY}" STREQUAL "")
    set(EOSIO_ROOT_KEY "GLS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV")
 endif()
 
-message( STATUS "Using '${EOSIO_ROOT_KEY}' as public key for 'eosio' account" )
+message( STATUS "Using '${EOSIO_ROOT_KEY}' as public key for 'cyber' account" )
 
 include(wasm)
 add_subdirectory( libraries )

--- a/Docker/config.ini
+++ b/Docker/config.ini
@@ -208,7 +208,7 @@ max-scheduled-transaction-time-per-block-ms = 2000
 max-irreversible-block-age = -1
 
 # ID of producer controlled by this node (e.g. inita; may specify multiple times) (eosio::producer_plugin)
-producer-name = eosio
+producer-name = cyber
 
 # (DEPRECATED - Use signature-provider instead) Tuple of [public key, WIF private key] (may specify multiple times) (eosio::producer_plugin)
 # private-key = 

--- a/contracts/eosio.system/eosio.system.cpp
+++ b/contracts/eosio.system/eosio.system.cpp
@@ -9,6 +9,8 @@
 
 namespace eosiosystem {
 
+   static constexpr auto names_account = N(cyber.names);
+
    system_contract::system_contract( account_name s )
    :native(s),
     _voters(_self,_self),
@@ -22,7 +24,7 @@ namespace eosiosystem {
       auto itr = _rammarket.find(S(4,RAMCORE));
 
       if( itr == _rammarket.end() ) {
-         auto system_token_supply   = eosio::token(N(eosio.token)).get_supply(eosio::symbol_type(system_token_symbol).name()).amount;
+         auto system_token_supply   = eosio::token(TOKEN_ACC).get_supply(eosio::symbol_type(system_token_symbol).name()).amount;
          if( system_token_supply > 0 ) {
             itr = _rammarket.emplace( _self, [&]( auto& m ) {
                m.supply.amount = 100000000000000ll;
@@ -74,7 +76,7 @@ namespace eosiosystem {
    }
 
    void system_contract::setparams( const eosio::blockchain_parameters& params ) {
-      require_auth( N(eosio) );
+      require_auth(SYSTEM_ACC);
       (eosio::blockchain_parameters&)(_gstate) = params;
       eosio_assert( 3 <= _gstate.max_authority_depth, "max_authority_depth should be at least 3" );
       set_blockchain_parameters( params );
@@ -104,8 +106,8 @@ namespace eosiosystem {
       eosio_assert( bid.symbol == asset().symbol, "asset must be system token" );
       eosio_assert( bid.amount > 0, "insufficient bid" );
 
-      INLINE_ACTION_SENDER(eosio::token, transfer)( N(eosio.token), {bidder,N(active)},
-                                                    { bidder, N(eosio.names), bid, std::string("bid name ")+(name{newname}).to_string()  } );
+      INLINE_ACTION_SENDER(eosio::token, transfer)(TOKEN_ACC, {bidder,N(active)},
+         {bidder, names_account, bid, std::string("bid name ")+(name{newname}).to_string()});
 
       name_bid_table bids(_self,_self);
       print( name{bidder}, " bid ", bid, " on ", name{newname}, "\n" );
@@ -122,9 +124,9 @@ namespace eosiosystem {
          eosio_assert( bid.amount - current->high_bid > (current->high_bid / 10), "must increase bid by 10%" );
          eosio_assert( current->high_bidder != bidder, "account is already highest bidder" );
 
-         INLINE_ACTION_SENDER(eosio::token, transfer)( N(eosio.token), {N(eosio.names),N(active)},
-                                                       { N(eosio.names), current->high_bidder, asset(current->high_bid),
-                                                       std::string("refund bid on name ")+(name{newname}).to_string()  } );
+         INLINE_ACTION_SENDER(eosio::token, transfer)(TOKEN_ACC, {names_account,N(active)},
+            {names_account, current->high_bidder, asset(current->high_bid),
+               std::string("refund bid on name ")+(name{newname}).to_string()});
 
          bids.modify( current, bidder, [&]( auto& b ) {
             b.high_bidder = bidder;

--- a/contracts/eosio.system/producer_pay.cpp
+++ b/contracts/eosio.system/producer_pay.cpp
@@ -16,11 +16,14 @@ namespace eosiosystem {
    const uint64_t useconds_per_day      = 24 * 3600 * uint64_t(1000000);
    const uint64_t useconds_per_year     = seconds_per_year*1000000ll;
 
+   static constexpr auto saving_account_name = N(cyber.saving);
+   static constexpr auto bpay_account_name = N(cyber.bpay);
+   static constexpr auto vpay_account_name = N(cyber.vpay);
 
    void system_contract::onblock( block_timestamp timestamp, account_name producer ) {
       using namespace eosio;
 
-      require_auth(N(eosio));
+      require_auth(SYSTEM_ACC);
 
       /** until activated stake crosses this threshold no new rewards are paid */
       if( _gstate.total_activated_stake < min_activated_stake )
@@ -78,7 +81,7 @@ namespace eosiosystem {
 
       eosio_assert( ct - prod.last_claim_time > useconds_per_day, "already claimed rewards within past day" );
 
-      const asset token_supply   = token( N(eosio.token)).get_supply(symbol_type(system_token_symbol).name() );
+      const asset token_supply = token(TOKEN_ACC).get_supply(symbol_type(system_token_symbol).name());
       const auto usecs_since_last_fill = ct - _gstate.last_pervote_bucket_fill;
 
       if( usecs_since_last_fill > 0 && _gstate.last_pervote_bucket_fill > 0 ) {
@@ -89,17 +92,17 @@ namespace eosiosystem {
          auto to_per_block_pay   = to_producers / 4;
          auto to_per_vote_pay    = to_producers - to_per_block_pay;
 
-         INLINE_ACTION_SENDER(eosio::token, issue)( N(eosio.token), {{N(eosio),N(active)}},
-                                                    {N(eosio), asset(new_tokens), std::string("issue tokens for producer pay and savings")} );
+         INLINE_ACTION_SENDER(eosio::token, issue)(TOKEN_ACC, {{SYSTEM_ACC,N(active)}},
+            {SYSTEM_ACC, asset(new_tokens), std::string("issue tokens for producer pay and savings")});
 
-         INLINE_ACTION_SENDER(eosio::token, transfer)( N(eosio.token), {N(eosio),N(active)},
-                                                       { N(eosio), N(eosio.saving), asset(to_savings), "unallocated inflation" } );
+         INLINE_ACTION_SENDER(eosio::token, transfer)(TOKEN_ACC, {SYSTEM_ACC,N(active)},
+            {SYSTEM_ACC, saving_account_name, asset(to_savings), "unallocated inflation"});
 
-         INLINE_ACTION_SENDER(eosio::token, transfer)( N(eosio.token), {N(eosio),N(active)},
-                                                       { N(eosio), N(eosio.bpay), asset(to_per_block_pay), "fund per-block bucket" } );
+         INLINE_ACTION_SENDER(eosio::token, transfer)(TOKEN_ACC, {SYSTEM_ACC,N(active)},
+            {SYSTEM_ACC, bpay_account_name, asset(to_per_block_pay), "fund per-block bucket"});
 
-         INLINE_ACTION_SENDER(eosio::token, transfer)( N(eosio.token), {N(eosio),N(active)},
-                                                       { N(eosio), N(eosio.vpay), asset(to_per_vote_pay), "fund per-vote bucket" } );
+         INLINE_ACTION_SENDER(eosio::token, transfer)(TOKEN_ACC, {SYSTEM_ACC,N(active)},
+            {SYSTEM_ACC, vpay_account_name, asset(to_per_vote_pay), "fund per-vote bucket"});
 
          _gstate.pervote_bucket  += to_per_vote_pay;
          _gstate.perblock_bucket += to_per_block_pay;
@@ -128,12 +131,12 @@ namespace eosiosystem {
       });
 
       if( producer_per_block_pay > 0 ) {
-         INLINE_ACTION_SENDER(eosio::token, transfer)( N(eosio.token), {N(eosio.bpay),N(active)},
-                                                       { N(eosio.bpay), owner, asset(producer_per_block_pay), std::string("producer block pay") } );
+         INLINE_ACTION_SENDER(eosio::token, transfer)( TOKEN_ACC, {bpay_account_name,N(active)},
+            {bpay_account_name, owner, asset(producer_per_block_pay), std::string("producer block pay")});
       }
       if( producer_per_vote_pay > 0 ) {
-         INLINE_ACTION_SENDER(eosio::token, transfer)( N(eosio.token), {N(eosio.vpay),N(active)},
-                                                       { N(eosio.vpay), owner, asset(producer_per_vote_pay), std::string("producer vote pay") } );
+         INLINE_ACTION_SENDER(eosio::token, transfer)(TOKEN_ACC, {vpay_account_name,N(active)},
+            {vpay_account_name, owner, asset(producer_per_vote_pay), std::string("producer vote pay")});
       }
    }
 

--- a/contracts/eosiolib/dispatcher.hpp
+++ b/contracts/eosiolib/dispatcher.hpp
@@ -122,8 +122,8 @@ extern "C" { \
    void apply( uint64_t receiver, uint64_t code, uint64_t action ) { \
       auto self = receiver; \
       if( action == N(onerror)) { \
-         /* onerror is only valid if it is for the "eosio" code account and authorized by "eosio"'s "active permission */ \
-         eosio_assert(code == N(eosio), "onerror action's are only valid from the \"eosio\" system account"); \
+         /* onerror is only valid if it is for the system code account and authorized by system's active permission */ \
+         eosio_assert(code == SYSTEM_ACC, "onerror action's are only valid from the system account"); \
       } \
       if( code == self || action == N(onerror) ) { \
          TYPE thiscontract( self ); \

--- a/contracts/eosiolib/eosio.hpp
+++ b/contracts/eosiolib/eosio.hpp
@@ -3,6 +3,10 @@
  *  @copyright defined in eos/LICENSE
  */
 #pragma once
+
+#define SYSTEM_ACC N(cyber)
+#define TOKEN_ACC  N(cyber.token)
+
 #include <eosiolib/types.hpp>
 #include <eosiolib/action.hpp>
 #include <eosiolib/print.hpp>

--- a/contracts/identity/identity.cpp
+++ b/contracts/identity/identity.cpp
@@ -1,7 +1,6 @@
 #include "common.hpp"
 
-#include <eosiolib/contract.hpp>
-#include <eosiolib/dispatcher.hpp>
+#include <eosiolib/eosio.hpp>
 #include <eosiolib/vector.hpp>
 
 namespace identity {

--- a/contracts/identity/test/identity_test.cpp
+++ b/contracts/identity/test/identity_test.cpp
@@ -1,6 +1,4 @@
-#include <eosiolib/action.h>
-#include <eosiolib/contract.hpp>
-#include <eosiolib/dispatcher.hpp>
+#include <eosiolib/eosio.hpp>
 #include <identity/interface.hpp>
 
 namespace identity_test {

--- a/contracts/proxy/proxy.cpp
+++ b/contracts/proxy/proxy.cpp
@@ -50,7 +50,7 @@ namespace proxy {
          configs::store(code_config, self);
 
          transaction out;
-         out.actions.emplace_back(permission_level{self, N(active)}, N(eosio.token), N(transfer), new_transfer);
+         out.actions.emplace_back(permission_level{self, N(active)}, TOKEN_ACC, N(transfer), new_transfer);
          out.delay_sec = code_config.delay;
          out.send(id, self);
       }
@@ -91,9 +91,9 @@ extern "C" {
 
     /// The apply method implements the dispatch of events to this contract
     void apply( uint64_t receiver, uint64_t code, uint64_t action ) {
-      if( code == N(eosio) && action == N(onerror) ) {
+      if( code == SYSTEM_ACC && action == N(onerror) ) {
          apply_onerror( receiver, onerror::from_current_action() );
-      } else if( code == N(eosio.token) ) {
+      } else if( code == TOKEN_ACC ) {
          if( action == N(transfer) ) {
             apply_transfer(receiver, code, unpack_action_data<eosio::token::transfer_args>());
          }

--- a/contracts/test_api/test_api.cpp
+++ b/contracts/test_api/test_api.cpp
@@ -22,7 +22,7 @@ account_name global_receiver;
 
 extern "C" {
    void apply( uint64_t receiver, uint64_t code, uint64_t action ) {
-      if( code == N(eosio) && action == N(onerror) ) {
+      if( code == SYSTEM_ACC && action == N(onerror) ) {
          auto error = eosio::onerror::from_current_action();
          eosio::print("onerror called\n");
          auto error_trx = error.unpack_sent_trx();

--- a/libraries/chain/authorization_manager.cpp
+++ b/libraries/chain/authorization_manager.cpp
@@ -344,7 +344,7 @@ namespace eosio { namespace chain {
 
       const auto linked_permission_name = lookup_minimum_permission(link.account, link.code, link.type);
 
-      if( !linked_permission_name ) // if action is linked to eosio.any permission
+      if( !linked_permission_name ) // if action is linked to cyber.any permission
          return;
 
       EOS_ASSERT( get_permission(auth).satisfies( get_permission({link.account, *linked_permission_name}),
@@ -479,7 +479,7 @@ namespace eosio { namespace chain {
 
             if( !special_case ) {
                auto min_permission_name = lookup_minimum_permission(declared_auth.actor, act.account, act.name);
-               if( min_permission_name ) { // since special cases were already handled, it should only be false if the permission is eosio.any
+               if( min_permission_name ) { // since special cases were already handled, it should only be false if the permission is cyber.any
                   const auto& min_permission = get_permission({declared_auth.actor, *min_permission_name});
                   EOS_ASSERT( get_permission(declared_auth).satisfies( min_permission,
                                                                        _db.get_index<permission_index>().indices() ),

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -228,23 +228,23 @@ struct controller_impl {
 #define SET_APP_HANDLER( receiver, contract, action) \
    set_apply_handler( #receiver, #contract, #action, &BOOST_PP_CAT(apply_, BOOST_PP_CAT(contract, BOOST_PP_CAT(_,action) ) ) )
 
-   SET_APP_HANDLER( eosio, eosio, newaccount );
-   SET_APP_HANDLER( eosio, eosio, setcode );
-   SET_APP_HANDLER( eosio, eosio, setabi );
-   SET_APP_HANDLER( eosio, eosio, updateauth );
-   SET_APP_HANDLER( eosio, eosio, deleteauth );
-   SET_APP_HANDLER( eosio, eosio, linkauth );
-   SET_APP_HANDLER( eosio, eosio, unlinkauth );
+   SET_APP_HANDLER(cyber, cyber, newaccount);
+   SET_APP_HANDLER(cyber, cyber, setcode);
+   SET_APP_HANDLER(cyber, cyber, setabi);
+   SET_APP_HANDLER(cyber, cyber, updateauth);
+   SET_APP_HANDLER(cyber, cyber, deleteauth);
+   SET_APP_HANDLER(cyber, cyber, linkauth);
+   SET_APP_HANDLER(cyber, cyber, unlinkauth);
 
-   SET_APP_HANDLER( eosio, eosio, providebw );
-   SET_APP_HANDLER( eosio, eosio, requestbw );
+   SET_APP_HANDLER(cyber, cyber, providebw);
+   SET_APP_HANDLER(cyber, cyber, requestbw);
 /*
-   SET_APP_HANDLER( eosio, eosio, postrecovery );
-   SET_APP_HANDLER( eosio, eosio, passrecovery );
-   SET_APP_HANDLER( eosio, eosio, vetorecovery );
+   SET_APP_HANDLER(cyber, cyber, postrecovery);
+   SET_APP_HANDLER(cyber, cyber, passrecovery);
+   SET_APP_HANDLER(cyber, cyber, vetorecovery);
 */
 
-   SET_APP_HANDLER( eosio, eosio, canceldelay );
+   SET_APP_HANDLER(cyber, cyber, canceldelay);
 
 #define SET_CONTRACT_HANDLER(contract, action, function) set_apply_handler(contract, contract, #action, function);
 #define SET_DOTCONTRACT_HANDLER(base, sub, action) SET_CONTRACT_HANDLER(#base "." #sub, action, \

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -860,9 +860,13 @@ struct controller_impl {
         signed_transaction call_provide_trx;
         transaction_context trx_context( self, call_provide_trx, call_provide_trx.id());
         for (const auto& action : actions) {
-            if (action.account == N(eosio) && action.name == N(requestbw)) {
+            if (action.account == config::system_account_name && action.name == config::request_bw_action) {
                 const auto request_bw = action.data_as<requestbw>();
-                call_provide_trx.actions.emplace_back(vector<permission_level>{{request_bw.provider, config::active_name}}, request_bw.provider, N(approvebw), fc::raw::pack(approvebw( request_bw.account)));
+                call_provide_trx.actions.emplace_back(
+                    vector<permission_level>{{request_bw.provider, config::active_name}},
+                    request_bw.provider,
+                    config::approve_bw_action,
+                    fc::raw::pack(approvebw(request_bw.account)));
             }
         }
 

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -74,7 +74,7 @@ const string& system_prefix() {
 /**
  *  This method is called assuming precondition_system_newaccount succeeds a
  */
-void apply_eosio_newaccount(apply_context& context) {
+void apply_cyber_newaccount(apply_context& context) {
    auto create = context.act.data_as<newaccount>();
    try {
    context.require_authorization(create.creator);
@@ -132,7 +132,7 @@ void apply_eosio_newaccount(apply_context& context) {
 
 } FC_CAPTURE_AND_RETHROW( (create) ) }
 
-void apply_eosio_setcode(apply_context& context) {
+void apply_cyber_setcode(apply_context& context) {
    const auto& cfg = context.control.get_global_properties().configuration;
 
    auto& db = context.db;
@@ -178,7 +178,7 @@ void apply_eosio_setcode(apply_context& context) {
    }
 }
 
-void apply_eosio_setabi(apply_context& context) {
+void apply_cyber_setabi(apply_context& context) {
    auto& db  = context.db;
    auto  act = context.act.data_as<setabi>();
 
@@ -209,7 +209,7 @@ void apply_eosio_setabi(apply_context& context) {
    }
 }
 
-void apply_eosio_updateauth(apply_context& context) {
+void apply_cyber_updateauth(apply_context& context) {
 
    auto update = context.act.data_as<updateauth>();
    context.require_authorization(update.account); // only here to mark the single authority on this action as used
@@ -273,7 +273,7 @@ void apply_eosio_updateauth(apply_context& context) {
    }
 }
 
-void apply_eosio_deleteauth(apply_context& context) {
+void apply_cyber_deleteauth(apply_context& context) {
 //   context.require_write_lock( config::eosio_auth_scope );
 
    auto remove = context.act.data_as<deleteauth>();
@@ -304,7 +304,7 @@ void apply_eosio_deleteauth(apply_context& context) {
 
 }
 
-void apply_eosio_linkauth(apply_context& context) {
+void apply_cyber_linkauth(apply_context& context) {
 //   context.require_write_lock( config::eosio_auth_scope );
 
    auto requirement = context.act.data_as<linkauth>();
@@ -352,7 +352,7 @@ void apply_eosio_linkauth(apply_context& context) {
   } FC_CAPTURE_AND_RETHROW((requirement))
 }
 
-void apply_eosio_unlinkauth(apply_context& context) {
+void apply_cyber_unlinkauth(apply_context& context) {
 //   context.require_write_lock( config::eosio_auth_scope );
 
    auto& db = context.db;
@@ -371,22 +371,22 @@ void apply_eosio_unlinkauth(apply_context& context) {
    db.remove(*link);
 }
 
-void apply_eosio_providebw(apply_context& context) {
+void apply_cyber_providebw(apply_context& context) {
    auto args = context.act.data_as<providebw>();
    context.require_authorization(args.provider);
 }
 
-void apply_eosio_requestbw(apply_context& context) {
+void apply_cyber_requestbw(apply_context& context) {
    auto args = context.act.data_as<requestbw>();
    context.require_authorization(args.account);
 }
 
-void apply_eosio_provideram(apply_context& context) {
+void apply_cyber_provideram(apply_context& context) {
    auto args = context.act.data_as<provideram>();
    context.require_authorization(args.provider);
 }
 
-void apply_eosio_canceldelay(apply_context& context) {
+void apply_cyber_canceldelay(apply_context& context) {
    auto cancel = context.act.data_as<canceldelay>();
    context.require_authorization(cancel.canceling_auth.actor); // only here to mark the single authority on this action as used
 

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -23,22 +23,26 @@ const static auto default_state_size            = 1*1024*1024*1024ll;
 const static auto default_state_guard_size      =    128*1024*1024ll;
 
 
-const static uint64_t system_account_name    = N(eosio);
-const static uint64_t null_account_name      = N(eosio.null);
-const static uint64_t producers_account_name = N(eosio.prods);
+const static uint64_t system_account_name    = N(cyber);
+const static uint64_t null_account_name      = N(cyber.null);
+const static uint64_t producers_account_name = N(cyber.prods);
 const static uint64_t domain_account_name    = N(cyber.domain);
 
 // Active permission of producers account requires greater than 2/3 of the producers to authorize
 const static uint64_t majority_producers_permission_name = N(prod.major); // greater than 1/2 of producers needed to authorize
 const static uint64_t minority_producers_permission_name = N(prod.minor); // greater than 1/3 of producers needed to authorize0
 
-const static uint64_t eosio_auth_scope       = N(eosio.auth);
-const static uint64_t eosio_all_scope        = N(eosio.all);
+const static uint64_t eosio_auth_scope       = N(cyber.auth);
+const static uint64_t eosio_all_scope        = N(cyber.all);
 
 const static uint64_t active_name = N(active);
 const static uint64_t owner_name  = N(owner);
-const static uint64_t eosio_any_name = N(eosio.any);
-const static uint64_t eosio_code_name = N(eosio.code);
+const static uint64_t eosio_any_name = N(cyber.any);
+const static uint64_t eosio_code_name = N(cyber.code);
+
+const static uint64_t request_bw_action = N(requestbw);
+const static uint64_t approve_bw_action = N(approvebw);
+const static uint64_t provide_bw_action = N(providebw);
 
 const static int      block_interval_ms = 3000;
 const static int      block_interval_us = block_interval_ms*1000;

--- a/libraries/chain/include/eosio/chain/contract_types.hpp
+++ b/libraries/chain/include/eosio/chain/contract_types.hpp
@@ -152,7 +152,7 @@ struct providebw {
     }
 
     static action_name get_name() {
-        return N(providebw);
+        return config::provide_bw_action;
     }
 };
 
@@ -170,7 +170,7 @@ struct requestbw {
     }
 
     static action_name get_name() {
-        return N(requestbw);
+        return config::request_bw_action;
     }
 };
 
@@ -262,7 +262,7 @@ struct approvebw {
     }
 
     static action_name get_name() {
-        return N(approvebw);
+        return config::approve_bw_action;
     }
 };
 

--- a/libraries/chain/include/eosio/chain/eosio_contract.hpp
+++ b/libraries/chain/include/eosio/chain/eosio_contract.hpp
@@ -15,15 +15,15 @@ namespace eosio { namespace chain {
     * @defgroup native_action_handlers Native Action Handlers
     */
    ///@{
-   void apply_eosio_newaccount(apply_context&);
-   void apply_eosio_updateauth(apply_context&);
-   void apply_eosio_deleteauth(apply_context&);
-   void apply_eosio_linkauth(apply_context&);
-   void apply_eosio_unlinkauth(apply_context&);
+   void apply_cyber_newaccount(apply_context&);
+   void apply_cyber_updateauth(apply_context&);
+   void apply_cyber_deleteauth(apply_context&);
+   void apply_cyber_linkauth(apply_context&);
+   void apply_cyber_unlinkauth(apply_context&);
 
-   void apply_eosio_providebw(apply_context&);
+   void apply_cyber_providebw(apply_context&);
 
-   void apply_eosio_requestbw(apply_context&);
+   void apply_cyber_requestbw(apply_context&);
 
    void apply_cyber_domain_newdomain(apply_context&);
    void apply_cyber_domain_passdomain(apply_context&);
@@ -32,15 +32,15 @@ namespace eosio { namespace chain {
    void apply_cyber_domain_newusername(apply_context&);
 
    /*
-   void apply_eosio_postrecovery(apply_context&);
-   void apply_eosio_passrecovery(apply_context&);
-   void apply_eosio_vetorecovery(apply_context&);
+   void apply_cyber_postrecovery(apply_context&);
+   void apply_cyber_passrecovery(apply_context&);
+   void apply_cyber_vetorecovery(apply_context&);
    */
 
-   void apply_eosio_setcode(apply_context&);
-   void apply_eosio_setabi(apply_context&);
+   void apply_cyber_setcode(apply_context&);
+   void apply_cyber_setabi(apply_context&);
 
-   void apply_eosio_canceldelay(apply_context&);
+   void apply_cyber_canceldelay(apply_context&);
    ///@}  end action handlers
 
 } } /// namespace eosio::chain

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -250,7 +250,7 @@ namespace bacc = boost::accumulators;
          if (act.account == config::system_account_name && act.name == config::provide_bw_action) {
             auto args = act.data_as<providebw>();
             provided_accounts.insert(args.account);
-         } else if( act.account == N(eosio) && act.name == N(provideram) ) {
+         } else if (act.account == config::system_account_name && act.name == N(provideram)) {
             add_ram_provider(act.data_as<provideram>());
          }
          for( const auto& auth : act.authorization ) {

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -247,7 +247,7 @@ namespace bacc = boost::accumulators;
       flat_set<account_name> provided_accounts;
 
       for( const auto& act : trx.actions ) {
-         if( act.account == N(eosio) && act.name == N(providebw) ) {
+         if (act.account == config::system_account_name && act.name == config::provide_bw_action) {
             auto args = act.data_as<providebw>();
             provided_accounts.insert(args.account);
          } else if( act.account == N(eosio) && act.name == N(provideram) ) {

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -55,6 +55,21 @@ namespace boost { namespace test_tools { namespace tt_detail {
 
 } } }
 
+// list common system names here to avoid "magic values" in tests
+namespace eosio { namespace chain { namespace config {
+
+static const auto msig_account_name    = N(cyber.msig);
+static const auto token_account_name   = N(cyber.token);
+static const auto names_account_name   = N(cyber.names);
+static const auto ram_account_name     = N(cyber.ram);
+static const auto ramfee_account_name  = N(cyber.ramfee);
+static const auto stake_account_name   = N(cyber.stake);
+static const auto bpay_account_name    = N(cyber.bpay);
+static const auto vpay_account_name    = N(cyber.vpay);
+static const auto saving_account_name  = N(cyber.saving);
+
+}}};
+
 namespace eosio { namespace testing {
    std::vector<uint8_t> read_wasm( const char* fn );
    std::vector<char>    read_abi( const char* fn );

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1713,11 +1713,11 @@ read_only::get_account_results read_only::get_account( const get_account_params&
 //   if( abi_serializer::to_abi(code_account.abi, abi) ) {
 //      abi_serializer abis( abi, abi_serializer_max_time );
 //
-//      const auto token_code = N(eosio.token);
+//      const auto token_code = N(cyber.token);
 //
 //      auto core_symbol = extract_core_symbol();
 //
-//      if (params.expected_core_symbol.valid()) 
+//      if (params.expected_core_symbol.valid())
 //         core_symbol = *(params.expected_core_symbol);
 //
 //      const auto* t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple( token_code, params.account_name, N(accounts) ));
@@ -1899,9 +1899,10 @@ namespace detail {
 chain::symbol read_only::extract_core_symbol()const {
    symbol core_symbol(0);
 
-   // The following code makes assumptions about the contract deployed on eosio account (i.e. the system contract) and how it stores its data.
+   // The following code makes assumptions about the contract deployed on cyber account (i.e. the system contract) and how it stores its data.
    const auto& d = db.db();
-   const auto* t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(boost::make_tuple( N(eosio), N(eosio), N(rammarket) ));
+   const auto* t_id = d.find<chain::table_id_object, chain::by_code_scope_table>(
+      boost::make_tuple(config::system_account_name, config::system_account_name, N(rammarket)));
    if( t_id != nullptr ) {
       const auto &idx = d.get_index<key_value_index, by_scope_primary>();
       auto it = idx.find(boost::make_tuple( t_id->id, eosio::chain::string_to_symbol_c(4,"RAMCORE") ));

--- a/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
+++ b/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
@@ -184,7 +184,7 @@ struct txn_test_gen_plugin_impl {
             trxs.emplace_back(std::move(trx));
          }
 
-         //set txn.test.t contract to eosio.token & initialize it
+         //set txn.test.t contract to cyber.token & initialize it
          {
             signed_transaction trx;
 

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -142,6 +142,7 @@ static const auto msig_contract = N(cyber.msig);
 static const auto token_contract = N(cyber.token);
 static const auto domain_contract = config::domain_account_name;
 static const auto declare_names_action = N(declarenames);
+static const auto msig_contract_str = name(msig_contract).to_string();
 
 FC_DECLARE_EXCEPTION( explained_exception, 9000000, "explained exception, see error log" );
 FC_DECLARE_EXCEPTION( localized_exception, 10000000, "an error occured" );
@@ -465,7 +466,7 @@ void print_action( const fc::variant& at ) {
    auto console = at["console"].as_string();
 
    /*
-   if( code == "eosio" && func == "setcode" )
+   if( name(code) == config::system_account_name && func == "setcode" )
       args = args.substr(40)+"...";
    if( name(code) == config::system_account_name && func == "setabi" )
       args = args.substr(40)+"...";
@@ -1593,7 +1594,9 @@ struct bidname_info_subcommand {
       list_producers->add_option("newname", newname, localized("The bidding name"))->required();
       list_producers->set_callback([this] {
          auto rawResult = call(get_table_func, fc::mutable_variant_object("json", true)
-                               ("code", "eosio")("scope", "eosio")("table", "namebids")
+                               ("code", name(config::system_account_name).to_string())
+                               ("scope", name(config::system_account_name).to_string())
+                               ("table", "namebids")
                                ("lower_bound", newname.value)
                                ("upper_bound", newname.value + 1)
                                // Less than ideal upper_bound usage preserved so cleos can still work with old buggy nodeos versions
@@ -3299,7 +3302,7 @@ int main( int argc, char** argv ) {
 
    review->set_callback([&] {
       const auto result1 = call(get_table_func, fc::mutable_variant_object("json", true)
-                         ("code", msig_contract)
+                         ("code", msig_contract_str)
                          ("scope", proposer)
                          ("table", "proposal")
                          ("table_key", "")
@@ -3336,7 +3339,7 @@ int main( int argc, char** argv ) {
 
          try {
             const auto& result2 = call(get_table_func, fc::mutable_variant_object("json", true)
-                                       ("code", "eosio.msig")
+                                       ("code", msig_contract_str)
                                        ("scope", proposer)
                                        ("table", "approvals2")
                                        ("table_key", "")
@@ -3368,7 +3371,7 @@ int main( int argc, char** argv ) {
             }
          } else {
             const auto result3 = call(get_table_func, fc::mutable_variant_object("json", true)
-                                       ("code", "eosio.msig")
+                                       ("code", msig_contract_str)
                                        ("scope", proposer)
                                        ("table", "approvals")
                                        ("table_key", "")
@@ -3401,8 +3404,8 @@ int main( int argc, char** argv ) {
          if( new_multisig ) {
             for( auto& a : provided_approvers ) {
                const auto result4 = call(get_table_func, fc::mutable_variant_object("json", true)
-                                          ("code", "eosio.msig")
-                                          ("scope", "eosio.msig")
+                                          ("code", msig_contract_str)
+                                          ("scope", msig_contract_str)
                                           ("table", "invals")
                                           ("table_key", "")
                                           ("lower_bound", a.first.value)
@@ -3536,7 +3539,7 @@ int main( int argc, char** argv ) {
          ("account", invalidator);
 
       auto accountPermissions = get_account_permissions(tx_permission, {invalidator,config::active_name});
-      send_actions({chain::action{accountPermissions, "eosio.msig", "invalidate", variant_to_bin( N(eosio.msig), "invalidate", args ) }});
+      send_actions({chain::action{accountPermissions, msig_contract, "invalidate", variant_to_bin(msig_contract, "invalidate", args)}});
    });
 
    // multisig cancel

--- a/programs/eosio-launcher/main.cpp
+++ b/programs/eosio-launcher/main.cpp
@@ -867,7 +867,7 @@ launcher_def::bind_nodes () {
          auto pubkey = kp.get_public_key();
          node.keys.emplace_back (move(kp));
          if (is_bios) {
-            string prodname = "eosio";
+            string prodname = "cyber";
             node.producers.push_back(prodname);
             producer_set.schedule.push_back({prodname,pubkey});
          }
@@ -1218,7 +1218,7 @@ launcher_def::write_setprods_file() {
   }
    producer_set_def no_bios;
    for (auto &p : producer_set.schedule) {
-      if (p.producer_name != "eosio")
+      if (p.producer_name != "cyber")
          no_bios.schedule.push_back(p);
    }
   auto str = fc::json::to_pretty_string( no_bios, fc::json::default_generator );
@@ -1259,7 +1259,7 @@ launcher_def::write_bios_boot () {
          }
          else if (key == "cacmd") {
             for (auto &p : producer_set.schedule) {
-               if (p.producer_name == "eosio") {
+               if (p.producer_name == "cyber") {
                   continue;
                }
                brb << "cacmd " << p.producer_name

--- a/testnet.template
+++ b/testnet.template
@@ -56,7 +56,7 @@ wcmd () {
 }
 
 cacmd () {
-    programs/cleos/cleos  --wallet-url $wdurl --url http://$bioshost:$biosport system newaccount --transfer --stake-net "10000000.0000 SYS" --stake-cpu "10000000.0000 SYS"  --buy-ram "10000000.0000 SYS" eosio $* >> $logfile 2>&1
+    programs/cleos/cleos  --wallet-url $wdurl --url http://$bioshost:$biosport system newaccount --transfer --stake-net "10000000.0000 SYS" --stake-cpu "10000000.0000 SYS"  --buy-ram "10000000.0000 SYS" cyber $* >> $logfile 2>&1
     ecmd system regproducer $1 $2
     ecmd system voteproducer prods $1 $1
 }
@@ -75,39 +75,39 @@ wcmd create --to-console -n ignition
 # ------ DO NOT ALTER THE NEXT LINE -------
 ###INSERT prodkeys
 
-ecmd set contract eosio contracts/eosio.bios eosio.bios.wasm eosio.bios.abi
+ecmd set contract cyber contracts/eosio.bios eosio.bios.wasm eosio.bios.abi
 
 # Create required system accounts
 ecmd create key --to-console
 pubsyskey=`grep "^Public key:" $logfile | tail -1 | sed "s/^Public key://"`
 prisyskey=`grep "^Private key:" $logfile | tail -1 | sed "s/^Private key://"`
-echo eosio.* keys: $prisyskey $pubsyskey >> $logfile
+echo cyber.* keys: $prisyskey $pubsyskey >> $logfile
 wcmd import -n ignition --private-key $prisyskey
-ecmd create account eosio eosio.bpay $pubsyskey $pubsyskey
-ecmd create account eosio eosio.msig $pubsyskey $pubsyskey
-ecmd create account eosio eosio.names $pubsyskey $pubsyskey
-ecmd create account eosio eosio.ram $pubsyskey $pubsyskey
-ecmd create account eosio eosio.ramfee $pubsyskey $pubsyskey
-ecmd create account eosio eosio.saving $pubsyskey $pubsyskey
-ecmd create account eosio eosio.stake $pubsyskey $pubsyskey
-ecmd create account eosio eosio.token $pubsyskey $pubsyskey
-ecmd create account eosio eosio.vpay $pubsyskey $pubsyskey
-ecmd create account eosio eosio.sudo $pubsyskey $pubsyskey
+ecmd create account cyber cyber.bpay $pubsyskey $pubsyskey
+ecmd create account cyber cyber.msig $pubsyskey $pubsyskey
+ecmd create account cyber cyber.names $pubsyskey $pubsyskey
+ecmd create account cyber cyber.ram $pubsyskey $pubsyskey
+ecmd create account cyber cyber.ramfee $pubsyskey $pubsyskey
+ecmd create account cyber cyber.saving $pubsyskey $pubsyskey
+ecmd create account cyber cyber.stake $pubsyskey $pubsyskey
+ecmd create account cyber cyber.token $pubsyskey $pubsyskey
+ecmd create account cyber cyber.vpay $pubsyskey $pubsyskey
+ecmd create account cyber cyber.sudo $pubsyskey $pubsyskey
 
-ecmd set contract eosio.token contracts/eosio.token eosio.token.wasm eosio.token.abi
-ecmd set contract eosio.msig contracts/eosio.msig eosio.msig.wasm eosio.msig.abi
-ecmd set contract eosio.sudo contracts/eosio.sudo eosio.sudo.wasm eosio.sudo.abi
+ecmd set contract cyber.token contracts/eosio.token eosio.token.wasm eosio.token.abi
+ecmd set contract cyber.msig contracts/eosio.msig eosio.msig.wasm eosio.msig.abi
+ecmd set contract cyber.sudo contracts/eosio.sudo eosio.sudo.wasm eosio.sudo.abi
 
 echo ===== Start: $step ============ >> $logfile
-echo executing: cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action eosio.token create '[ "eosio", "10000000000.0000 SYS" ]' -p eosio.token | tee -a $logfile
-echo executing: cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action eosio.token issue '[ "eosio", "1000000000.0000 SYS", "memo" ]' -p eosio | tee -a $logfile
+echo executing: cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action cyber.token create '["cyber", "10000000000.0000 SYS"]' -p cyber.token | tee -a $logfile
+echo executing: cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action cyber.token issue '["cyber", "1000000000.0000 SYS", "memo"]' -p cyber | tee -a $logfile
 echo ----------------------- >> $logfile
-programs/cleos/cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action eosio.token create '[ "eosio", "10000000000.0000 SYS" ]' -p eosio.token >> $logfile 2>&1
-programs/cleos/cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action eosio.token issue '[ "eosio", "1000000000.0000 SYS", "memo" ]' -p eosio >> $logfile 2>&1
+programs/cleos/cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action cyber.token create '["cyber", "10000000000.0000 SYS"]' -p cyber.token >> $logfile 2>&1
+programs/cleos/cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action cyber.token issue '["cyber", "1000000000.0000 SYS", "memo"]' -p cyber >> $logfile 2>&1
 echo ==== End: $step ============== >> $logfile
 step=$(($step + 1))
 
-ecmd set contract eosio contracts/eosio.system eosio.system.wasm eosio.system.abi
+ecmd set contract cyber contracts/eosio.system eosio.system.wasm eosio.system.abi
 
 # Manual deployers, add a series of lines below this block that looks like:
 #    cacmd $PRODNAME[0] $OWNERKEY[0] $ACTIVEKEY[0]

--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -75,7 +75,7 @@ class Cluster(object):
         self.defProducerAccounts={}
         self.defproduceraAccount=self.defProducerAccounts["defproducera"]= Account("defproducera")
         self.defproducerbAccount=self.defProducerAccounts["defproducerb"]= Account("defproducerb")
-        self.eosioAccount=self.defProducerAccounts["eosio"]= Account("eosio")
+        self.eosioAccount=self.defProducerAccounts["cyber"]= Account("cyber")
 
         self.defproduceraAccount.ownerPrivateKey=defproduceraPrvtKey
         self.defproduceraAccount.activePrivateKey=defproduceraPrvtKey
@@ -372,7 +372,7 @@ class Cluster(object):
             initAccountKeys(account, producerKeys[name])
             self.defProducerAccounts[name] = account
 
-        self.eosioAccount=self.defProducerAccounts["eosio"]
+        self.eosioAccount=self.defProducerAccounts["cyber"]
         self.defproduceraAccount=self.defProducerAccounts["defproducera"]
         self.defproducerbAccount=self.defProducerAccounts["defproducerb"]
 
@@ -877,7 +877,7 @@ class Cluster(object):
             Utils.Print("ERROR: Failed to create ignition wallet.")
             return None
 
-        eosioName="eosio"
+        eosioName="cyber"
         eosioKeys=producerKeys[eosioName]
         eosioAccount=Account(eosioName)
         eosioAccount.ownerPrivateKey=eosioKeys["private"]
@@ -893,15 +893,15 @@ class Cluster(object):
         initialFunds="1000000.0000 {0}".format(CORE_SYMBOL)
         Utils.Print("Transfer initial fund %s to individual accounts." % (initialFunds))
         trans=None
-        contract="eosio.token"
+        contract="cyber.token"
         action="transfer"
         for name, keys in producerKeys.items():
-            data="{\"from\":\"eosio\",\"to\":\"%s\",\"quantity\":\"%s\",\"memo\":\"%s\"}" % (name, initialFunds, "init eosio transfer")
-            opts="--permission eosio@active"
-            if name != "eosio":
+            data="{\"from\":\"cyber\",\"to\":\"%s\",\"quantity\":\"%s\",\"memo\":\"%s\"}" % (name, initialFunds, "init cyber transfer")
+            opts="--permission cyber@active"
+            if name != "cyber":
                 trans=biosNode.pushMessage(contract, action, data, opts)
                 if trans is None or not trans[0]:
-                    Utils.Print("ERROR: Failed to transfer funds from eosio.token to %s." % (name))
+                    Utils.Print("ERROR: Failed to transfer funds from cyber.token to %s." % (name))
                     return None
 
             Node.validateTransaction(trans[1])
@@ -948,7 +948,7 @@ class Cluster(object):
 
         ignWallet=walletMgr.create("ignition")
 
-        eosioName="eosio"
+        eosioName="cyber"
         eosioKeys=producerKeys[eosioName]
         eosioAccount=Account(eosioName)
         eosioAccount.ownerPrivateKey=eosioKeys["private"]
@@ -1005,8 +1005,8 @@ class Cluster(object):
                     setProdsStr=f.read()
 
                     Utils.Print("Setting producers.")
-                    opts="--permission eosio@active"
-                    myTrans=biosNode.pushMessage("eosio", "setprods", setProdsStr, opts)
+                    opts="--permission cyber@active"
+                    myTrans=biosNode.pushMessage("cyber", "setprods", setProdsStr, opts)
                     if myTrans is None or not myTrans[0]:
                         Utils.Print("ERROR: Failed to set producers.")
                         return None
@@ -1030,9 +1030,9 @@ class Cluster(object):
                 setProdsStr += ' ] }'
                 if Utils.Debug: Utils.Print("setprods: %s" % (setProdsStr))
                 Utils.Print("Setting producers: %s." % (", ".join(prodNames)))
-                opts="--permission eosio@active"
+                opts="--permission cyber@active"
                 # pylint: disable=redefined-variable-type
-                trans=biosNode.pushMessage("eosio", "setprods", setProdsStr, opts)
+                trans=biosNode.pushMessage("cyber", "setprods", setProdsStr, opts)
                 if trans is None or not trans[0]:
                     Utils.Print("ERROR: Failed to set producer %s." % (keys["name"]))
                     return None
@@ -1043,36 +1043,36 @@ class Cluster(object):
                 Utils.Print("ERROR: Failed to validate transaction %s got rolled into a block on server port %d." % (transId, biosNode.port))
                 return None
 
-            # wait for block production handover (essentially a block produced by anyone but eosio).
-            lam = lambda: biosNode.getInfo(exitOnError=True)["head_block_producer"] != "eosio"
+            # wait for block production handover (essentially a block produced by anyone but cyber).
+            lam = lambda: biosNode.getInfo(exitOnError=True)["head_block_producer"] != "cyber"
             ret=Utils.waitForBool(lam)
             if not ret:
                 Utils.Print("ERROR: Block production handover failed.")
                 return None
 
         eosioTokenAccount=copy.deepcopy(eosioAccount)
-        eosioTokenAccount.name="eosio.token"
+        eosioTokenAccount.name="cyber.token"
         trans=biosNode.createAccount(eosioTokenAccount, eosioAccount, 0)
         if trans is None:
             Utils.Print("ERROR: Failed to create account %s" % (eosioTokenAccount.name))
             return None
 
         eosioRamAccount=copy.deepcopy(eosioAccount)
-        eosioRamAccount.name="eosio.ram"
+        eosioRamAccount.name="cyber.ram"
         trans=biosNode.createAccount(eosioRamAccount, eosioAccount, 0)
         if trans is None:
             Utils.Print("ERROR: Failed to create account %s" % (eosioRamAccount.name))
             return None
 
         eosioRamfeeAccount=copy.deepcopy(eosioAccount)
-        eosioRamfeeAccount.name="eosio.ramfee"
+        eosioRamfeeAccount.name="cyber.ramfee"
         trans=biosNode.createAccount(eosioRamfeeAccount, eosioAccount, 0)
         if trans is None:
             Utils.Print("ERROR: Failed to create account %s" % (eosioRamfeeAccount.name))
             return None
 
         eosioStakeAccount=copy.deepcopy(eosioAccount)
-        eosioStakeAccount.name="eosio.stake"
+        eosioStakeAccount.name="cyber.stake"
         trans=biosNode.createAccount(eosioStakeAccount, eosioAccount, 0)
         if trans is None:
             Utils.Print("ERROR: Failed to create account %s" % (eosioStakeAccount.name))
@@ -1084,7 +1084,7 @@ class Cluster(object):
             Utils.Print("ERROR: Failed to validate transaction %s got rolled into a block on server port %d." % (transId, biosNode.port))
             return None
 
-        contract="eosio.token"
+        contract="cyber.token"
         contractDir="contracts/%s" % (contract)
         wasmFile="%s.wasm" % (contract)
         abiFile="%s.abi" % (contract)
@@ -1102,7 +1102,7 @@ class Cluster(object):
         opts="--permission %s@active" % (contract)
         trans=biosNode.pushMessage(contract, action, data, opts)
         if trans is None or not trans[0]:
-            Utils.Print("ERROR: Failed to push create action to eosio contract.")
+            Utils.Print("ERROR: Failed to push create action to cyber contract.")
             return None
 
         Node.validateTransaction(trans[1])
@@ -1118,7 +1118,7 @@ class Cluster(object):
         opts="--permission %s@active" % (contract)
         trans=biosNode.pushMessage(contract, action, data, opts)
         if trans is None or not trans[0]:
-            Utils.Print("ERROR: Failed to push issue action to eosio contract.")
+            Utils.Print("ERROR: Failed to push issue action to cyber contract.")
             return None
 
         Node.validateTransaction(trans[1])
@@ -1132,7 +1132,7 @@ class Cluster(object):
             return None
 
         expectedAmount="1000000000.0000 {0}".format(CORE_SYMBOL)
-        Utils.Print("Verify eosio issue, Expected: %s" % (expectedAmount))
+        Utils.Print("Verify cyber issue, Expected: %s" % (expectedAmount))
         actualAmount=biosNode.getAccountEosBalanceStr(eosioAccount.name)
         if expectedAmount != actualAmount:
             Utils.Print("ERROR: Issue verification failed. Excepted %s, actual: %s" %

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -851,7 +851,7 @@ class Node(object):
     def getAccountEosBalanceStr(self, scope):
         """Returns SYS currency0000 account balance from cleos get table command. Returned balance is string following syntax "98.0311 SYS". """
         assert isinstance(scope, str)
-        amount=self.getTableAccountBalance("eosio.token", scope)
+        amount=self.getTableAccountBalance("cyber.token", scope)
         if Utils.Debug: Utils.Print("getNodeAccountEosBalance %s %s" % (scope, amount))
         assert isinstance(amount, str)
         return amount

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -44,26 +44,27 @@ BOOST_AUTO_TEST_SUITE(get_table_tests)
 BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts({ N(eosio.token), N(eosio.ram), N(eosio.ramfee), N(eosio.stake),
-      N(eosio.bpay), N(eosio.vpay), N(eosio.saving), N(eosio.names) });
+   create_accounts({config::token_account_name, config::ram_account_name, config::ramfee_account_name,
+      config::stake_account_name, config::bpay_account_name, config::vpay_account_name,
+      config::saving_account_name, config::names_account_name});
 
    std::vector<account_name> accs{N(inita), N(initb), N(initc), N(initd)};
    create_accounts(accs);
    produce_block();
 
-   set_code( N(eosio.token), eosio_token_wast );
-   set_abi( N(eosio.token), eosio_token_abi );
+   set_code(config::token_account_name, eosio_token_wast);
+   set_abi(config::token_account_name, eosio_token_abi);
    produce_blocks(1);
 
    // create currency
    auto act = mutable_variant_object()
-         ("issuer",       "eosio")
+         ("issuer",         config::system_account_name)
          ("maximum_supply", eosio::chain::asset::from_string("1000000000.0000 SYS"));
-   push_action(N(eosio.token), N(create), N(eosio.token), act );
+   push_action(config::token_account_name, N(create), config::token_account_name, act);
 
    // issue
    for (account_name a: accs) {
-      push_action( N(eosio.token), N(issue), "eosio", mutable_variant_object()
+      push_action(config::token_account_name, N(issue), config::system_account_name, mutable_variant_object()
                   ("to",      name(a) )
                   ("quantity", eosio::chain::asset::from_string("999.0000 SYS") )
                   ("memo", "")
@@ -73,16 +74,16 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
 
    // iterate over scope
    eosio::chain_apis::read_only plugin(*(this->control), fc::microseconds(INT_MAX));
-   eosio::chain_apis::read_only::get_table_by_scope_params param{N(eosio.token), N(accounts), "inita", "", 10};
+   eosio::chain_apis::read_only::get_table_by_scope_params param{config::token_account_name, N(accounts), "inita", "", 10};
    eosio::chain_apis::read_only::get_table_by_scope_result result = plugin.read_only::get_table_by_scope(param);
 
    BOOST_REQUIRE_EQUAL(4, result.rows.size());
    BOOST_REQUIRE_EQUAL("", result.more);
    if (result.rows.size() >= 4) {
-      BOOST_REQUIRE_EQUAL(name(N(eosio.token)), result.rows[0].code);
+      BOOST_REQUIRE_EQUAL(name(config::token_account_name), result.rows[0].code);
       BOOST_REQUIRE_EQUAL(name(N(inita)), result.rows[0].scope);
       BOOST_REQUIRE_EQUAL(name(N(accounts)), result.rows[0].table);
-      BOOST_REQUIRE_EQUAL(name(N(eosio)), result.rows[0].payer);
+      BOOST_REQUIRE_EQUAL(name(config::system_account_name), result.rows[0].payer);
       BOOST_REQUIRE_EQUAL(1, result.rows[0].count);
 
       BOOST_REQUIRE_EQUAL(name(N(initb)), result.rows[1].scope);
@@ -120,26 +121,27 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
 BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts({ N(eosio.token), N(eosio.ram), N(eosio.ramfee), N(eosio.stake),
-      N(eosio.bpay), N(eosio.vpay), N(eosio.saving), N(eosio.names) });
+   create_accounts({config::token_account_name, config::ram_account_name, config::ramfee_account_name,
+      config::stake_account_name, config::bpay_account_name, config::vpay_account_name,
+      config::saving_account_name, config::names_account_name});
 
    std::vector<account_name> accs{N(inita), N(initb)};
    create_accounts(accs);
    produce_block();
 
-   set_code( N(eosio.token), eosio_token_wast );
-   set_abi( N(eosio.token), eosio_token_abi );
+   set_code(config::token_account_name, eosio_token_wast);
+   set_abi(config::token_account_name, eosio_token_abi);
    produce_blocks(1);
 
    // create currency
    auto act = mutable_variant_object()
-         ("issuer",       "eosio")
+         ("issuer",         config::system_account_name)
          ("maximum_supply", eosio::chain::asset::from_string("1000000000.0000 SYS"));
-   push_action(N(eosio.token), N(create), N(eosio.token), act );
+   push_action(config::token_account_name, N(create), config::token_account_name, act);
 
    // issue
    for (account_name a: accs) {
-      push_action( N(eosio.token), N(issue), "eosio", mutable_variant_object()
+      push_action(config::token_account_name, N(issue), config::system_account_name, mutable_variant_object()
                   ("to",      name(a) )
                   ("quantity", eosio::chain::asset::from_string("10000.0000 SYS") )
                   ("memo", "")
@@ -149,12 +151,12 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
 
    // create currency 2
    act = mutable_variant_object()
-         ("issuer",       "eosio")
+         ("issuer",         config::system_account_name)
          ("maximum_supply", eosio::chain::asset::from_string("1000000000.0000 AAA"));
-   push_action(N(eosio.token), N(create), N(eosio.token), act );
+   push_action(config::token_account_name, N(create), config::token_account_name, act);
    // issue
    for (account_name a: accs) {
-      push_action( N(eosio.token), N(issue), "eosio", mutable_variant_object()
+      push_action(config::token_account_name, N(issue), config::system_account_name, mutable_variant_object()
                   ("to",      name(a) )
                   ("quantity", eosio::chain::asset::from_string("9999.0000 AAA") )
                   ("memo", "")
@@ -164,12 +166,12 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
 
    // create currency 3
    act = mutable_variant_object()
-         ("issuer",       "eosio")
+         ("issuer",         config::system_account_name)
          ("maximum_supply", eosio::chain::asset::from_string("1000000000.0000 CCC"));
-   push_action(N(eosio.token), N(create), N(eosio.token), act );
+   push_action(config::token_account_name, N(create), config::token_account_name, act);
    // issue
    for (account_name a: accs) {
-      push_action( N(eosio.token), N(issue), "eosio", mutable_variant_object()
+      push_action(config::token_account_name, N(issue), config::system_account_name, mutable_variant_object()
                   ("to",      name(a) )
                   ("quantity", eosio::chain::asset::from_string("7777.0000 CCC") )
                   ("memo", "")
@@ -179,12 +181,12 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
 
    // create currency 3
    act = mutable_variant_object()
-         ("issuer",       "eosio")
+         ("issuer",         config::system_account_name)
          ("maximum_supply", eosio::chain::asset::from_string("1000000000.0000 BBB"));
-   push_action(N(eosio.token), N(create), N(eosio.token), act );
+   push_action(config::token_account_name, N(create), config::token_account_name, act);
    // issue
    for (account_name a: accs) {
-      push_action( N(eosio.token), N(issue), "eosio", mutable_variant_object()
+      push_action(config::token_account_name, N(issue), config::system_account_name, mutable_variant_object()
                   ("to",      name(a) )
                   ("quantity", eosio::chain::asset::from_string("8888.0000 BBB") )
                   ("memo", "")
@@ -195,7 +197,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
    // get table: normal case
    eosio::chain_apis::read_only plugin(*(this->control), fc::microseconds(INT_MAX));
    eosio::chain_apis::read_only::get_table_rows_params p;
-   p.code = N(eosio.token);
+   p.code = config::token_account_name;
    p.scope = "inita";
    p.table = N(accounts);
    p.json = true;
@@ -228,15 +230,16 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
    result = plugin.read_only::get_table_rows(p);
    BOOST_REQUIRE_EQUAL(4, result.rows.size());
    BOOST_REQUIRE_EQUAL(false, result.more);
+   const string sys_acc = name{config::system_account_name}.to_string();
    if (result.rows.size() >= 4) {
       BOOST_REQUIRE_EQUAL("9999.0000 AAA", result.rows[3]["data"]["balance"].as_string());
       BOOST_REQUIRE_EQUAL("8888.0000 BBB", result.rows[2]["data"]["balance"].as_string());
       BOOST_REQUIRE_EQUAL("7777.0000 CCC", result.rows[1]["data"]["balance"].as_string());
       BOOST_REQUIRE_EQUAL("10000.0000 SYS", result.rows[0]["data"]["balance"].as_string());
-      BOOST_REQUIRE_EQUAL("eosio", result.rows[0]["payer"].as_string());
-      BOOST_REQUIRE_EQUAL("eosio", result.rows[1]["payer"].as_string());
-      BOOST_REQUIRE_EQUAL("eosio", result.rows[2]["payer"].as_string());
-      BOOST_REQUIRE_EQUAL("eosio", result.rows[3]["payer"].as_string());
+      BOOST_REQUIRE_EQUAL(sys_acc, result.rows[0]["payer"].as_string());
+      BOOST_REQUIRE_EQUAL(sys_acc, result.rows[1]["payer"].as_string());
+      BOOST_REQUIRE_EQUAL(sys_acc, result.rows[2]["payer"].as_string());
+      BOOST_REQUIRE_EQUAL(sys_acc, result.rows[3]["payer"].as_string());
    }
    p.show_payer = false;
 
@@ -315,26 +318,27 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
 BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts({ N(eosio.token), N(eosio.ram), N(eosio.ramfee), N(eosio.stake),
-      N(eosio.bpay), N(eosio.vpay), N(eosio.saving), N(eosio.names) });
+   create_accounts({config::token_account_name, config::ram_account_name, config::ramfee_account_name,
+      config::stake_account_name, config::bpay_account_name, config::vpay_account_name,
+      config::saving_account_name, config::names_account_name});
 
    std::vector<account_name> accs{N(inita), N(initb), N(initc), N(initd)};
    create_accounts(accs);
    produce_block();
 
-   set_code( N(eosio.token), eosio_token_wast );
-   set_abi( N(eosio.token), eosio_token_abi );
+   set_code(config::token_account_name, eosio_token_wast);
+   set_abi(config::token_account_name, eosio_token_abi);
    produce_blocks(1);
 
    // create currency
    auto act = mutable_variant_object()
-         ("issuer",       "eosio")
+         ("issuer",         config::system_account_name)
          ("maximum_supply", eosio::chain::asset::from_string("1000000000.0000 SYS"));
-   push_action(N(eosio.token), N(create), N(eosio.token), act );
+   push_action(config::token_account_name, N(create), config::token_account_name, act);
 
    // issue
    for (account_name a: accs) {
-      push_action( N(eosio.token), N(issue), "eosio", mutable_variant_object()
+      push_action(config::token_account_name, N(issue), config::system_account_name, mutable_variant_object()
                   ("to",      name(a) )
                   ("quantity", eosio::chain::asset::from_string("10000.0000 SYS") )
                   ("memo", "")
@@ -347,7 +351,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, TESTER ) try {
 
    // bidname
    auto bidname = [this]( const account_name& bidder, const account_name& newname, const asset& bid ) {
-      return push_action( N(eosio), N(bidname), bidder, fc::mutable_variant_object()
+      return push_action(config::system_account_name, N(bidname), bidder, fc::mutable_variant_object()
                           ("bidder",  bidder)
                           ("newname", newname)
                           ("bid", bid)
@@ -363,8 +367,8 @@ BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, TESTER ) try {
    // get table: normal case
    eosio::chain_apis::read_only plugin(*(this->control), fc::microseconds(INT_MAX));
    eosio::chain_apis::read_only::get_table_rows_params p;
-   p.code = N(eosio);
-   p.scope = "eosio";
+   p.code = config::system_account_name;
+   p.scope = name(config::system_account_name).to_string();
    p.table = N(namebids);
    p.json = true;
    p.index_position = "secondary"; // ordered by high_bid

--- a/tests/p2p_network_test.py
+++ b/tests/p2p_network_test.py
@@ -135,7 +135,7 @@ node0=cluster.getNode(0)
 
 # eosio should have the same key as defproducera
 eosio = copy.copy(defproduceraAccount)
-eosio.name = "eosio"
+eosio.name = "cyber"
 
 Print("Info of each node:")
 for i in range(len(hosts)):

--- a/tests/p2p_stress.py
+++ b/tests/p2p_stress.py
@@ -50,10 +50,10 @@ class StressNetwork:
         print("transaction id %s" % (trid))
 
         print("issue currency0000 into %s" % (acc1.name))
-        contract="eosio"
+        contract="cyber"
         action="issue"
         data="{\"to\":\"" + acc1.name + "\",\"quantity\":\"1000000.0000 "+CORE_SYMBOL+"\"}"
-        opts="--permission eosio@active"
+        opts="--permission cyber@active"
         tr=node.pushMessage(contract, action, data, opts)
         trid = node.getTransId(tr[1])
         if trid is None:

--- a/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
+++ b/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
@@ -14,18 +14,18 @@ args = None
 logFile = None
 
 unlockTimeout = 999999999
-fastUnstakeSystem = './fast.refund/eosio.system/eosio.system.wasm'
+fastUnstakeSystem = './fast.refund/cyber.system/cyber.system.wasm'
 
 systemAccounts = [
-    'eosio.bpay',
-    'eosio.msig',
-    'eosio.names',
-    'eosio.ram',
-    'eosio.ramfee',
-    'eosio.saving',
-    'eosio.stake',
-    'eosio.token',
-    'eosio.vpay',
+    'cyber.bpay',
+    'cyber.msig',
+    'cyber.names',
+    'cyber.ram',
+    'cyber.ramfee',
+    'cyber.saving',
+    'cyber.stake',
+    'cyber.token',
+    'cyber.vpay',
 ]
 
 def jsonArg(a):
@@ -129,7 +129,7 @@ def startProducers(b, e):
 
 def createSystemAccounts():
     for a in systemAccounts:
-        run(args.cleos + 'create account eosio ' + a + ' ' + args.public_key)
+        run(args.cleos + 'create account cyber ' + a + ' ' + args.public_key)
 
 def intToCurrency(i):
     return '%d.%04d %s' % (i // 10000, i % 10000, args.symbol)
@@ -168,10 +168,10 @@ def createStakedAccounts(b, e):
         stakeCpu = stake - stakeNet
         print('%s: total funds=%s, ram=%s, net=%s, cpu=%s, unstaked=%s' % (a['name'], intToCurrency(a['funds']), intToCurrency(ramFunds), intToCurrency(stakeNet), intToCurrency(stakeCpu), intToCurrency(unstaked)))
         assert(funds == ramFunds + stakeNet + stakeCpu + unstaked)
-        retry(args.cleos + 'system newaccount --transfer eosio %s %s --stake-net "%s" --stake-cpu "%s" --buy-ram "%s"   ' % 
+        retry(args.cleos + 'system newaccount --transfer cyber %s %s --stake-net "%s" --stake-cpu "%s" --buy-ram "%s"   ' % 
             (a['name'], a['pub'], intToCurrency(stakeNet), intToCurrency(stakeCpu), intToCurrency(ramFunds)))
         if unstaked:
-            retry(args.cleos + 'transfer eosio %s "%s"' % (a['name'], intToCurrency(unstaked)))
+            retry(args.cleos + 'transfer cyber %s "%s"' % (a['name'], intToCurrency(unstaked)))
 
 def regProducers(b, e):
     for i in range(b, e):
@@ -192,7 +192,7 @@ def vote(b, e):
         retry(args.cleos + 'system voteproducer prods ' + voter + ' ' + prods)
 
 def claimRewards():
-    table = getJsonOutput(args.cleos + 'get table eosio eosio producers -l 100')
+    table = getJsonOutput(args.cleos + 'get table cyber cyber producers -l 100')
     times = []
     for row in table['rows']:
         if row['unpaid_blocks'] and not row['last_claim_time']:
@@ -209,7 +209,7 @@ def proxyVotes(b, e):
         retry(args.cleos + 'system voteproducer proxy ' + voter + ' ' + proxy)
 
 def updateAuth(account, permission, parent, controller):
-    run(args.cleos + 'push action eosio updateauth' + jsonArg({
+    run(args.cleos + 'push action cyber updateauth' + jsonArg({
         'account': account,
         'permission': permission,
         'parent': parent,
@@ -240,11 +240,11 @@ def msigProposeReplaceSystem(proposer, proposalName):
     requestedPermissions = []
     for i in range(firstProducer, firstProducer + numProducers):
         requestedPermissions.append({'actor': accounts[i]['name'], 'permission': 'active'})
-    trxPermissions = [{'actor': 'eosio', 'permission': 'active'}]
+    trxPermissions = [{'actor': 'cyber', 'permission': 'active'}]
     with open(fastUnstakeSystem, mode='rb') as f:
-        setcode = {'account': 'eosio', 'vmtype': 0, 'vmversion': 0, 'code': f.read().hex()}
+        setcode = {'account': 'cyber', 'vmtype': 0, 'vmversion': 0, 'code': f.read().hex()}
     run(args.cleos + 'multisig propose ' + proposalName + jsonArg(requestedPermissions) + 
-        jsonArg(trxPermissions) + 'eosio setcode' + jsonArg(setcode) + ' -p ' + proposer)
+        jsonArg(trxPermissions) + 'cyber setcode' + jsonArg(setcode) + ' -p ' + proposer)
 
 def msigApproveReplaceSystem(proposer, proposalName):
     for i in range(firstProducer, firstProducer + numProducers):
@@ -256,7 +256,7 @@ def msigExecReplaceSystem(proposer, proposalName):
     retry(args.cleos + 'multisig exec ' + proposer + ' ' + proposalName + ' -p ' + proposer)
 
 def msigReplaceSystem():
-    run(args.cleos + 'push action eosio buyrambytes' + jsonArg(['eosio', accounts[0]['name'], 200000]) + '-p eosio')
+    run(args.cleos + 'push action cyber buyrambytes' + jsonArg(['cyber', accounts[0]['name'], 200000]) + '-p cyber')
     sleep(1)
     msigProposeReplaceSystem(accounts[0]['name'], 'fast.unstake')
     sleep(1)
@@ -281,22 +281,22 @@ def stepStartWallet():
     startWallet()
     importKeys()
 def stepStartBoot():
-    startNode(0, {'name': 'eosio', 'pvt': args.private_key, 'pub': args.public_key})
+    startNode(0, {'name': 'cyber', 'pvt': args.private_key, 'pub': args.public_key})
     sleep(1.5)
 def stepInstallSystemContracts():
-    run(args.cleos + 'set contract eosio.token ' + args.contracts_dir + '/eosio.token/')
-    run(args.cleos + 'set contract eosio.msig ' + args.contracts_dir + '/eosio.msig/')
+    run(args.cleos + 'set contract cyber.token ' + args.contracts_dir + '/eosio.token/')
+    run(args.cleos + 'set contract cyber.msig ' + args.contracts_dir + '/eosio.msig/')
 def stepCreateTokens():
-    run(args.cleos + 'push action eosio.token create \'["eosio", "10000000000.0000 %s"]\' -p eosio.token' % (args.symbol))
+    run(args.cleos + 'push action cyber.token create \'["cyber", "10000000000.0000 %s"]\' -p cyber.token' % (args.symbol))
     totalAllocation = allocateFunds(0, len(accounts))
-    run(args.cleos + 'push action eosio.token issue \'["eosio", "%s", "memo"]\' -p eosio' % intToCurrency(totalAllocation))
+    run(args.cleos + 'push action cyber.token issue \'["cyber", "%s", "memo"]\' -p cyber' % intToCurrency(totalAllocation))
     sleep(1)
 def stepSetSystemContract():
-    retry(args.cleos + 'set contract eosio ' + args.contracts_dir + '/eosio.system/')
+    retry(args.cleos + 'set contract cyber ' + args.contracts_dir + '/eosio.system/')
     sleep(1)
-    run(args.cleos + 'push action eosio setpriv' + jsonArg(['eosio.msig', 1]) + '-p eosio@active')
+    run(args.cleos + 'push action cyber setpriv' + jsonArg(['cyber.msig', 1]) + '-p cyber@active')
 def stepInitSystemContract():
-    run(args.cleos + 'push action eosio init' + jsonArg(['0', '4,SYS']) + '-p eosio@active')
+    run(args.cleos + 'push action cyber init' + jsonArg(['0', '4,SYS']) + '-p cyber@active')
     sleep(1)
 def stepCreateStakedAccounts():
     createStakedAccounts(0, len(accounts))
@@ -315,9 +315,9 @@ def stepVote():
 def stepProxyVotes():
     proxyVotes(0, 0 + args.num_voters)
 def stepResign():
-    resign('eosio', 'eosio.prods')
+    resign('cyber', 'cyber.prods')
     for a in systemAccounts:
-        resign(a, 'eosio')
+        resign(a, 'cyber')
 def stepTransfer():
     while True:
         randomTransfer(0, args.num_senders)
@@ -332,7 +332,7 @@ commands = [
     ('k', 'kill',               stepKillAll,                True,    "Kill all nodeos and keosd processes"),
     ('w', 'wallet',             stepStartWallet,            True,    "Start keosd, create wallet, fill with keys"),
     ('b', 'boot',               stepStartBoot,              True,    "Start boot node"),
-    ('s', 'sys',                createSystemAccounts,       True,    "Create system accounts (eosio.*)"),
+    ('s', 'sys',                createSystemAccounts,       True,    "Create system accounts (cyber.*)"),
     ('c', 'contracts',          stepInstallSystemContracts, True,    "Install system contracts (token, msig)"),
     ('t', 'tokens',             stepCreateTokens,           True,    "Create tokens"),
     ('S', 'sys-contract',       stepSetSystemContract,      True,    "Set system contract"),
@@ -343,7 +343,7 @@ commands = [
     ('v', 'vote',               stepVote,                   True,    "Vote for producers"),
     ('R', 'claim',              claimRewards,               True,    "Claim rewards"),
     ('x', 'proxy',              stepProxyVotes,             True,    "Proxy votes"),
-    ('q', 'resign',             stepResign,                 True,    "Resign eosio"),
+    ('q', 'resign',             stepResign,                 True,    "Resign cyber"),
     ('m', 'msg-replace',        msigReplaceSystem,          False,   "Replace system contract using msig"),
     ('X', 'xfer',               stepTransfer,               False,   "Random transfer tokens (infinite loop)"),
     ('l', 'log',                stepLog,                    True,    "Show tail of node's log"),
@@ -359,7 +359,7 @@ parser.add_argument('--nodes-dir', metavar='', help="Path to nodes directory", d
 parser.add_argument('--genesis', metavar='', help="Path to genesis.json", default="./genesis.json")
 parser.add_argument('--wallet-dir', metavar='', help="Path to wallet directory", default='./wallet/')
 parser.add_argument('--log-path', metavar='', help="Path to log file", default='./output.log')
-parser.add_argument('--symbol', metavar='', help="The eosio.system symbol", default='SYS')
+parser.add_argument('--symbol', metavar='', help="The cyber.system symbol", default='SYS')
 parser.add_argument('--user-limit', metavar='', help="Max number of users. (0 = no limit)", type=int, default=3000)
 parser.add_argument('--max-user-keys', metavar='', help="Maximum user keys to import into wallet", type=int, default=10)
 parser.add_argument('--ram-funds', metavar='', help="How much funds for each user to spend on ram", type=float, default=0.1)

--- a/tutorials/exchange-tutorial-python/exchange_tutorial.py
+++ b/tutorials/exchange-tutorial-python/exchange_tutorial.py
@@ -94,7 +94,7 @@ def is_valid_deposit(action):
     if receiver != 'tokenxchange':
         return False
 
-    if (account == 'eosio.token' and
+    if (account == 'cyber.token' and
             action_name == 'transfer' and
             memo == KEY_TO_INTERNAL_ACCOUNT and
             valid_user and
@@ -121,7 +121,7 @@ def is_valid_withdrawal(action):
     if receiver != 'tokenxchange':
         return False
 
-    if (account == 'eosio.token' and
+    if (account == 'cyber.token' and
             action_name == 'transfer' and
             memo == KEY_TO_INTERNAL_ACCOUNT and
             valid_user and

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -2055,7 +2055,7 @@ BOOST_AUTO_TEST_CASE(abi_large_array)
 
       abi_serializer abis( fc::json::from_string( abi_str ).as<abi_def>(), max_serialization_time );
       // indicate a very large array, but don't actually provide a large array
-      // curl http://127.0.0.1:8888/v1/chain/abi_bin_to_json -X POST -d '{"code":"eosio", "action":"hi", "binargs":"ffffffff08"}'
+      // curl http://127.0.0.1:8888/v1/chain/abi_bin_to_json -X POST -d '{"code":"cyber", "action":"hi", "binargs":"ffffffff08"}'
       bytes bin = {static_cast<char>(0xff),
                    static_cast<char>(0xff),
                    static_cast<char>(0xff),

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -1207,7 +1207,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, TESTER) { try {
       CALL_TEST_FUNCTION(*this, "test_transaction", "send_deferred_tx_with_dtt_action", fc::raw::pack(dtt_act2));
 
       // If the deferred tx receiver == this tx receiver, the authorization checking would originally be bypassed.
-      // But not anymore. Now it should subjectively fail because testapi@additional permission is not unilaterally satisfied by testapi@eosio.code.
+      // But not anymore. Now it should subjectively fail because testapi@additional permission is not unilaterally satisfied by testapi@cyber.code.
       dtt_action dtt_act3;
       dtt_act3.deferred_account = N(testapi);
       dtt_act3.permission_name = N(additional);
@@ -2038,7 +2038,7 @@ BOOST_FIXTURE_TEST_CASE(permission_usage_tests, TESTER) { try {
 
    push_action(config::system_account_name, linkauth::get_name(), N(bob), fc::mutable_variant_object()
            ("account", "bob")
-           ("code", "eosio")
+           ("code", config::system_account_name)
            ("type", "reqauth")
            ("requirement", "perm1")
    );

--- a/unittests/auth_tests.cpp
+++ b/unittests/auth_tests.cpp
@@ -241,17 +241,17 @@ BOOST_AUTO_TEST_CASE(link_auths) { try {
    // Send req auth action with alice's spending key, it should fail
    BOOST_CHECK_THROW(chain.push_reqauth("alice", { permission_level{N(alice), "spending"} }, { spending_priv_key }), irrelevant_auth_exception);
    // Link authority for eosio reqauth action with alice's spending key
-   chain.link_authority("alice", "eosio", "spending",  "reqauth");
+   chain.link_authority("alice", config::system_account_name, "spending", "reqauth");
    // Now, req auth action with alice's spending key should succeed
    chain.push_reqauth("alice", { permission_level{N(alice), "spending"} }, { spending_priv_key });
 
    chain.produce_block();
 
    // Relink the same auth should fail
-   BOOST_CHECK_THROW( chain.link_authority("alice", "eosio", "spending",  "reqauth"), action_validate_exception);
+   BOOST_CHECK_THROW(chain.link_authority("alice", config::system_account_name, "spending", "reqauth"), action_validate_exception);
 
    // Unlink alice with eosio reqauth
-   chain.unlink_authority("alice", "eosio", "reqauth");
+   chain.unlink_authority("alice", config::system_account_name, "reqauth");
    // Now, req auth action with alice's spending key should fail
    BOOST_CHECK_THROW(chain.push_reqauth("alice", { permission_level{N(alice), "spending"} }, { spending_priv_key }), irrelevant_auth_exception);
 
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE(link_auths) { try {
    // Send req auth action with scud key, it should fail
    BOOST_CHECK_THROW(chain.push_reqauth("alice", { permission_level{N(alice), "scud"} }, { scud_priv_key }), irrelevant_auth_exception);
    // Link authority for any eosio action with alice's scud key
-   chain.link_authority("alice", "eosio", "scud");
+   chain.link_authority("alice", config::system_account_name, "scud");
    // Now, req auth action with alice's scud key should succeed
    chain.push_reqauth("alice", { permission_level{N(alice), "scud"} }, { scud_priv_key });
    // req auth action with alice's spending key should also be fine, since it is the parent of alice's scud key
@@ -280,7 +280,7 @@ BOOST_AUTO_TEST_CASE(link_then_update_auth) { try {
 
    chain.set_authority("alice", "first", first_pub_key, "active");
 
-   chain.link_authority("alice", "eosio", "first",  "reqauth");
+   chain.link_authority("alice", config::system_account_name, "first", "reqauth");
    chain.push_reqauth("alice", { permission_level{N(alice), "first"} }, { first_priv_key });
 
    chain.produce_blocks(13); // Wait at least 6 seconds for first push_reqauth transaction to expire.
@@ -324,12 +324,12 @@ try {
                          fc_exception_message_is("account names can only be 12 chars long"));
 
 
-   // Creating account with eosio. prefix with privileged account
-   chain.create_account("eosio.test1");
+   // Creating account with cyber. prefix with privileged account
+   chain.create_account("cyber.test1");
 
-   // Creating account with eosio. prefix with non-privileged account, should fail
-   BOOST_CHECK_EXCEPTION(chain.create_account("eosio.test2", "joe"), action_validate_exception,
-                         fc_exception_message_is("only privileged accounts can have names that start with 'eosio.'"));
+   // Creating account with cyber. prefix with non-privileged account, should fail
+   BOOST_CHECK_EXCEPTION(chain.create_account("cyber.test2", "joe"), action_validate_exception,
+                         fc_exception_message_is("only privileged accounts can have names that start with 'cyber.'"));
 
 } FC_LOG_AND_RETHROW() }
 
@@ -354,8 +354,8 @@ BOOST_AUTO_TEST_CASE( any_auth ) { try {
 
    //test.push_reqauth( N(alice), { permission_level{N(alice),"spending"} }, { spending_priv_key });
 
-   chain.link_authority( "alice", "eosio", "eosio.any", "reqauth" );
-   chain.link_authority( "bob", "eosio", "eosio.any", "reqauth" );
+   chain.link_authority("alice", config::system_account_name, config::eosio_any_name, "reqauth");
+   chain.link_authority("bob", config::system_account_name, config::eosio_any_name, "reqauth");
 
    /// this should succeed because eosio::reqauth is linked to any permission
    chain.push_reqauth("alice", { permission_level{N(alice), "spending"} }, { spending_priv_key });
@@ -502,7 +502,7 @@ BOOST_AUTO_TEST_CASE( linkauth_special ) { try {
       BOOST_REQUIRE_EXCEPTION(
          chain.push_action(config::system_account_name, linkauth::get_name(), tester_account, fc::mutable_variant_object()
                ("account", "tester")
-               ("code", "eosio")
+               ("code", config::system_account_name)
                ("type", type)
                ("requirement", "first")),
          action_validate_exception,

--- a/unittests/contracts/deferred_test/deferred_test.cpp
+++ b/unittests/contracts/deferred_test/deferred_test.cpp
@@ -51,7 +51,7 @@ void apply_onerror(uint64_t receiver, const onerror& error ) {
 extern "C" {
     /// The apply method implements the dispatch of events to this contract
     void apply( uint64_t receiver, uint64_t code, uint64_t action ) {
-      if( code == N(eosio) && action == N(onerror) ) {
+      if( code == SYSTEM_ACC && action == N(onerror) ) {
          apply_onerror( receiver, onerror::from_current_action() );
       } else if( code == receiver ) {
          deferred_test thiscontract(receiver);

--- a/unittests/delay_tests.cpp
+++ b/unittests/delay_tests.cpp
@@ -82,10 +82,10 @@ BOOST_FIXTURE_TEST_CASE( delay_error_create_account, validating_tester) { try {
 
 
 asset get_currency_balance(const TESTER& chain, account_name account) {
-   return chain.get_currency_balance(N(eosio.token), symbol(SY(4,CUR)), account);
+   return chain.get_currency_balance(config::token_account_name, symbol(SY(4,CUR)), account);
 }
 
-const std::string eosio_token = name(N(eosio.token)).to_string();
+const std::string eosio_token = name(config::token_account_name).to_string();
 
 // test link to permission with delay directly on it
 BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
@@ -94,11 +94,11 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
    const auto& tester_account = N(tester);
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account(config::token_account_name);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), eosio_token_wast);
-   chain.set_abi(N(eosio.token), eosio_token_abi);
+   chain.set_code(config::token_account_name, eosio_token_wast);
+   chain.set_abi(config::token_account_name, eosio_token_abi);
 
    chain.produce_blocks();
    chain.create_account(N(tester));
@@ -117,19 +117,19 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
            ("type", "transfer")
            ("requirement", "first"));
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action(config::token_account_name, N(create), config::token_account_name, mutable_variant_object()
            ("issuer", eosio_token)
            ("maximum_supply", "9000000.0000 CUR")
    );
 
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action(config::token_account_name, name("issue"), config::token_account_name, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action(config::token_account_name, name("transfer"), config::token_account_name, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -141,12 +141,12 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -159,7 +159,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
 
    chain.produce_blocks();
 
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "3.0000 CUR")
@@ -232,11 +232,11 @@ BOOST_AUTO_TEST_CASE(delete_auth_test) { try {
    const auto& tester_account = N(tester);
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account(config::token_account_name);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), eosio_token_wast);
-   chain.set_abi(N(eosio.token), eosio_token_abi);
+   chain.set_code(config::token_account_name, eosio_token_wast);
+   chain.set_abi(config::token_account_name, eosio_token_abi);
 
    chain.produce_blocks();
    chain.create_account(N(tester));
@@ -267,27 +267,27 @@ BOOST_AUTO_TEST_CASE(delete_auth_test) { try {
    // link auth
    chain.push_action(config::system_account_name, linkauth::get_name(), tester_account, fc::mutable_variant_object()
            ("account", "tester")
-           ("code", "eosio.token")
+           ("code", config::token_account_name)
            ("type", "transfer")
            ("requirement", "first"));
 
    // create CUR token
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
-           ("issuer", "eosio.token" )
+   chain.push_action(config::token_account_name, N(create), config::token_account_name, mutable_variant_object()
+           ("issuer", config::token_account_name )
            ("maximum_supply", "9000000.0000 CUR" )
    );
 
-   // issue to account "eosio.token"
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
-           ("to",       "eosio.token")
+   // issue to account "cyber.token"
+   chain.push_action(config::token_account_name, name("issue"), config::token_account_name, fc::mutable_variant_object()
+           ("to",       config::token_account_name)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   // transfer from eosio.token to tester
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
-       ("from", "eosio.token")
+   // transfer from cyber.token to tester
+   trace = chain.push_action(config::token_account_name, name("transfer"), config::token_account_name, fc::mutable_variant_object()
+       ("from", config::token_account_name)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
        ("memo", "hi" )
@@ -296,12 +296,12 @@ BOOST_AUTO_TEST_CASE(delete_auth_test) { try {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -310,7 +310,7 @@ BOOST_AUTO_TEST_CASE(delete_auth_test) { try {
 
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
@@ -331,7 +331,7 @@ BOOST_AUTO_TEST_CASE(delete_auth_test) { try {
    // unlink auth
    trace = chain.push_action(config::system_account_name, unlinkauth::get_name(), tester_account, fc::mutable_variant_object()
            ("account", "tester")
-           ("code", "eosio.token")
+           ("code", config::token_account_name)
            ("type", "transfer"));
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
 
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_CASE(delete_auth_test) { try {
 
    chain.produce_blocks(1);;
 
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "3.0000 CUR")
@@ -369,11 +369,11 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
    const auto& tester_account = N(tester);
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account(config::token_account_name);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), eosio_token_wast);
-   chain.set_abi(N(eosio.token), eosio_token_abi);
+   chain.set_code(config::token_account_name, eosio_token_wast);
+   chain.set_abi(config::token_account_name, eosio_token_abi);
 
    chain.produce_blocks();
    chain.create_account(N(tester));
@@ -393,18 +393,18 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
            ("requirement", "first"));
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action(config::token_account_name, N(create), config::token_account_name, mutable_variant_object()
            ("issuer", eosio_token)
            ("maximum_supply", "9000000.0000 CUR")
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action(config::token_account_name, name("issue"), config::token_account_name, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action(config::token_account_name, name("transfer"), config::token_account_name, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -416,12 +416,12 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -434,7 +434,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
@@ -453,7 +453,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
 
    chain.produce_blocks();
 
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "3.0000 CUR")
@@ -507,11 +507,11 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
    const auto& tester_account = N(tester);
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account(config::token_account_name);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), eosio_token_wast);
-   chain.set_abi(N(eosio.token), eosio_token_abi);
+   chain.set_code(config::token_account_name, eosio_token_wast);
+   chain.set_abi(config::token_account_name, eosio_token_abi);
 
    chain.produce_blocks();
    chain.create_account(N(tester));
@@ -537,18 +537,18 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
            ("requirement", "second"));
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action(config::token_account_name, N(create), config::token_account_name, mutable_variant_object()
            ("issuer", eosio_token)
            ("maximum_supply", "9000000.0000 CUR")
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action(config::token_account_name, name("issue"), config::token_account_name, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action(config::token_account_name, name("transfer"), config::token_account_name, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -560,12 +560,12 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -578,7 +578,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
@@ -597,7 +597,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
 
    chain.produce_blocks();
 
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "3.0000 CUR")
@@ -651,11 +651,11 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
    const auto& tester_account = N(tester);
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account(config::token_account_name);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), eosio_token_wast);
-   chain.set_abi(N(eosio.token), eosio_token_abi);
+   chain.set_code(config::token_account_name, eosio_token_wast);
+   chain.set_abi(config::token_account_name, eosio_token_abi);
 
    chain.produce_blocks();
    chain.create_account(N(tester));
@@ -675,18 +675,18 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
            ("requirement", "first"));
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action(config::token_account_name, N(create), config::token_account_name, mutable_variant_object()
            ("issuer", eosio_token )
            ("maximum_supply", "9000000.0000 CUR" )
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action(config::token_account_name, name("issue"), config::token_account_name, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action(config::token_account_name, name("transfer"), config::token_account_name, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -698,13 +698,13 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -719,7 +719,7 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
@@ -753,7 +753,7 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "5.0000 CUR")
@@ -797,7 +797,7 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
    BOOST_CHECK_EQUAL(1, gen_size);
 
    // this transfer is performed right away since delay is removed
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "10.0000 CUR")
@@ -842,11 +842,11 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
    const auto& tester_account = N(tester);
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account(config::token_account_name);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), eosio_token_wast);
-   chain.set_abi(N(eosio.token), eosio_token_abi);
+   chain.set_code(config::token_account_name, eosio_token_wast);
+   chain.set_abi(config::token_account_name, eosio_token_abi);
 
    chain.produce_blocks();
    chain.create_account(N(tester));
@@ -872,18 +872,18 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
            ("requirement", "second"));
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action(config::token_account_name, N(create), config::token_account_name, mutable_variant_object()
            ("issuer", eosio_token)
            ("maximum_supply", "9000000.0000 CUR" )
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action(config::token_account_name, name("issue"), config::token_account_name, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action(config::token_account_name, name("transfer"), config::token_account_name, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -895,13 +895,13 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -916,7 +916,7 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
@@ -952,7 +952,7 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "5.0000 CUR")
@@ -990,7 +990,7 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
    chain.produce_blocks();
 
    // this transfer is performed right away since delay is removed
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "10.0000 CUR")
@@ -1039,11 +1039,11 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
    const auto& tester_account = N(tester);
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account(config::token_account_name);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), eosio_token_wast);
-   chain.set_abi(N(eosio.token), eosio_token_abi);
+   chain.set_code(config::token_account_name, eosio_token_wast);
+   chain.set_abi(config::token_account_name, eosio_token_abi);
 
    chain.produce_blocks();
    chain.create_account(N(tester));
@@ -1069,18 +1069,18 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
    );
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action(config::token_account_name, N(create), config::token_account_name, mutable_variant_object()
            ("issuer", eosio_token)
            ("maximum_supply", "9000000.0000 CUR" )
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action(config::token_account_name, name("issue"), config::token_account_name, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action(config::token_account_name, name("transfer"), config::token_account_name, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -1092,13 +1092,13 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -1112,7 +1112,7 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
@@ -1162,7 +1162,7 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "5.0000 CUR")
@@ -1200,7 +1200,7 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
    chain.produce_blocks();
 
    // this transfer is performed right away since delay is removed
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "10.0000 CUR")
@@ -1241,11 +1241,11 @@ BOOST_AUTO_TEST_CASE( link_delay_unlink_test ) { try {
    const auto& tester_account = N(tester);
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account(config::token_account_name);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), eosio_token_wast);
-   chain.set_abi(N(eosio.token), eosio_token_abi);
+   chain.set_code(config::token_account_name, eosio_token_wast);
+   chain.set_abi(config::token_account_name, eosio_token_abi);
 
    chain.produce_blocks();
    chain.create_account(N(tester));
@@ -1265,18 +1265,18 @@ BOOST_AUTO_TEST_CASE( link_delay_unlink_test ) { try {
            ("requirement", "first"));
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action(config::token_account_name, N(create), config::token_account_name, mutable_variant_object()
            ("issuer", eosio_token )
            ("maximum_supply", "9000000.0000 CUR" )
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action(config::token_account_name, name("issue"), config::token_account_name, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action(config::token_account_name, name("transfer"), config::token_account_name, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -1286,13 +1286,13 @@ BOOST_AUTO_TEST_CASE( link_delay_unlink_test ) { try {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -1306,7 +1306,7 @@ BOOST_AUTO_TEST_CASE( link_delay_unlink_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
@@ -1353,7 +1353,7 @@ BOOST_AUTO_TEST_CASE( link_delay_unlink_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "5.0000 CUR")
@@ -1391,7 +1391,7 @@ BOOST_AUTO_TEST_CASE( link_delay_unlink_test ) { try {
    chain.produce_blocks();
 
    // this transfer is performed right away since delay is removed
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "10.0000 CUR")
@@ -1430,11 +1430,11 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
    const auto& tester_account = N(tester);
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account(config::token_account_name);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), eosio_token_wast);
-   chain.set_abi(N(eosio.token), eosio_token_abi);
+   chain.set_code(config::token_account_name, eosio_token_wast);
+   chain.set_abi(config::token_account_name, eosio_token_abi);
 
    chain.produce_blocks();
    chain.create_account(N(tester));
@@ -1466,18 +1466,18 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
    );
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action(config::token_account_name, N(create), config::token_account_name, mutable_variant_object()
            ("issuer", eosio_token)
            ("maximum_supply", "9000000.0000 CUR" )
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action(config::token_account_name, name("issue"), config::token_account_name, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action(config::token_account_name, name("transfer"), config::token_account_name, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -1489,13 +1489,13 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -1509,7 +1509,7 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
@@ -1544,7 +1544,7 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "5.0000 CUR")
@@ -1582,7 +1582,7 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
    chain.produce_blocks();
 
    // this transfer is performed right away since delay is removed
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "10.0000 CUR")
@@ -1621,29 +1621,29 @@ BOOST_AUTO_TEST_CASE( mindelay_test ) { try {
    const auto& tester_account = N(tester);
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account(config::token_account_name);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), eosio_token_wast);
-   chain.set_abi(N(eosio.token), eosio_token_abi);
+   chain.set_code(config::token_account_name, eosio_token_wast);
+   chain.set_abi(config::token_account_name, eosio_token_abi);
 
    chain.produce_blocks();
    chain.create_account(N(tester));
    chain.create_account(N(tester2));
    chain.produce_blocks(10);
 
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action(config::token_account_name, N(create), config::token_account_name, mutable_variant_object()
            ("issuer", eosio_token)
            ("maximum_supply", "9000000.0000 CUR")
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action(config::token_account_name, name("issue"), config::token_account_name, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action(config::token_account_name, name("transfer"), config::token_account_name, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -1655,12 +1655,12 @@ BOOST_AUTO_TEST_CASE( mindelay_test ) { try {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -1673,7 +1673,7 @@ BOOST_AUTO_TEST_CASE( mindelay_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
@@ -1681,15 +1681,15 @@ BOOST_AUTO_TEST_CASE( mindelay_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    // send transfer with delay_sec set to 10
-   const auto& acnt = chain.control->db().get<account_object,by_name>(N(eosio.token));
+   const auto& acnt = chain.control->db().get<account_object,by_name>(config::token_account_name);
    const auto abi = acnt.get_abi();
    chain::abi_serializer abis(abi, chain.abi_serializer_max_time);
-   const auto a = chain.control->db().get<account_object,by_name>(N(eosio.token)).get_abi();
+   const auto a = chain.control->db().get<account_object,by_name>(config::token_account_name).get_abi();
 
    string action_type_name = abis.get_action_type(name("transfer"));
 
    action act;
-   act.account = N(eosio.token);
+   act.account = config::token_account_name;
    act.name = name("transfer");
    act.authorization.push_back(permission_level{N(tester), config::active_name});
    act.data = abis.variant_to_binary(action_type_name, fc::mutable_variant_object()
@@ -1753,11 +1753,11 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    std::vector<transaction_id_type> ids;
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account(config::token_account_name);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), eosio_token_wast);
-   chain.set_abi(N(eosio.token), eosio_token_abi);
+   chain.set_code(config::token_account_name, eosio_token_wast);
+   chain.set_abi(config::token_account_name, eosio_token_abi);
 
    chain.produce_blocks();
    chain.create_account(N(tester));
@@ -1777,18 +1777,18 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
            ("requirement", "first"));
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action(config::token_account_name, N(create), config::token_account_name, mutable_variant_object()
            ("issuer", eosio_token)
            ("maximum_supply", "9000000.0000 CUR")
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action(config::token_account_name, name("issue"), config::token_account_name, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action(config::token_account_name, name("transfer"), config::token_account_name, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -1799,13 +1799,13 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    BOOST_REQUIRE_EQUAL(0, gen_size);
 
    chain.produce_blocks();
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -1825,7 +1825,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
@@ -1877,7 +1877,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "5.0000 CUR")
@@ -1942,7 +1942,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // this transfer is performed right away since delay is removed
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "10.0000 CUR")
@@ -1990,11 +1990,11 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
    const auto& tester_account = N(tester);
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account(config::token_account_name);
    chain.produce_blocks();
 
-   chain.set_code(N(eosio.token), eosio_token_wast);
-   chain.set_abi(N(eosio.token), eosio_token_abi);
+   chain.set_code(config::token_account_name, eosio_token_wast);
+   chain.set_abi(config::token_account_name, eosio_token_abi);
 
    chain.produce_blocks();
    chain.create_account(N(tester));
@@ -2020,18 +2020,18 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
            ("requirement", "first"));
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action(config::token_account_name, N(create), config::token_account_name, mutable_variant_object()
            ("issuer", eosio_token)
            ("maximum_supply", "9000000.0000 CUR")
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action(config::token_account_name, name("issue"), config::token_account_name, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action(config::token_account_name, name("transfer"), config::token_account_name, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -2042,7 +2042,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
    BOOST_REQUIRE_EQUAL(0, gen_size);
 
    chain.produce_blocks();
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, config::token_account_name);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
    liquid_balance = get_currency_balance(chain, N(tester));
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
@@ -2051,7 +2051,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
 
    {
       // this transaction will be delayed 10 blocks
-      trace = chain.push_action(N(eosio.token), name("transfer"), vector<permission_level>{{N(tester), N(first)}}, fc::mutable_variant_object()
+      trace = chain.push_action(config::token_account_name, name("transfer"), vector<permission_level>{{N(tester), N(first)}}, fc::mutable_variant_object()
           ("from", "tester")
           ("to", "tester2")
           ("quantity", "1.0000 CUR")
@@ -2138,7 +2138,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
    ilog("attempting second delayed transfer");
    {
       // this transaction will be delayed 10 blocks
-      trace = chain.push_action(N(eosio.token), name("transfer"), vector<permission_level>{{N(tester), N(second)}}, fc::mutable_variant_object()
+      trace = chain.push_action(config::token_account_name, name("transfer"), vector<permission_level>{{N(tester), N(second)}}, fc::mutable_variant_object()
           ("from", "tester")
           ("to", "tester2")
           ("quantity", "5.0000 CUR")
@@ -2190,7 +2190,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
 
    {
       // this transaction will be delayed 10 blocks
-      trace = chain.push_action(N(eosio.token), name("transfer"), vector<permission_level>{{N(tester), config::owner_name}}, fc::mutable_variant_object()
+      trace = chain.push_action(config::token_account_name, name("transfer"), vector<permission_level>{{N(tester), config::owner_name}}, fc::mutable_variant_object()
           ("from", "tester")
           ("to", "tester2")
           ("quantity", "10.0000 CUR")
@@ -2278,19 +2278,19 @@ BOOST_AUTO_TEST_CASE( max_transaction_delay_execute ) { try {
 
    const auto& tester_account = N(tester);
 
-   chain.create_account(N(eosio.token));
-   chain.set_code(N(eosio.token), eosio_token_wast);
-   chain.set_abi(N(eosio.token), eosio_token_abi);
+   chain.create_account(config::token_account_name);
+   chain.set_code(config::token_account_name, eosio_token_wast);
+   chain.set_abi(config::token_account_name, eosio_token_abi);
 
    chain.produce_blocks();
    chain.create_account(N(tester));
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
-           ("issuer", "eosio.token" )
+   chain.push_action(config::token_account_name, N(create), config::token_account_name, mutable_variant_object()
+           ("issuer", config::token_account_name )
            ("maximum_supply", "9000000.0000 CUR" )
    );
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action(config::token_account_name, name("issue"), config::token_account_name, fc::mutable_variant_object()
            ("to",       "tester")
            ("quantity", "100.0000 CUR")
            ("memo", "for stuff")
@@ -2307,7 +2307,7 @@ BOOST_AUTO_TEST_CASE( max_transaction_delay_execute ) { try {
 
    trace = chain.push_action(config::system_account_name, linkauth::get_name(), tester_account, fc::mutable_variant_object()
                      ("account", "tester")
-                     ("code", "eosio.token")
+                     ("code", config::token_account_name)
                      ("type", "transfer")
                      ("requirement", "first"));
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
@@ -2322,9 +2322,9 @@ BOOST_AUTO_TEST_CASE( max_transaction_delay_execute ) { try {
 
    chain.produce_blocks();
    //should be able to create transaction with delay 60 sec, despite permission delay being 30 days, because max_transaction_delay is 60 sec
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action(config::token_account_name, name("transfer"), N(tester), fc::mutable_variant_object()
                            ("from", "tester")
-                           ("to", "eosio.token")
+                           ("to", config::token_account_name)
                            ("quantity", "9.0000 CUR")
                            ("memo", "" ), 120, 60);
    BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace->receipt->status);

--- a/unittests/eosio.system_tests.cpp
+++ b/unittests/eosio.system_tests.cpp
@@ -16,18 +16,18 @@ BOOST_FIXTURE_TEST_CASE( buysell, eosio_system_tester ) try {
 
    BOOST_REQUIRE_EQUAL( core_from_string("0.0000"), get_balance( "alice1111111" ) );
 
-   transfer( "eosio", "alice1111111", core_from_string("1000.0000"), "eosio" );
-   BOOST_REQUIRE_EQUAL( success(), stake( "eosio", "alice1111111", core_from_string("200.0000"), core_from_string("100.0000") ) );
+   transfer(config::system_account_name, "alice1111111", core_from_string("1000.0000"), config::system_account_name);
+   BOOST_REQUIRE_EQUAL(success(), stake(config::system_account_name, "alice1111111", core_from_string("200.0000"), core_from_string("100.0000")));
 
    auto total = get_total_stake( "alice1111111" );
    auto init_bytes =  total["ram_bytes"].as_uint64();
 
-   const asset initial_ram_balance = get_balance(N(eosio.ram));
-   const asset initial_ramfee_balance = get_balance(N(eosio.ramfee));
+   const asset initial_ram_balance = get_balance(config::ram_account_name);
+   const asset initial_ramfee_balance = get_balance(config::ramfee_account_name);
    BOOST_REQUIRE_EQUAL( success(), buyram( "alice1111111", "alice1111111", core_from_string("200.0000") ) );
    BOOST_REQUIRE_EQUAL( core_from_string("800.0000"), get_balance( "alice1111111" ) );
-   BOOST_REQUIRE_EQUAL( initial_ram_balance + core_from_string("199.0000"), get_balance(N(eosio.ram)) );
-   BOOST_REQUIRE_EQUAL( initial_ramfee_balance + core_from_string("1.0000"), get_balance(N(eosio.ramfee)) );
+   BOOST_REQUIRE_EQUAL( initial_ram_balance + core_from_string("199.0000"), get_balance(config::ram_account_name) );
+   BOOST_REQUIRE_EQUAL( initial_ramfee_balance + core_from_string("1.0000"), get_balance(config::ramfee_account_name) );
 
    total = get_total_stake( "alice1111111" );
    auto bytes = total["ram_bytes"].as_uint64();
@@ -41,7 +41,7 @@ BOOST_FIXTURE_TEST_CASE( buysell, eosio_system_tester ) try {
    total = get_total_stake( "alice1111111" );
    BOOST_REQUIRE_EQUAL( true, total["ram_bytes"].as_uint64() == init_bytes );
 
-   transfer( "eosio", "alice1111111", core_from_string("100000000.0000"), "eosio" );
+   transfer(config::system_account_name, "alice1111111", core_from_string("100000000.0000"), config::system_account_name);
    BOOST_REQUIRE_EQUAL( core_from_string("100000998.0049"), get_balance( "alice1111111" ) );
    // alice buys ram for 10000000.0000, 0.5% = 50000.0000 go to ramfee
    // after fee 9950000.0000 go to bought bytes
@@ -120,31 +120,31 @@ BOOST_FIXTURE_TEST_CASE( stake_unstake, eosio_system_tester ) try {
    produce_block( fc::hours(3*24) );
 
    BOOST_REQUIRE_EQUAL( core_from_string("0.0000"), get_balance( "alice1111111" ) );
-   transfer( "eosio", "alice1111111", core_from_string("1000.0000"), "eosio" );
+   transfer(config::system_account_name, "alice1111111", core_from_string("1000.0000"), config::system_account_name);
 
    BOOST_REQUIRE_EQUAL( core_from_string("1000.0000"), get_balance( "alice1111111" ) );
-   BOOST_REQUIRE_EQUAL( success(), stake( "eosio", "alice1111111", core_from_string("200.0000"), core_from_string("100.0000") ) );
+   BOOST_REQUIRE_EQUAL( success(), stake(config::system_account_name, "alice1111111", core_from_string("200.0000"), core_from_string("100.0000")));
 
    auto total = get_total_stake("alice1111111");
    BOOST_REQUIRE_EQUAL( core_from_string("210.0000"), total["net_weight"].as<asset>());
    BOOST_REQUIRE_EQUAL( core_from_string("110.0000"), total["cpu_weight"].as<asset>());
 
-   const auto init_eosio_stake_balance = get_balance( N(eosio.stake) );
+   const auto init_eosio_stake_balance = get_balance(config::stake_account_name);
    BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111", "alice1111111", core_from_string("200.0000"), core_from_string("100.0000") ) );
    BOOST_REQUIRE_EQUAL( core_from_string("700.0000"), get_balance( "alice1111111" ) );
-   BOOST_REQUIRE_EQUAL( init_eosio_stake_balance + core_from_string("300.0000"), get_balance( N(eosio.stake) ) );
+   BOOST_REQUIRE_EQUAL( init_eosio_stake_balance + core_from_string("300.0000"), get_balance(config::stake_account_name) );
    BOOST_REQUIRE_EQUAL( success(), unstake( "alice1111111", "alice1111111", core_from_string("200.0000"), core_from_string("100.0000") ) );
    BOOST_REQUIRE_EQUAL( core_from_string("700.0000"), get_balance( "alice1111111" ) );
 
    produce_block( fc::hours(3*24-1) );
    produce_blocks(1);
    BOOST_REQUIRE_EQUAL( core_from_string("700.0000"), get_balance( "alice1111111" ) );
-   BOOST_REQUIRE_EQUAL( init_eosio_stake_balance + core_from_string("300.0000"), get_balance( N(eosio.stake) ) );
+   BOOST_REQUIRE_EQUAL( init_eosio_stake_balance + core_from_string("300.0000"), get_balance(config::stake_account_name) );
    //after 3 days funds should be released
    produce_block( fc::hours(1) );
    produce_blocks(1);
    BOOST_REQUIRE_EQUAL( core_from_string("1000.0000"), get_balance( "alice1111111" ) );
-   BOOST_REQUIRE_EQUAL( init_eosio_stake_balance, get_balance( N(eosio.stake) ) );
+   BOOST_REQUIRE_EQUAL( init_eosio_stake_balance, get_balance(config::stake_account_name) );
 
    BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111", "bob111111111", core_from_string("200.0000"), core_from_string("100.0000") ) );
    BOOST_REQUIRE_EQUAL( core_from_string("700.0000"), get_balance( "alice1111111" ) );
@@ -181,13 +181,13 @@ BOOST_FIXTURE_TEST_CASE( stake_unstake, eosio_system_tester ) try {
 BOOST_FIXTURE_TEST_CASE( stake_unstake_with_transfer, eosio_system_tester ) try {
    cross_15_percent_threshold();
 
-   issue( "eosio", core_from_string("1000.0000"), config::system_account_name );
-   issue( "eosio.stake", core_from_string("1000.0000"), config::system_account_name );
+   issue(config::system_account_name, core_from_string("1000.0000"), config::system_account_name);
+   issue(config::stake_account_name, core_from_string("1000.0000"), config::system_account_name);
    BOOST_REQUIRE_EQUAL( core_from_string("0.0000"), get_balance( "alice1111111" ) );
 
    //eosio stakes for alice with transfer flag
 
-   transfer( "eosio", "bob111111111", core_from_string("1000.0000"), "eosio" );
+   transfer(config::system_account_name, "bob111111111", core_from_string("1000.0000"), config::system_account_name);
    BOOST_REQUIRE_EQUAL( success(), stake_with_transfer( "bob111111111", "alice1111111", core_from_string("200.0000"), core_from_string("100.0000") ) );
 
    //check that alice has both bandwidth and voting power
@@ -199,7 +199,7 @@ BOOST_FIXTURE_TEST_CASE( stake_unstake_with_transfer, eosio_system_tester ) try 
    BOOST_REQUIRE_EQUAL( core_from_string("0.0000"), get_balance( "alice1111111" ) );
 
    //alice stakes for herself
-   transfer( "eosio", "alice1111111", core_from_string("1000.0000"), "eosio" );
+   transfer(config::system_account_name, "alice1111111", core_from_string("1000.0000"), config::system_account_name);
    BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111", "alice1111111", core_from_string("200.0000"), core_from_string("100.0000") ) );
    //now alice's stake should be equal to transfered from eosio + own stake
    total = get_total_stake("alice1111111");
@@ -237,7 +237,7 @@ BOOST_FIXTURE_TEST_CASE( stake_to_self_with_transfer, eosio_system_tester ) try 
    cross_15_percent_threshold();
 
    BOOST_REQUIRE_EQUAL( core_from_string("0.0000"), get_balance( "alice1111111" ) );
-   transfer( "eosio", "alice1111111", core_from_string("1000.0000"), "eosio" );
+   transfer(config::system_account_name, "alice1111111", core_from_string("1000.0000"), config::system_account_name);
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("cannot use transfer flag if delegating to self"),
                         stake_with_transfer( "alice1111111", "alice1111111", core_from_string("200.0000"), core_from_string("100.0000") )
@@ -248,13 +248,13 @@ BOOST_FIXTURE_TEST_CASE( stake_to_self_with_transfer, eosio_system_tester ) try 
 BOOST_FIXTURE_TEST_CASE( stake_while_pending_refund, eosio_system_tester ) try {
    cross_15_percent_threshold();
 
-   issue( "eosio", core_from_string("1000.0000"), config::system_account_name );
-   issue( "eosio.stake", core_from_string("1000.0000"), config::system_account_name );
+   issue(config::system_account_name, core_from_string("1000.0000"), config::system_account_name);
+   issue(config::stake_account_name, core_from_string("1000.0000"), config::system_account_name);
    BOOST_REQUIRE_EQUAL( core_from_string("0.0000"), get_balance( "alice1111111" ) );
 
    //eosio stakes for alice with transfer flag
 
-   transfer( "eosio", "bob111111111", core_from_string("1000.0000"), "eosio" );
+   transfer(config::system_account_name, "bob111111111", core_from_string("1000.0000"), config::system_account_name);
    BOOST_REQUIRE_EQUAL( success(), stake_with_transfer( "bob111111111", "alice1111111", core_from_string("200.0000"), core_from_string("100.0000") ) );
 
    //check that alice has both bandwidth and voting power
@@ -266,7 +266,7 @@ BOOST_FIXTURE_TEST_CASE( stake_while_pending_refund, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( core_from_string("0.0000"), get_balance( "alice1111111" ) );
 
    //alice stakes for herself
-   transfer( "eosio", "alice1111111", core_from_string("1000.0000"), "eosio" );
+   transfer(config::system_account_name, "alice1111111", core_from_string("1000.0000"), config::system_account_name);
    BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111", "alice1111111", core_from_string("200.0000"), core_from_string("100.0000") ) );
    //now alice's stake should be equal to transfered from eosio + own stake
    total = get_total_stake("alice1111111");
@@ -305,7 +305,7 @@ BOOST_FIXTURE_TEST_CASE( fail_without_auth, eosio_system_tester ) try {
 
    issue( "alice1111111", core_from_string("1000.0000"),  config::system_account_name );
 
-   BOOST_REQUIRE_EQUAL( success(), stake( "eosio", "alice1111111", core_from_string("2000.0000"), core_from_string("1000.0000") ) );
+   BOOST_REQUIRE_EQUAL( success(), stake(config::system_account_name, "alice1111111", core_from_string("2000.0000"), core_from_string("1000.0000")) );
    BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111", "bob111111111", core_from_string("10.0000"), core_from_string("10.0000") ) );
 
    BOOST_REQUIRE_EQUAL( error("missing authority of alice1111111"),
@@ -1216,7 +1216,7 @@ BOOST_FIXTURE_TEST_CASE(producer_pay, eosio_system_tester, * boost::unit_test::t
       const uint64_t initial_claim_time        = initial_global_state["last_pervote_bucket_fill"].as_uint64();
       const int64_t  initial_pervote_bucket    = initial_global_state["pervote_bucket"].as<int64_t>();
       const int64_t  initial_perblock_bucket   = initial_global_state["perblock_bucket"].as<int64_t>();
-      const int64_t  initial_savings           = get_balance(N(eosio.saving)).get_amount();
+      const int64_t  initial_savings           = get_balance(config::saving_account_name).get_amount();
       const uint32_t initial_tot_unpaid_blocks = initial_global_state["total_unpaid_blocks"].as<uint32_t>();
 
       prod = get_producer_info("defproducera");
@@ -1235,7 +1235,7 @@ BOOST_FIXTURE_TEST_CASE(producer_pay, eosio_system_tester, * boost::unit_test::t
       const uint64_t claim_time        = global_state["last_pervote_bucket_fill"].as_uint64();
       const int64_t  pervote_bucket    = global_state["pervote_bucket"].as<int64_t>();
       const int64_t  perblock_bucket   = global_state["perblock_bucket"].as<int64_t>();
-      const int64_t  savings           = get_balance(N(eosio.saving)).get_amount();
+      const int64_t  savings           = get_balance(config::saving_account_name).get_amount();
       const uint32_t tot_unpaid_blocks = global_state["total_unpaid_blocks"].as<uint32_t>();
 
       prod = get_producer_info("defproducera");
@@ -1293,7 +1293,7 @@ BOOST_FIXTURE_TEST_CASE(producer_pay, eosio_system_tester, * boost::unit_test::t
       const uint64_t initial_claim_time        = initial_global_state["last_pervote_bucket_fill"].as_uint64();
       const int64_t  initial_pervote_bucket    = initial_global_state["pervote_bucket"].as<int64_t>();
       const int64_t  initial_perblock_bucket   = initial_global_state["perblock_bucket"].as<int64_t>();
-      const int64_t  initial_savings           = get_balance(N(eosio.saving)).get_amount();
+      const int64_t  initial_savings           = get_balance(config::saving_account_name).get_amount();
       const uint32_t initial_tot_unpaid_blocks = initial_global_state["total_unpaid_blocks"].as<uint32_t>();
       const double   initial_tot_vote_weight   = initial_global_state["total_producer_vote_weight"].as<double>();
 
@@ -1316,7 +1316,7 @@ BOOST_FIXTURE_TEST_CASE(producer_pay, eosio_system_tester, * boost::unit_test::t
       const uint64_t claim_time        = global_state["last_pervote_bucket_fill"].as_uint64();
       const int64_t  pervote_bucket    = global_state["pervote_bucket"].as<int64_t>();
       const int64_t  perblock_bucket   = global_state["perblock_bucket"].as<int64_t>();
-      const int64_t  savings           = get_balance(N(eosio.saving)).get_amount();
+      const int64_t  savings           = get_balance(config::saving_account_name).get_amount();
       const uint32_t tot_unpaid_blocks = global_state["total_unpaid_blocks"].as<uint32_t>();
 
       prod = get_producer_info("defproducera");
@@ -1357,7 +1357,7 @@ BOOST_FIXTURE_TEST_CASE(producer_pay, eosio_system_tester, * boost::unit_test::t
       regproducer(N(defproducerb));
       regproducer(N(defproducerc));
       const asset   initial_supply  = get_token_supply();
-      const int64_t initial_savings = get_balance(N(eosio.saving)).get_amount();
+      const int64_t initial_savings = get_balance(config::saving_account_name).get_amount();
       for (uint32_t i = 0; i < 7 * 52; ++i) {
          produce_block(fc::seconds(8 * 3600));
          BOOST_REQUIRE_EQUAL(success(), push_action(N(defproducerc), N(claimrewards), mvo()("owner", "defproducerc")));
@@ -1367,7 +1367,7 @@ BOOST_FIXTURE_TEST_CASE(producer_pay, eosio_system_tester, * boost::unit_test::t
          BOOST_REQUIRE_EQUAL(success(), push_action(N(defproducera), N(claimrewards), mvo()("owner", "defproducera")));
       }
       const asset   supply  = get_token_supply();
-      const int64_t savings = get_balance(N(eosio.saving)).get_amount();
+      const int64_t savings = get_balance(config::saving_account_name).get_amount();
       // Amount issued per year is very close to the 5% inflation target. Small difference (500 tokens out of 50'000'000 issued)
       // is due to compounding every 8 hours in this test as opposed to theoretical continuous compounding
       BOOST_REQUIRE(500 * 10000 > int64_t(double(initial_supply.get_amount()) * double(0.05)) - (supply.get_amount() - initial_supply.get_amount()));
@@ -1492,11 +1492,11 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_pay, eosio_system_tester, * boost::uni
       const uint64_t initial_claim_time        = initial_global_state["last_pervote_bucket_fill"].as_uint64();
       const int64_t  initial_pervote_bucket    = initial_global_state["pervote_bucket"].as<int64_t>();
       const int64_t  initial_perblock_bucket   = initial_global_state["perblock_bucket"].as<int64_t>();
-      const int64_t  initial_savings           = get_balance(N(eosio.saving)).get_amount();
+      const int64_t  initial_savings           = get_balance(config::saving_account_name).get_amount();
       const uint32_t initial_tot_unpaid_blocks = initial_global_state["total_unpaid_blocks"].as<uint32_t>();
       const asset    initial_supply            = get_token_supply();
-      const asset    initial_bpay_balance      = get_balance(N(eosio.bpay));
-      const asset    initial_vpay_balance      = get_balance(N(eosio.vpay));
+      const asset    initial_bpay_balance      = get_balance(config::bpay_account_name);
+      const asset    initial_vpay_balance      = get_balance(config::vpay_account_name);
       const asset    initial_balance           = get_balance(prod_name);
       const uint32_t initial_unpaid_blocks     = get_producer_info(prod_name)["unpaid_blocks"].as<uint32_t>();
 
@@ -1506,11 +1506,11 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_pay, eosio_system_tester, * boost::uni
       const uint64_t claim_time        = global_state["last_pervote_bucket_fill"].as_uint64();
       const int64_t  pervote_bucket    = global_state["pervote_bucket"].as<int64_t>();
       const int64_t  perblock_bucket   = global_state["perblock_bucket"].as<int64_t>();
-      const int64_t  savings           = get_balance(N(eosio.saving)).get_amount();
+      const int64_t  savings           = get_balance(config::saving_account_name).get_amount();
       const uint32_t tot_unpaid_blocks = global_state["total_unpaid_blocks"].as<uint32_t>();
       const asset    supply            = get_token_supply();
-      const asset    bpay_balance      = get_balance(N(eosio.bpay));
-      const asset    vpay_balance      = get_balance(N(eosio.vpay));
+      const asset    bpay_balance      = get_balance(config::bpay_account_name);
+      const asset    vpay_balance      = get_balance(config::vpay_account_name);
       const asset    balance           = get_balance(prod_name);
       const uint32_t unpaid_blocks     = get_producer_info(prod_name)["unpaid_blocks"].as<uint32_t>();
 
@@ -1568,11 +1568,11 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_pay, eosio_system_tester, * boost::uni
       const uint64_t initial_claim_time        = initial_global_state["last_pervote_bucket_fill"].as_uint64();
       const int64_t  initial_pervote_bucket    = initial_global_state["pervote_bucket"].as<int64_t>();
       const int64_t  initial_perblock_bucket   = initial_global_state["perblock_bucket"].as<int64_t>();
-      const int64_t  initial_savings           = get_balance(N(eosio.saving)).get_amount();
+      const int64_t  initial_savings           = get_balance(config::saving_account_name).get_amount();
       const uint32_t initial_tot_unpaid_blocks = initial_global_state["total_unpaid_blocks"].as<uint32_t>();
       const asset    initial_supply            = get_token_supply();
-      const asset    initial_bpay_balance      = get_balance(N(eosio.bpay));
-      const asset    initial_vpay_balance      = get_balance(N(eosio.vpay));
+      const asset    initial_bpay_balance      = get_balance(config::bpay_account_name);
+      const asset    initial_vpay_balance      = get_balance(config::vpay_account_name);
       const asset    initial_balance           = get_balance(prod_name);
       const uint32_t initial_unpaid_blocks     = get_producer_info(prod_name)["unpaid_blocks"].as<uint32_t>();
 
@@ -1582,11 +1582,11 @@ BOOST_FIXTURE_TEST_CASE(multiple_producer_pay, eosio_system_tester, * boost::uni
       const uint64_t claim_time        = global_state["last_pervote_bucket_fill"].as_uint64();
       const int64_t  pervote_bucket    = global_state["pervote_bucket"].as<int64_t>();
       const int64_t  perblock_bucket   = global_state["perblock_bucket"].as<int64_t>();
-      const int64_t  savings           = get_balance(N(eosio.saving)).get_amount();
+      const int64_t  savings           = get_balance(config::saving_account_name).get_amount();
       const uint32_t tot_unpaid_blocks = global_state["total_unpaid_blocks"].as<uint32_t>();
       const asset    supply            = get_token_supply();
-      const asset    bpay_balance      = get_balance(N(eosio.bpay));
-      const asset    vpay_balance      = get_balance(N(eosio.vpay));
+      const asset    bpay_balance      = get_balance(config::bpay_account_name);
+      const asset    vpay_balance      = get_balance(config::vpay_account_name);
       const asset    balance           = get_balance(prod_name);
       const uint32_t unpaid_blocks     = get_producer_info(prod_name)["unpaid_blocks"].as<uint32_t>();
 
@@ -1692,7 +1692,7 @@ BOOST_FIXTURE_TEST_CASE(producers_upgrade_system_contract, eosio_system_tester) 
          string action_type_name = msig_abi_ser.get_action_type(name);
 
          action act;
-         act.account = N(eosio.msig);
+         act.account = config::msig_account_name;
          act.name = name;
          act.data = msig_abi_ser.variant_to_binary( action_type_name, data, abi_serializer_max_time );
 
@@ -2114,7 +2114,7 @@ BOOST_FIXTURE_TEST_CASE( elect_producers /*_and_parameters*/, eosio_system_teste
    BOOST_REQUIRE_EQUAL( success(), regproducer( "defproducer3", 3) );
 
    //stake more than 15% of total EOS supply to activate chain
-   transfer( "eosio", "alice1111111", core_from_string("600000000.0000"), "eosio" );
+   transfer(config::system_account_name, "alice1111111", core_from_string("600000000.0000"), config::system_account_name);
    BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111", "alice1111111", core_from_string("300000000.0000"), core_from_string("300000000.0000") ) );
    //vote for producers
    BOOST_REQUIRE_EQUAL( success(), vote( N(alice1111111), { N(defproducer1) } ) );
@@ -2202,7 +2202,7 @@ BOOST_FIXTURE_TEST_CASE( buyname, eosio_system_tester ) try {
    //wlog( "verify sam can create nofail" );
    create_accounts_with_resources( { N(nofail) }, N(sam) ); // sam should be able to do this, he won the bid
    //wlog( "verify nofail can create test.nofail" );
-   transfer( "eosio", "nofail", core_from_string( "1000.0000" ) );
+   transfer(config::system_account_name, "nofail", core_from_string("1000.0000"));
    create_accounts_with_resources( { N(test.nofail) }, N(nofail) ); // only nofail can create test.nofail
    //wlog( "verify dan cannot create test.fail" );
    BOOST_REQUIRE_EXCEPTION( create_accounts_with_resources( { N(test.fail) }, N(dan) ), // dan shouldn't be able to do this
@@ -2268,12 +2268,12 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
 
    // alice outbids bob on prefb
    {
-      const asset initial_names_balance = get_balance(N(eosio.names));
+      const asset initial_names_balance = get_balance(config::names_account_name);
       BOOST_REQUIRE_EQUAL( success(),
                            bidname( "alice", "prefb", core_from_string("1.1001") ) );
       BOOST_REQUIRE_EQUAL( core_from_string( "9997.9997" ), get_balance("bob") );
       BOOST_REQUIRE_EQUAL( core_from_string( "9998.8999" ), get_balance("alice") );
-      BOOST_REQUIRE_EQUAL( initial_names_balance + core_from_string("0.1001"), get_balance(N(eosio.names)) );
+      BOOST_REQUIRE_EQUAL( initial_names_balance + core_from_string("0.1001"), get_balance(config::names_account_name) );
    }
 
    // david outbids carl on prefd
@@ -2453,7 +2453,7 @@ BOOST_FIXTURE_TEST_CASE( setparams, eosio_system_tester ) try {
          string action_type_name = msig_abi_ser.get_action_type(name);
 
          action act;
-         act.account = N(eosio.msig);
+         act.account = config::msig_account_name;
          act.name = name;
          act.data = msig_abi_ser.variant_to_binary( action_type_name, data, abi_serializer_max_time );
 

--- a/unittests/eosio_system_tester.hpp
+++ b/unittests/eosio_system_tester.hpp
@@ -46,25 +46,26 @@ public:
 
       produce_blocks( 2 );
 
-      create_accounts({ N(eosio.token), N(eosio.ram), N(eosio.ramfee), N(eosio.stake),
-               N(eosio.bpay), N(eosio.vpay), N(eosio.saving), N(eosio.names) });
+      create_accounts({config::token_account_name, config::ram_account_name, config::ramfee_account_name,
+         config::stake_account_name, config::bpay_account_name, config::vpay_account_name,
+         config::saving_account_name, config::names_account_name});
 
 
       produce_blocks( 100 );
 
-      set_code( N(eosio.token), eosio_token_wast );
-      set_abi( N(eosio.token), eosio_token_abi );
+      set_code(config::token_account_name, eosio_token_wast);
+      set_abi(config::token_account_name, eosio_token_abi);
 
       {
-         const auto& accnt = control->db().get<account_object,by_name>( N(eosio.token) );
+         const auto& accnt = control->db().get<account_object,by_name>(config::token_account_name);
          abi_def abi;
          BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
          token_abi_ser.set_abi(abi, abi_serializer_max_time);
       }
 
-      create_currency( N(eosio.token), config::system_account_name, core_from_string("10000000000.0000") );
+      create_currency(config::token_account_name, config::system_account_name, core_from_string("10000000000.0000"));
       issue(config::system_account_name,      core_from_string("1000000000.0000"));
-      BOOST_REQUIRE_EQUAL( core_from_string("1000000000.0000"), get_balance( "eosio" ) );
+      BOOST_REQUIRE_EQUAL(core_from_string("1000000000.0000"), get_balance(config::system_account_name));
 
       set_code( config::system_account_name, eosio_system_wast );
       set_abi( config::system_account_name, eosio_system_abi );
@@ -82,7 +83,9 @@ public:
       create_account_with_resources( N(bob111111111), config::system_account_name, core_from_string("0.4500"), false );
       create_account_with_resources( N(carol1111111), config::system_account_name, core_from_string("1.0000"), false );
 
-      BOOST_REQUIRE_EQUAL( core_from_string("1000000000.0000"), get_balance("eosio")  + get_balance("eosio.ramfee") + get_balance("eosio.stake") + get_balance("eosio.ram") );
+      BOOST_REQUIRE_EQUAL(core_from_string("1000000000.0000"),
+         get_balance(config::system_account_name) + get_balance(config::ramfee_account_name) +
+         get_balance(config::stake_account_name) + get_balance(config::ram_account_name));
    }
 
 
@@ -329,7 +332,7 @@ public:
    }
 
    asset get_balance( const account_name& act ) {
-      vector<char> data = get_row_by_account( N(eosio.token), act, N(accounts), symbol(CORE_SYMBOL).to_symbol_code().value );
+      vector<char> data = get_row_by_account(config::token_account_name, act, N(accounts), symbol(CORE_SYMBOL).to_symbol_code().value);
       return data.empty() ? asset(0, symbol(CORE_SYMBOL)) : token_abi_ser.binary_to_variant("account", data, abi_serializer_max_time)["balance"].as<asset>();
    }
 
@@ -357,14 +360,14 @@ public:
    }
 
    void issue( name to, const asset& amount, name manager = config::system_account_name ) {
-      base_tester::push_action( N(eosio.token), N(issue), manager, mutable_variant_object()
+      base_tester::push_action( config::token_account_name, N(issue), manager, mutable_variant_object()
                                 ("to",      to )
                                 ("quantity", amount )
                                 ("memo", "")
                                 );
    }
    void transfer( name from, name to, const asset& amount, name manager = config::system_account_name ) {
-      base_tester::push_action( N(eosio.token), N(transfer), manager, mutable_variant_object()
+      base_tester::push_action( config::token_account_name, N(transfer), manager, mutable_variant_object()
                                 ("from",    from)
                                 ("to",      to )
                                 ("quantity", amount)
@@ -384,7 +387,7 @@ public:
    fc::variant get_stats( const string& symbolname ) {
       auto symb = eosio::chain::symbol::from_string(symbolname);
       auto symbol_code = symb.to_symbol_code().value;
-      vector<char> data = get_row_by_account( N(eosio.token), symbol_code, N(stat), symbol_code );
+      vector<char> data = get_row_by_account(config::token_account_name, symbol_code, N(stat), symbol_code);
       return data.empty() ? fc::variant() : token_abi_ser.binary_to_variant( "currency_stats", data, abi_serializer_max_time );
    }
 
@@ -407,21 +410,22 @@ public:
    abi_serializer initialize_multisig() {
       abi_serializer msig_abi_ser;
       {
-         create_account_with_resources( N(eosio.msig), config::system_account_name );
-         BOOST_REQUIRE_EQUAL( success(), buyram( "eosio", "eosio.msig", core_from_string("5000.0000") ) );
+         create_account_with_resources(config::msig_account_name, config::system_account_name);
+         BOOST_REQUIRE_EQUAL(success(),
+            buyram(config::system_account_name, config::msig_account_name, core_from_string("5000.0000")));
          produce_block();
 
          auto trace = base_tester::push_action(config::system_account_name, N(setpriv),
                                                config::system_account_name,  mutable_variant_object()
-                                               ("account", "eosio.msig")
+                                               ("account", config::msig_account_name)
                                                ("is_priv", 1)
          );
 
-         set_code( N(eosio.msig), eosio_msig_wast );
-         set_abi( N(eosio.msig), eosio_msig_abi );
+         set_code(config::msig_account_name, eosio_msig_wast);
+         set_abi(config::msig_account_name, eosio_msig_abi);
 
          produce_blocks();
-         const auto& accnt = control->db().get<account_object,by_name>( N(eosio.msig) );
+         const auto& accnt = control->db().get<account_object,by_name>(config::msig_account_name);
          abi_def msig_abi;
          BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, msig_abi), true);
          msig_abi_ser.set_abi(msig_abi, abi_serializer_max_time);
@@ -431,7 +435,7 @@ public:
 
    vector<name> active_and_vote_producers() {
       //stake more than 15% of total EOS supply to activate chain
-      transfer( "eosio", "alice1111111", core_from_string("650000000.0000"), "eosio" );
+      transfer(config::system_account_name, "alice1111111", core_from_string("650000000.0000"), config::system_account_name);
       BOOST_REQUIRE_EQUAL( success(), stake( "alice1111111", "alice1111111", core_from_string("300000000.0000"), core_from_string("300000000.0000") ) );
 
       // create accounts {defproducera, defproducerb, ..., defproducerz} and register as producers

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -156,21 +156,21 @@ BOOST_AUTO_TEST_CASE( forking ) try {
    wlog("set producer schedule to [dan,sam,pam]");
    c.produce_blocks(30);
 
-   auto r2 = c.create_accounts( {N(eosio.token)} );
+   auto r2 = c.create_accounts({config::token_account_name});
    wdump((fc::json::to_pretty_string(r2)));
-   c.set_code( N(eosio.token), eosio_token_wast );
-   c.set_abi( N(eosio.token), eosio_token_abi );
+   c.set_code(config::token_account_name, eosio_token_wast);
+   c.set_abi(config::token_account_name, eosio_token_abi);
    c.produce_blocks(10);
 
 
-   auto cr = c.push_action( N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
-              ("issuer",       "eosio" )
+   auto cr = c.push_action(config::token_account_name, N(create), config::token_account_name, mutable_variant_object()
+              ("issuer",         config::system_account_name)
               ("maximum_supply", core_from_string("10000000.0000"))
       );
 
    wdump((fc::json::to_pretty_string(cr)));
 
-   cr = c.push_action( N(eosio.token), N(issue), config::system_account_name, mutable_variant_object()
+   cr = c.push_action(config::token_account_name, N(issue), config::system_account_name, mutable_variant_object()
               ("to",       "dan" )
               ("quantity", core_from_string("100.0000"))
               ("memo", "")

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -556,22 +556,22 @@ BOOST_AUTO_TEST_CASE(transaction_test) { try {
    variant pretty_trx = fc::mutable_variant_object()
       ("actions", fc::variants({
          fc::mutable_variant_object()
-            ("account", "eosio")
+            ("account", config::system_account_name)
             ("name", "reqauth")
             ("authorization", fc::variants({
                fc::mutable_variant_object()
-                  ("actor", "eosio")
+                  ("actor", config::system_account_name)
                   ("permission", "active")
             }))
             ("data", fc::mutable_variant_object()
-               ("from", "eosio")
+               ("from", config::system_account_name)
             )
          })
       )
       // lets also push a context free action, the multi chain test will then also include a context free action
       ("context_free_actions", fc::variants({
          fc::mutable_variant_object()
-            ("account", "eosio")
+            ("account", config::system_account_name)
             ("name", "nonce")
             ("data", fc::raw::pack(std::string("dummy")))
          })

--- a/unittests/providebw_tests.cpp
+++ b/unittests/providebw_tests.cpp
@@ -26,6 +26,7 @@
 
 using namespace eosio;
 using namespace eosio::chain;
+using namespace eosio::chain::config;
 using namespace eosio::testing;
 using namespace fc;
 
@@ -88,7 +89,7 @@ public:
     }
 
     asset get_balance( const account_name& act ) {
-         return get_currency_balance(N(eosio.token), symbol(CORE_SYMBOL), act);
+         return get_currency_balance(token_account_name, symbol(CORE_SYMBOL), act);
     }
 
     void set_code_abi(const account_name& account, const char* wast, const char* abi, const private_key_type* signer = nullptr) {
@@ -112,32 +113,33 @@ BOOST_AUTO_TEST_SUITE(providebw_tests)
 BOOST_FIXTURE_TEST_CASE( providebw_test, system_contract_tester ) {
     try {
         // Create eosio.msig and eosio.token
-        create_accounts({N(eosio.msig), N(eosio.token), N(eosio.ram), N(eosio.ramfee), N(eosio.stake), N(eosio.vpay), N(eosio.bpay), N(eosio.saving) });
+        create_accounts({msig_account_name, token_account_name, ram_account_name, ramfee_account_name,
+         stake_account_name, vpay_account_name, bpay_account_name, saving_account_name});
 
         // Set code for the following accounts:
         //  - eosio (code: eosio.bios) (already set by tester constructor)
         //  - eosio.msig (code: eosio.msig)
         //  - eosio.token (code: eosio.token)
-        set_code_abi(N(eosio.msig), eosio_msig_wast, eosio_msig_abi);//, &eosio_active_pk);
-        set_code_abi(N(eosio.token), eosio_token_wast, eosio_token_abi); //, &eosio_active_pk);
+        set_code_abi(msig_account_name, eosio_msig_wast, eosio_msig_abi);//, &eosio_active_pk);
+        set_code_abi(token_account_name, eosio_token_wast, eosio_token_abi); //, &eosio_active_pk);
 
         // Set privileged for eosio.msig and eosio.token
-        set_privileged(N(eosio.msig));
-        set_privileged(N(eosio.token));
+        set_privileged(msig_account_name);
+        set_privileged(token_account_name);
 
         // Verify eosio.msig and eosio.token is privileged
-        const auto& eosio_msig_acc = get<account_object, by_name>(N(eosio.msig));
+        const auto& eosio_msig_acc = get<account_object, by_name>(msig_account_name);
         BOOST_TEST(eosio_msig_acc.privileged == true);
-        const auto& eosio_token_acc = get<account_object, by_name>(N(eosio.token));
+        const auto& eosio_token_acc = get<account_object, by_name>(token_account_name);
         BOOST_TEST(eosio_token_acc.privileged == true);
 
 
         // Create SYS tokens in eosio.token, set its manager as eosio
         auto max_supply = core_from_string("10000000000.0000"); /// 1x larger than 1B initial tokens
         auto initial_supply = core_from_string("1000000000.0000"); /// 1x larger than 1B initial tokens
-        create_currency(N(eosio.token), config::system_account_name, max_supply);
+        create_currency(token_account_name, system_account_name, max_supply);
         // Issue the genesis supply of 1 billion SYS tokens to eosio.system
-        issue(N(eosio.token), config::system_account_name, config::system_account_name, initial_supply);
+        issue(token_account_name, system_account_name, system_account_name, initial_supply);
 
         auto actual = get_balance(config::system_account_name);
         BOOST_REQUIRE_EQUAL(initial_supply, actual);
@@ -151,7 +153,7 @@ BOOST_FIXTURE_TEST_CASE( providebw_test, system_contract_tester ) {
             auto r = buyram(config::system_account_name, N(provider), asset(1000));
             BOOST_REQUIRE( !r->except_ptr );
 
-            r = delegate_bandwidth(N(eosio.stake), N(provider), asset(1000000), asset(100000));
+            r = delegate_bandwidth(stake_account_name, N(provider), asset(1000000), asset(100000));
             BOOST_REQUIRE( !r->except_ptr );
 
             r = buyram(config::system_account_name, N(user), asset(1000));

--- a/unittests/ram_tests.cpp
+++ b/unittests/ram_tests.cpp
@@ -39,7 +39,7 @@ BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester) { try {
    create_account_with_resources(N(testram11111),config::system_account_name, init_request_bytes + 40);
    create_account_with_resources(N(testram22222),config::system_account_name, init_request_bytes + 1190);
    produce_blocks(10);
-   BOOST_REQUIRE_EQUAL( success(), stake( "eosio.stake", "testram11111", core_from_string("10.0000"), core_from_string("5.0000") ) );
+   BOOST_REQUIRE_EQUAL(success(), stake(config::stake_account_name, "testram11111", core_from_string("10.0000"), core_from_string("5.0000")));
    produce_blocks(10);
 
    for (auto i = 0; i < 10; ++i) {


### PR DESCRIPTION
it's quite large, so divided to several commits.

Base:
1. change values of `config.hpp` constants
2. use constants instead of `N(eosio)`
3. fix names strings in cleos ("eosio" and "eosio.msig")
4. update default producer in `config.ini`
5. update comments to refer new system accounts

System contracts:
1. Hardcoded names replaced with constants

Unittests:
1. common system names moved to tester.hpp config namespace
2. tests updated to use constants instead of hardcoded names

Other:
1. eosio-launcher & test scripts updated to use new names. note: contracts' dirs do not renamed for now
2. tutorial scripts updated to use new names
3. testnet template updated to use new names

+Fix macro:
1. fix names in SET_APP_HANDLER macro
2. fix hardcoded `N(eosio)` check for provideram