### PR TITLE
Port block_log implementation from Golos blockchain #320

### DIFF
--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -126,8 +126,7 @@ namespace eosio { namespace chain {
 
                 const auto* ptr = block_mapped_file.data() + pos;
                 const auto available_size = file_size - pos;
-                //const auto max_block_size = std::min<std::size_t>(available_size, STEEMIT_MAX_BLOCK_SIZE);
-                const auto max_block_size = available_size;
+                const auto max_block_size = std::min<std::size_t>(available_size, eosio::chain::config::maximum_block_size);
 
                 fc::datastream<const char*> ds(ptr, max_block_size);
                 fc::raw::unpack(ds, block);
@@ -285,6 +284,11 @@ namespace eosio { namespace chain {
 
             uint64_t append(const signed_block_ptr& block, const std::vector<char>& data) { try {
                 const auto index_pos = get_mapped_size(index_mapped_file);
+
+                EOS_ASSERT(data.size() <= eosio::chain::config::maximum_block_size,
+                    block_log_exception,
+                    "Block size to large (current ${size}, maximum ${max})",
+                    ("size", data.size())("max", eosio::chain::config::maximum_block_size));
 
                 EOS_ASSERT(index_pos == sizeof(uint64_t) * (block->block_num() - 1),
                     block_log_exception,

--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -6,13 +6,14 @@
 #include <eosio/chain/exceptions.hpp>
 #include <fstream>
 #include <fc/io/raw.hpp>
+#include <boost/iostreams/device/mapped_file.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/thread/shared_mutex.hpp>
 
 #define LOG_READ  (std::ios::in | std::ios::binary)
 #define LOG_WRITE (std::ios::out | std::ios::binary | std::ios::app)
 
 namespace eosio { namespace chain {
-
-   const uint32_t block_log::min_supported_version = 1;
 
    /**
     * History:
@@ -20,65 +21,299 @@ namespace eosio { namespace chain {
     * Version 2: adds optional partial block log, cannot be used for replay without snapshot
     *            this is in the form of an first_block_num that is written immediately after the version
     */
-   const uint32_t block_log::max_supported_version = 2;
 
    namespace detail {
+
+      using read_write_mutex = boost::shared_mutex;
+      using read_lock = boost::shared_lock<read_write_mutex>;
+      using write_lock = boost::unique_lock<read_write_mutex>;
+      using boost::iostreams::mapped_file;
+      static constexpr boost::iostreams::stream_offset min_valid_file_size = sizeof(uint32_t);
+
       class block_log_impl {
          public:
             signed_block_ptr         head;
             block_id_type            head_id;
-            std::fstream             block_stream;
-            std::fstream             index_stream;
-            fc::path                 block_file;
-            fc::path                 index_file;
-            bool                     block_write;
-            bool                     index_write;
-            bool                     genesis_written_to_block_log = false;
+
+            std::string              block_path;
+            std::string              index_path;
+            mapped_file              block_mapped_file;
+            mapped_file              index_mapped_file;
+            read_write_mutex         mutex;
+
             uint32_t                 version = 0;
-            uint32_t                 first_block_num = 0;
+            const uint32_t           min_supported_version = 1;
+            const uint32_t           max_supported_version = 1;
 
-            inline void check_block_read() {
-               if (block_write) {
-                  block_stream.close();
-                  block_stream.open(block_file.generic_string().c_str(), LOG_READ);
-                  block_write = false;
-               }
+
+            // TODO: removed by CyberWay
+            //bool                     genesis_written_to_block_log = false;
+            //uint32_t                 first_block_num = 0;
+
+            bool has_block_records() const {
+                auto size = block_mapped_file.size();
+                return (size > min_valid_file_size + sizeof(version));
             }
 
-            inline void check_block_write() {
-               if (!block_write) {
-                  block_stream.close();
-                  block_stream.open(block_file.generic_string().c_str(), LOG_WRITE);
-                  block_write = true;
-               }
+            bool has_index_records() const {
+                auto size = index_mapped_file.size();
+                return (size >= min_valid_file_size);
             }
 
-            inline void check_index_read() {
-               try {
-                  if (index_write) {
-                     index_stream.close();
-                     index_stream.open(index_file.generic_string().c_str(), LOG_READ);
-                     index_write = false;
-                  }
-               }
-               FC_LOG_AND_RETHROW()
+            std::size_t get_mapped_size(const boost::iostreams::mapped_file& mapped_file) const {
+                auto size = mapped_file.size();
+                if (size < min_valid_file_size) {
+                    return 0;
+                }
+                return size;
             }
 
-            inline void check_index_write() {
-               if (!index_write) {
-                  index_stream.close();
-                  index_stream.open(index_file.generic_string().c_str(), LOG_WRITE);
-                  index_write = true;
-               }
+            uint64_t get_uint64(const boost::iostreams::mapped_file& mapped_file, std::size_t pos) const {
+                uint64_t value;
+                auto file_size = get_mapped_size(mapped_file);
+                EOS_ASSERT(pos + sizeof(value) <= file_size,
+                        block_log_exception,
+                        "Reading data beyond end of file",
+                        ("pos", pos)("size", sizeof(value))("file_size", file_size));
+
+                auto* ptr = mapped_file.data() + pos;
+                value = *reinterpret_cast<uint64_t*>(ptr);
+                return value;
             }
+
+            uint32_t get_uint32(const boost::iostreams::mapped_file& mapped_file, std::size_t pos) const {
+                uint32_t value;
+                auto file_size = get_mapped_size(mapped_file);
+                EOS_ASSERT(pos + sizeof(value) <= file_size,
+                        block_log_exception,
+                        "Reading data beyond end of file",
+                        ("pos", pos)("size", sizeof(value))("file_size", file_size));
+
+                auto* ptr = mapped_file.data() + pos;
+                value = *reinterpret_cast<uint32_t*>(ptr);
+                return value;
+            }
+
+            uint64_t get_last_uint64(const boost::iostreams::mapped_file& mapped_file) const {
+                uint64_t value;
+                auto file_size = get_mapped_size(mapped_file);
+                EOS_ASSERT(sizeof(value) <= file_size,
+                        block_log_exception,
+                        "Reading data beyond end of file",
+                        ("size", sizeof(value))("file_size", file_size));
+
+                auto* ptr = mapped_file.data() + file_size - sizeof(value);
+                value = *reinterpret_cast<uint64_t*>(ptr);
+                return value;
+            }
+
+            uint64_t get_block_pos(uint32_t block_num) const {
+                if (head.get() != nullptr &&
+                    block_num <= block_header::num_from_id(head_id) &&
+                    block_num > 0
+                ) {
+                    return get_uint64(index_mapped_file, sizeof(uint64_t) * (block_num - 1));
+                }
+                return block_log::npos;
+            }
+
+            uint64_t read_block(uint64_t pos, signed_block& block) const {
+                const auto file_size = get_mapped_size(block_mapped_file);
+                EOS_ASSERT(pos < file_size,
+                        block_log_exception,
+                        "Reading data beyond end of file",
+                        ("pos", pos)("file_size", file_size));
+
+                const auto* ptr = block_mapped_file.data() + pos;
+                const auto available_size = file_size - pos;
+                //const auto max_block_size = std::min<std::size_t>(available_size, STEEMIT_MAX_BLOCK_SIZE);
+                const auto max_block_size = available_size;
+
+                fc::datastream<const char*> ds(ptr, max_block_size);
+                fc::raw::unpack(ds, block);
+
+                const auto end_pos = pos + ds.tellp();
+                const auto block_pos = get_uint64(block_mapped_file, end_pos);
+                EOS_ASSERT(block_pos == pos,
+                        block_log_exception,
+                        "Wrong position markers was read (read ${block_pos}, expected ${expected})",
+                        ("block_pos", block_pos)("expected", pos));
+
+                return end_pos + sizeof(uint64_t);
+            }
+
+            signed_block_ptr read_head() const {
+                if (get_mapped_size(block_mapped_file) == 0) {
+                    return {};
+                }
+                auto pos = get_last_uint64(block_mapped_file);
+                signed_block_ptr block = std::make_shared<signed_block>();
+                read_block(pos, *block);
+                return block;
+            }
+
+            void create_nonexist_file(const std::string& path) const {
+                if (!boost::filesystem::is_regular_file(path) || boost::filesystem::file_size(path) == 0) {
+                    std::ofstream stream(path, std::ios::out|std::ios::binary);
+                    stream << '\0';
+                    stream.close();
+                }
+            }
+
+            void open_block_mapped_file() {
+                create_nonexist_file(block_path);
+                block_mapped_file.open(block_path, boost::iostreams::mapped_file::readwrite);
+            }
+
+            void open_index_mapped_file() {
+                create_nonexist_file(index_path);
+                index_mapped_file.open(index_path, boost::iostreams::mapped_file::readwrite);
+            }
+
+            void construct_index() {
+                ilog("Reconstructing Block Log Index...");
+                index_mapped_file.close();
+                boost::filesystem::remove_all(index_path);
+                open_index_mapped_file();
+                index_mapped_file.resize(head->block_num() * sizeof(uint64_t));
+
+                uint64_t pos = sizeof(uint32_t); // version
+                uint64_t end_pos = get_last_uint64(block_mapped_file);
+                auto* idx_ptr = index_mapped_file.data();
+                signed_block tmp_block;
+
+                while (pos <= end_pos) {
+                    *reinterpret_cast<uint64_t*>(idx_ptr) = pos;
+                    pos = read_block(pos, tmp_block);
+                    ilog("Read block: ${block_id} ${previous}", ("block_id",tmp_block.id())("previous",tmp_block.previous));
+                    idx_ptr += sizeof(pos);
+                }
+            }
+
+            void open(const fc::path& data_dir) { try {
+                block_mapped_file.close();
+                index_mapped_file.close();
+
+                block_path = (data_dir / "blocks.log").string();
+                index_path = (data_dir / "blocks.index").string();
+ 
+                open_block_mapped_file();
+                open_index_mapped_file();
+
+                /* On startup of the block log, there are several states the log file and the index file can be
+                 * in relation to each other.
+                 *
+                 *                          Block Log
+                 *                     Exists       Is New
+                 *                 +------------+------------+
+                 *          Exists |    Check   |   Delete   |
+                 *   Index         |    Head    |    Index   |
+                 *    File         +------------+------------+
+                 *          Is New |   Replay   |     Do     |
+                 *                 |    Log     |   Nothing  |
+                 *                 +------------+------------+
+                 *
+                 * Checking the heads of the files has several conditions as well.
+                 *  - If they are the same, do nothing.
+                 *  - If the index file head is not in the log file, delete the index and replay.
+                 *  - If the index file head is in the log, but not up to date, replay from index head.
+                 */
+
+                if (has_block_records()) {
+                    ilog("Log is nonempty");
+
+                    version = get_uint32(block_mapped_file, 0);
+                    EOS_ASSERT(version >= min_supported_version && version <= max_supported_version, block_log_unsupported_version,
+                            "Unsupported version of block log. Block log version is ${version} while code supports version(s) [${min},${max}]",
+                            ("version", version)("min", min_supported_version)("max", max_supported_version) );
+
+                    head = read_head();
+                    head_id = head->id();
+
+                    if (has_index_records()) {
+                        ilog("Index is nonempty");
+
+                        auto block_pos = get_last_uint64(block_mapped_file);
+                        auto index_pos = get_last_uint64(index_mapped_file);
+
+                        if (block_pos != index_pos) {
+                            ilog("block_pos != index_pos, close and reopen index_stream");
+                            construct_index();
+                        }
+                    } else {
+                        ilog("Index is empty");
+                        construct_index();
+                    }
+                } else if (has_index_records()) {
+                    ilog("Index is nonempty, remove and recreate it");
+                    index_mapped_file.close();
+                    block_mapped_file.close();
+
+                    boost::filesystem::remove_all(block_path);
+                    boost::filesystem::remove_all(index_path);
+
+                    open_block_mapped_file();
+                    open_index_mapped_file();
+                }
+            } FC_LOG_AND_RETHROW() }
+
+            void reset( const signed_block_ptr& first_block, const std::vector<char>& first_block_data ) try {
+                block_mapped_file.close();
+                index_mapped_file.close();
+
+                fc::remove_all(block_path);
+                fc::remove_all(index_path);
+
+                open_block_mapped_file();
+                open_index_mapped_file();
+
+                block_mapped_file.resize(sizeof(uint32_t));
+                auto* ptr = block_mapped_file.data();
+                *reinterpret_cast<uint32_t*>(ptr) = max_supported_version;
+
+                if (first_block) {
+                    append(first_block, first_block_data);
+                }
+            } FC_LOG_AND_RETHROW()
+
+            void close() {
+                block_mapped_file.close();
+                index_mapped_file.close();
+                head.reset();
+                head_id = block_id_type();
+            }
+
+            uint64_t append(const signed_block_ptr& block, const std::vector<char>& data) { try {
+                const auto index_pos = get_mapped_size(index_mapped_file);
+
+                EOS_ASSERT(index_pos == sizeof(uint64_t) * (block->block_num() - 1),
+                    block_log_exception,
+                    "Append to index file occuring at wrong position.",
+                    ("position", index_pos)
+                    ("expected", (block->block_num() - 1) * sizeof(uint64_t)));
+
+                uint64_t block_pos = get_mapped_size(block_mapped_file);
+
+                block_mapped_file.resize(block_pos + data.size() + sizeof(block_pos));
+                auto* ptr = block_mapped_file.data() + block_pos;
+                std::memcpy(ptr, data.data(), data.size());
+                ptr += data.size();
+                *reinterpret_cast<uint64_t*>(ptr) = block_pos;
+
+                index_mapped_file.resize(index_pos + sizeof(index_pos));
+                ptr = index_mapped_file.data() + index_pos;
+                *reinterpret_cast<uint64_t*>(ptr) = block_pos;
+
+                head = block;
+                head_id = block->id();
+                return block_pos;
+            } FC_LOG_AND_RETHROW() }
       };
    }
 
    block_log::block_log(const fc::path& data_dir)
-   :my(new detail::block_log_impl()) {
-      my->block_stream.exceptions(std::fstream::failbit | std::fstream::badbit);
-      my->index_stream.exceptions(std::fstream::failbit | std::fstream::badbit);
-      open(data_dir);
+   : my(std::make_unique<detail::block_log_impl>()) {
+       open(data_dir);
    }
 
    block_log::block_log(block_log&& other) {
@@ -93,460 +328,328 @@ namespace eosio { namespace chain {
    }
 
    void block_log::open(const fc::path& data_dir) {
-      if (my->block_stream.is_open())
-         my->block_stream.close();
-      if (my->index_stream.is_open())
-         my->index_stream.close();
-
-      if (!fc::is_directory(data_dir))
-         fc::create_directories(data_dir);
-      my->block_file = data_dir / "blocks.log";
-      my->index_file = data_dir / "blocks.index";
-
-      //ilog("Opening block log at ${path}", ("path", my->block_file.generic_string()));
-      my->block_stream.open(my->block_file.generic_string().c_str(), LOG_WRITE);
-      my->index_stream.open(my->index_file.generic_string().c_str(), LOG_WRITE);
-      my->block_write = true;
-      my->index_write = true;
-
-      /* On startup of the block log, there are several states the log file and the index file can be
-       * in relation to each other.
-       *
-       *                          Block Log
-       *                     Exists       Is New
-       *                 +------------+------------+
-       *          Exists |    Check   |   Delete   |
-       *   Index         |    Head    |    Index   |
-       *    File         +------------+------------+
-       *          Is New |   Replay   |     Do     |
-       *                 |    Log     |   Nothing  |
-       *                 +------------+------------+
-       *
-       * Checking the heads of the files has several conditions as well.
-       *  - If they are the same, do nothing.
-       *  - If the index file head is not in the log file, delete the index and replay.
-       *  - If the index file head is in the log, but not up to date, replay from index head.
-       */
-      auto log_size = fc::file_size(my->block_file);
-      auto index_size = fc::file_size(my->index_file);
-
-      if (log_size) {
-         ilog("Log is nonempty");
-         my->check_block_read();
-         my->block_stream.seekg( 0 );
-         my->version = 0;
-         my->block_stream.read( (char*)&my->version, sizeof(my->version) );
-         EOS_ASSERT( my->version > 0, block_log_exception, "Block log was not setup properly" );
-         EOS_ASSERT( my->version >= min_supported_version && my->version <= max_supported_version, block_log_unsupported_version,
-                 "Unsupported version of block log. Block log version is ${version} while code supports version(s) [${min},${max}]",
-                 ("version", my->version)("min", block_log::min_supported_version)("max", block_log::max_supported_version) );
-
-
-         my->genesis_written_to_block_log = true; // Assume it was constructed properly.
-         if (my->version > 1){
-            my->first_block_num = 0;
-            my->block_stream.read( (char*)&my->first_block_num, sizeof(my->first_block_num) );
-            EOS_ASSERT(my->first_block_num > 0, block_log_exception, "Block log is malformed, first recorded block number is 0 but must be greater than or equal to 1");
-         } else {
-            my->first_block_num = 1;
-         }
-
-         my->head = read_head();
-         my->head_id = my->head->id();
-
-         if (index_size) {
-            my->check_block_read();
-            my->check_index_read();
-
-            ilog("Index is nonempty");
-            uint64_t block_pos;
-            my->block_stream.seekg(-sizeof(uint64_t), std::ios::end);
-            my->block_stream.read((char*)&block_pos, sizeof(block_pos));
-
-            uint64_t index_pos;
-            my->index_stream.seekg(-sizeof(uint64_t), std::ios::end);
-            my->index_stream.read((char*)&index_pos, sizeof(index_pos));
-
-            if (block_pos < index_pos) {
-               ilog("block_pos < index_pos, close and reopen index_stream");
-               construct_index();
-            } else if (block_pos > index_pos) {
-               ilog("Index is incomplete");
-               construct_index();
-            }
-         } else {
-            ilog("Index is empty");
-            construct_index();
-         }
-      } else if (index_size) {
-         ilog("Index is nonempty, remove and recreate it");
-         my->index_stream.close();
-         fc::remove_all(my->index_file);
-         my->index_stream.open(my->index_file.generic_string().c_str(), LOG_WRITE);
-         my->index_write = true;
-      }
+        detail::write_lock lock(my->mutex);
+        my->open(data_dir);
    }
 
-   uint64_t block_log::append(const signed_block_ptr& b) {
-      try {
-         EOS_ASSERT( my->genesis_written_to_block_log, block_log_append_fail, "Cannot append to block log until the genesis is first written" );
-
-         my->check_block_write();
-         my->check_index_write();
-
-         uint64_t pos = my->block_stream.tellp();
-         EOS_ASSERT(my->index_stream.tellp() == sizeof(uint64_t) * (b->block_num() - my->first_block_num),
-                   block_log_append_fail,
-                   "Append to index file occuring at wrong position.",
-                   ("position", (uint64_t) my->index_stream.tellp())
-                   ("expected", (b->block_num() - my->first_block_num) * sizeof(uint64_t)));
-         auto data = fc::raw::pack(*b);
-         my->block_stream.write(data.data(), data.size());
-         my->block_stream.write((char*)&pos, sizeof(pos));
-         my->index_stream.write((char*)&pos, sizeof(pos));
-         my->head = b;
-         my->head_id = b->id();
-
-         flush();
-
-         return pos;
-      }
-      FC_LOG_AND_RETHROW()
-   }
+   uint64_t block_log::append(const signed_block_ptr& block) try {
+        auto data = fc::raw::pack(*block);
+        detail::write_lock lock(my->mutex);
+        return my->append(block, data);
+   } FC_LOG_AND_RETHROW()
 
    void block_log::flush() {
-      my->block_stream.flush();
-      my->index_stream.flush();
+       // it isn't needed, because all data is already in page cache
    }
 
    void block_log::reset( const genesis_state& gs, const signed_block_ptr& first_block, uint32_t first_block_num ) {
-      if (my->block_stream.is_open())
-         my->block_stream.close();
-      if (my->index_stream.is_open())
-         my->index_stream.close();
+       EOS_ASSERT(first_block_num == 1, block_log_exception,
+            "Unsupported first_block_num (can be only 1)");
 
-      fc::remove_all(my->block_file);
-      fc::remove_all(my->index_file);
+       std::vector<char> data;
+       if (first_block) {
+           data = fc::raw::pack(*first_block);
+       }
 
-      my->block_stream.open(my->block_file.generic_string().c_str(), LOG_WRITE);
-      my->index_stream.open(my->index_file.generic_string().c_str(), LOG_WRITE);
-      my->block_write = true;
-      my->index_write = true;
+       detail::write_lock lock(my->mutex);
+       my->reset(first_block, data);
 
-      auto data = fc::raw::pack(gs);
-      my->version = 0; // version of 0 is invalid; it indicates that the genesis was not properly written to the block log
-      my->first_block_num = first_block_num;
-      my->block_stream.write((char*)&my->version, sizeof(my->version));
-      my->block_stream.write((char*)&my->first_block_num, sizeof(my->first_block_num));
-      my->block_stream.write(data.data(), data.size());
-      my->genesis_written_to_block_log = true;
-
-      // append a totem to indicate the division between blocks and header
-      auto totem = npos;
-      my->block_stream.write((char*)&totem, sizeof(totem));
-
-      if (first_block) {
-         append(first_block);
-      }
-
-      auto pos = my->block_stream.tellp();
-
-      my->block_stream.close();
-      my->block_stream.open(my->block_file.generic_string().c_str(), std::ios::in | std::ios::out | std::ios::binary ); // Bypass append-only writing just once
-
-      static_assert( block_log::max_supported_version > 0, "a version number of zero is not supported" );
-      my->version = block_log::max_supported_version;
-      my->block_stream.seekp( 0 );
-      my->block_stream.write( (char*)&my->version, sizeof(my->version) );
-      my->block_stream.seekp( pos );
-      flush();
-
-      my->block_write = false;
-      my->check_block_write(); // Reset to append-only writing.
+// TODO: removed by CyberWay
+//      auto data = fc::raw::pack(gs);
+//      my->version = 0; // version of 0 is invalid; it indicates that the genesis was not properly written to the block log
+//      my->first_block_num = first_block_num;
+//      my->block_stream.write((char*)&my->version, sizeof(my->version));
+//      my->block_stream.write((char*)&my->first_block_num, sizeof(my->first_block_num));
+//      my->block_stream.write(data.data(), data.size());
+//      my->genesis_written_to_block_log = true;
+//
+//      // append a totem to indicate the division between blocks and header
+//      auto totem = npos;
+//      my->block_stream.write((char*)&totem, sizeof(totem));
+//
+//      if (first_block) {
+//         append(first_block);
+//      }
+//
+//      auto pos = my->block_stream.tellp();
+//
+//      my->block_stream.close();
+//      my->block_stream.open(my->block_file.generic_string().c_str(), std::ios::in | std::ios::out | std::ios::binary ); // Bypass append-only writing just once
+//
+//      static_assert( block_log::max_supported_version > 0, "a version number of zero is not supported" );
+//      my->version = block_log::max_supported_version;
+//      my->block_stream.seekp( 0 );
+//      my->block_stream.write( (char*)&my->version, sizeof(my->version) );
+//      my->block_stream.seekp( pos );
+//      flush();
+//
+//      my->block_write = false;
+//      my->check_block_write(); // Reset to append-only writing.
    }
 
-   std::pair<signed_block_ptr, uint64_t> block_log::read_block(uint64_t pos)const {
-      my->check_block_read();
+   std::pair<signed_block_ptr, uint64_t> block_log::read_block(uint64_t pos) const {
+        detail::read_lock lock(my->mutex);
+        std::pair<signed_block_ptr, uint64_t> result;
+        result.first = std::make_shared<signed_block>();
+        result.second = my->read_block(pos, *result.first);
+        return result;
+    }
 
-      my->block_stream.seekg(pos);
-      std::pair<signed_block_ptr,uint64_t> result;
-      result.first = std::make_shared<signed_block>();
-      fc::raw::unpack(my->block_stream, *result.first);
-      result.second = uint64_t(my->block_stream.tellg()) + 8;
-      return result;
-   }
-
-   signed_block_ptr block_log::read_block_by_num(uint32_t block_num)const {
-      try {
-         signed_block_ptr b;
-         uint64_t pos = get_block_pos(block_num);
-         if (pos != npos) {
-            b = read_block(pos).first;
-            EOS_ASSERT(b->block_num() == block_num, reversible_blocks_exception,
-                      "Wrong block was read from block log.", ("returned", b->block_num())("expected", block_num));
-         }
-         return b;
-      } FC_LOG_AND_RETHROW()
-   }
+   signed_block_ptr block_log::read_block_by_num(uint32_t block_num) const try {
+       detail::read_lock lock(my->mutex);
+       signed_block_ptr block = std::make_shared<signed_block>();
+       uint64_t pos = my->get_block_pos(block_num);
+       if (pos != npos) {
+           my->read_block(pos, *block);
+           EOS_ASSERT(block->block_num() == block_num,
+                   block_log_exception,
+                   "Wrong block was read from block log (read ${block_num}, expected ${expected}).",
+                   ("block_num", block->block_num())("expected", block_num));
+       }
+       return block;
+   } FC_LOG_AND_RETHROW()
 
    uint64_t block_log::get_block_pos(uint32_t block_num) const {
-      my->check_index_read();
-      if (!(my->head && block_num <= block_header::num_from_id(my->head_id) && block_num >= my->first_block_num))
-         return npos;
-      my->index_stream.seekg(sizeof(uint64_t) * (block_num - my->first_block_num));
-      uint64_t pos;
-      my->index_stream.read((char*)&pos, sizeof(pos));
-      return pos;
+        detail::read_lock lock(my->mutex);
+        return my->get_block_pos(block_num);
    }
 
    signed_block_ptr block_log::read_head()const {
-      my->check_block_read();
-
-      uint64_t pos;
-
-      // Check that the file is not empty
-      my->block_stream.seekg(0, std::ios::end);
-      if (my->block_stream.tellg() <= sizeof(pos))
-         return {};
-
-      my->block_stream.seekg(-sizeof(pos), std::ios::end);
-      my->block_stream.read((char*)&pos, sizeof(pos));
-      if (pos != npos) {
-         return read_block(pos).first;
-      } else {
-         return {};
-      }
+       detail::read_lock lock(my->mutex);
+       return my->read_head();
    }
 
    const signed_block_ptr& block_log::head()const {
+      detail::read_lock lock(my->mutex);
       return my->head;
    }
 
-   uint32_t block_log::first_block_num() const {
-      return my->first_block_num;
-   }
+// TODO: removed by CyberWay
+//   uint32_t block_log::first_block_num() const {
+//      return my->first_block_num;
+//   }
+//
+//   void block_log::construct_index() {
+//      ilog("Reconstructing Block Log Index...");
+//      my->index_stream.close();
+//      fc::remove_all(my->index_file);
+//      my->index_stream.open(my->index_file.generic_string().c_str(), LOG_WRITE);
+//      my->index_write = true;
+//
+//      uint64_t end_pos;
+//      my->check_block_read();
+//
+//      my->block_stream.seekg(-sizeof( uint64_t), std::ios::end);
+//      my->block_stream.read((char*)&end_pos, sizeof(end_pos));
+//      signed_block tmp;
+//
+//      uint64_t pos = 0;
+//      if (my->version == 1) {
+//         pos = 4; // Skip version which should have already been checked.
+//      } else {
+//         pos = 8; // Skip version and first block offset which should have already been checked
+//      }
+//      my->block_stream.seekg(pos);
+//
+//      genesis_state gs;
+//      fc::raw::unpack(my->block_stream, gs);
+//
+//      // skip the totem
+//      if (my->version > 1) {
+//         uint64_t totem;
+//         my->block_stream.read((char*) &totem, sizeof(totem));
+//      }
+//
+//      while( pos < end_pos ) {
+//         fc::raw::unpack(my->block_stream, tmp);
+//         my->block_stream.read((char*)&pos, sizeof(pos));
+//         my->index_stream.write((char*)&pos, sizeof(pos));
+//      }
+//   } // construct_index
+//
+//   fc::path block_log::repair_log( const fc::path& data_dir, uint32_t truncate_at_block ) {
+//      ilog("Recovering Block Log...");
+//      EOS_ASSERT( fc::is_directory(data_dir) && fc::is_regular_file(data_dir / "blocks.log"), block_log_not_found,
+//                 "Block log not found in '${blocks_dir}'", ("blocks_dir", data_dir)          );
+//
+//      auto now = fc::time_point::now();
+//
+//      auto blocks_dir = fc::canonical( data_dir );
+//      if( blocks_dir.filename().generic_string() == "." ) {
+//         blocks_dir = blocks_dir.parent_path();
+//      }
+//      auto backup_dir = blocks_dir.parent_path();
+//      auto blocks_dir_name = blocks_dir.filename();
+//      EOS_ASSERT( blocks_dir_name.generic_string() != ".", block_log_exception, "Invalid path to blocks directory" );
+//      backup_dir = backup_dir / blocks_dir_name.generic_string().append("-").append( now );
+//
+//      EOS_ASSERT( !fc::exists(backup_dir), block_log_backup_dir_exist,
+//                 "Cannot move existing blocks directory to already existing directory '${new_blocks_dir}'",
+//                 ("new_blocks_dir", backup_dir) );
+//
+//      fc::rename( blocks_dir, backup_dir );
+//      ilog( "Moved existing blocks directory to backup location: '${new_blocks_dir}'", ("new_blocks_dir", backup_dir) );
+//
+//      fc::create_directories(blocks_dir);
+//      auto block_log_path = blocks_dir / "blocks.log";
+//
+//      ilog( "Reconstructing '${new_block_log}' from backed up block log", ("new_block_log", block_log_path) );
+//
+//      std::fstream  old_block_stream;
+//      std::fstream  new_block_stream;
+//
+//      old_block_stream.open( (backup_dir / "blocks.log").generic_string().c_str(), LOG_READ );
+//      new_block_stream.open( block_log_path.generic_string().c_str(), LOG_WRITE );
+//
+//      old_block_stream.seekg( 0, std::ios::end );
+//      uint64_t end_pos = old_block_stream.tellg();
+//      old_block_stream.seekg( 0 );
+//
+//      uint32_t version = 0;
+//      old_block_stream.read( (char*)&version, sizeof(version) );
+//      EOS_ASSERT( version > 0, block_log_exception, "Block log was not setup properly" );
+//      EOS_ASSERT( version >= min_supported_version && version <= max_supported_version, block_log_unsupported_version,
+//                 "Unsupported version of block log. Block log version is ${version} while code supports version(s) [${min},${max}]",
+//                 ("version", version)("min", block_log::min_supported_version)("max", block_log::max_supported_version) );
+//
+//      new_block_stream.write( (char*)&version, sizeof(version) );
+//
+//      uint32_t first_block_num = 1;
+//      if (version != 1) {
+//         old_block_stream.read ( (char*)&first_block_num, sizeof(first_block_num) );
+//         new_block_stream.write( (char*)&first_block_num, sizeof(first_block_num) );
+//      }
+//
+//      genesis_state gs;
+//      fc::raw::unpack(old_block_stream, gs);
+//
+//      auto data = fc::raw::pack( gs );
+//      new_block_stream.write( data.data(), data.size() );
+//
+//      if (version != 1) {
+//         auto expected_totem = npos;
+//         std::decay_t<decltype(npos)> actual_totem;
+//         old_block_stream.read ( (char*)&actual_totem, sizeof(actual_totem) );
+//
+//         EOS_ASSERT(actual_totem == expected_totem, block_log_exception,
+//                    "Expected separator between block log header and blocks was not found( expected: ${e}, actual: ${a} )",
+//                    ("e", fc::to_hex((char*)&expected_totem, sizeof(expected_totem) ))("a", fc::to_hex((char*)&actual_totem, sizeof(actual_totem) )));
+//
+//         new_block_stream.write( (char*)&actual_totem, sizeof(actual_totem) );
+//      }
+//
+//      std::exception_ptr     except_ptr;
+//      vector<char>           incomplete_block_data;
+//      optional<signed_block> bad_block;
+//      uint32_t               block_num = 0;
+//
+//      block_id_type previous;
+//
+//      uint64_t pos = old_block_stream.tellg();
+//      while( pos < end_pos ) {
+//         signed_block tmp;
+//
+//         try {
+//            fc::raw::unpack(old_block_stream, tmp);
+//         } catch( ... ) {
+//            except_ptr = std::current_exception();
+//            incomplete_block_data.resize( end_pos - pos );
+//            old_block_stream.read( incomplete_block_data.data(), incomplete_block_data.size() );
+//            break;
+//         }
+//
+//         auto id = tmp.id();
+//         if( block_header::num_from_id(previous) + 1 != block_header::num_from_id(id) ) {
+//            elog( "Block ${num} (${id}) skips blocks. Previous block in block log is block ${prev_num} (${previous})",
+//                  ("num", block_header::num_from_id(id))("id", id)
+//                  ("prev_num", block_header::num_from_id(previous))("previous", previous) );
+//         }
+//         if( previous != tmp.previous ) {
+//            elog( "Block ${num} (${id}) does not link back to previous block. "
+//                  "Expected previous: ${expected}. Actual previous: ${actual}.",
+//                  ("num", block_header::num_from_id(id))("id", id)("expected", previous)("actual", tmp.previous) );
+//         }
+//         previous = id;
+//
+//         uint64_t tmp_pos = std::numeric_limits<uint64_t>::max();
+//         if( (static_cast<uint64_t>(old_block_stream.tellg()) + sizeof(pos)) <= end_pos ) {
+//            old_block_stream.read( reinterpret_cast<char*>(&tmp_pos), sizeof(tmp_pos) );
+//         }
+//         if( pos != tmp_pos ) {
+//            bad_block.emplace(std::move(tmp));
+//            break;
+//         }
+//
+//         auto data = fc::raw::pack(tmp);
+//         new_block_stream.write( data.data(), data.size() );
+//         new_block_stream.write( reinterpret_cast<char*>(&pos), sizeof(pos) );
+//         block_num = tmp.block_num();
+//         pos = new_block_stream.tellp();
+//         if( block_num == truncate_at_block )
+//            break;
+//      }
+//
+//      if( bad_block.valid() ) {
+//         ilog( "Recovered only up to block number ${num}. Last block in block log was not properly committed:\n${last_block}",
+//               ("num", block_num)("last_block", *bad_block) );
+//      } else if( except_ptr ) {
+//         std::string error_msg;
+//
+//         try {
+//            std::rethrow_exception(except_ptr);
+//         } catch( const fc::exception& e ) {
+//            error_msg = e.what();
+//         } catch( const std::exception& e ) {
+//            error_msg = e.what();
+//         } catch( ... ) {
+//            error_msg = "unrecognized exception";
+//         }
+//
+//         ilog( "Recovered only up to block number ${num}. "
+//               "The block ${next_num} could not be deserialized from the block log due to error:\n${error_msg}",
+//               ("num", block_num)("next_num", block_num+1)("error_msg", error_msg) );
+//
+//         auto tail_path = blocks_dir / std::string("blocks-bad-tail-").append( now ).append(".log");
+//         if( !fc::exists(tail_path) && incomplete_block_data.size() > 0 ) {
+//            std::fstream tail_stream;
+//            tail_stream.open( tail_path.generic_string().c_str(), LOG_WRITE );
+//            tail_stream.write( incomplete_block_data.data(), incomplete_block_data.size() );
+//
+//            ilog( "Data at tail end of block log which should contain the (incomplete) serialization of block ${num} "
+//                  "has been written out to '${tail_path}'.",
+//                  ("num", block_num+1)("tail_path", tail_path) );
+//         }
+//      } else if( block_num == truncate_at_block && pos < end_pos ) {
+//         ilog( "Stopped recovery of block log early at specified block number: ${stop}.", ("stop", truncate_at_block) );
+//      } else {
+//         ilog( "Existing block log was undamaged. Recovered all irreversible blocks up to block number ${num}.", ("num", block_num) );
+//      }
+//
+//      return backup_dir;
+//   }
 
-   void block_log::construct_index() {
-      ilog("Reconstructing Block Log Index...");
-      my->index_stream.close();
-      fc::remove_all(my->index_file);
-      my->index_stream.open(my->index_file.generic_string().c_str(), LOG_WRITE);
-      my->index_write = true;
-
-      uint64_t end_pos;
-      my->check_block_read();
-
-      my->block_stream.seekg(-sizeof( uint64_t), std::ios::end);
-      my->block_stream.read((char*)&end_pos, sizeof(end_pos));
-      signed_block tmp;
-
-      uint64_t pos = 0;
-      if (my->version == 1) {
-         pos = 4; // Skip version which should have already been checked.
-      } else {
-         pos = 8; // Skip version and first block offset which should have already been checked
-      }
-      my->block_stream.seekg(pos);
-
-      genesis_state gs;
-      fc::raw::unpack(my->block_stream, gs);
-
-      // skip the totem
-      if (my->version > 1) {
-         uint64_t totem;
-         my->block_stream.read((char*) &totem, sizeof(totem));
-      }
-
-      while( pos < end_pos ) {
-         fc::raw::unpack(my->block_stream, tmp);
-         my->block_stream.read((char*)&pos, sizeof(pos));
-         my->index_stream.write((char*)&pos, sizeof(pos));
-      }
-   } // construct_index
-
-   fc::path block_log::repair_log( const fc::path& data_dir, uint32_t truncate_at_block ) {
-      ilog("Recovering Block Log...");
-      EOS_ASSERT( fc::is_directory(data_dir) && fc::is_regular_file(data_dir / "blocks.log"), block_log_not_found,
-                 "Block log not found in '${blocks_dir}'", ("blocks_dir", data_dir)          );
-
-      auto now = fc::time_point::now();
-
-      auto blocks_dir = fc::canonical( data_dir );
-      if( blocks_dir.filename().generic_string() == "." ) {
-         blocks_dir = blocks_dir.parent_path();
-      }
-      auto backup_dir = blocks_dir.parent_path();
-      auto blocks_dir_name = blocks_dir.filename();
-      EOS_ASSERT( blocks_dir_name.generic_string() != ".", block_log_exception, "Invalid path to blocks directory" );
-      backup_dir = backup_dir / blocks_dir_name.generic_string().append("-").append( now );
-
-      EOS_ASSERT( !fc::exists(backup_dir), block_log_backup_dir_exist,
-                 "Cannot move existing blocks directory to already existing directory '${new_blocks_dir}'",
-                 ("new_blocks_dir", backup_dir) );
-
-      fc::rename( blocks_dir, backup_dir );
-      ilog( "Moved existing blocks directory to backup location: '${new_blocks_dir}'", ("new_blocks_dir", backup_dir) );
-
-      fc::create_directories(blocks_dir);
-      auto block_log_path = blocks_dir / "blocks.log";
-
-      ilog( "Reconstructing '${new_block_log}' from backed up block log", ("new_block_log", block_log_path) );
-
-      std::fstream  old_block_stream;
-      std::fstream  new_block_stream;
-
-      old_block_stream.open( (backup_dir / "blocks.log").generic_string().c_str(), LOG_READ );
-      new_block_stream.open( block_log_path.generic_string().c_str(), LOG_WRITE );
-
-      old_block_stream.seekg( 0, std::ios::end );
-      uint64_t end_pos = old_block_stream.tellg();
-      old_block_stream.seekg( 0 );
-
-      uint32_t version = 0;
-      old_block_stream.read( (char*)&version, sizeof(version) );
-      EOS_ASSERT( version > 0, block_log_exception, "Block log was not setup properly" );
-      EOS_ASSERT( version >= min_supported_version && version <= max_supported_version, block_log_unsupported_version,
-                 "Unsupported version of block log. Block log version is ${version} while code supports version(s) [${min},${max}]",
-                 ("version", version)("min", block_log::min_supported_version)("max", block_log::max_supported_version) );
-
-      new_block_stream.write( (char*)&version, sizeof(version) );
-
-      uint32_t first_block_num = 1;
-      if (version != 1) {
-         old_block_stream.read ( (char*)&first_block_num, sizeof(first_block_num) );
-         new_block_stream.write( (char*)&first_block_num, sizeof(first_block_num) );
-      }
-
-      genesis_state gs;
-      fc::raw::unpack(old_block_stream, gs);
-
-      auto data = fc::raw::pack( gs );
-      new_block_stream.write( data.data(), data.size() );
-
-      if (version != 1) {
-         auto expected_totem = npos;
-         std::decay_t<decltype(npos)> actual_totem;
-         old_block_stream.read ( (char*)&actual_totem, sizeof(actual_totem) );
-
-         EOS_ASSERT(actual_totem == expected_totem, block_log_exception,
-                    "Expected separator between block log header and blocks was not found( expected: ${e}, actual: ${a} )",
-                    ("e", fc::to_hex((char*)&expected_totem, sizeof(expected_totem) ))("a", fc::to_hex((char*)&actual_totem, sizeof(actual_totem) )));
-
-         new_block_stream.write( (char*)&actual_totem, sizeof(actual_totem) );
-      }
-
-      std::exception_ptr     except_ptr;
-      vector<char>           incomplete_block_data;
-      optional<signed_block> bad_block;
-      uint32_t               block_num = 0;
-
-      block_id_type previous;
-
-      uint64_t pos = old_block_stream.tellg();
-      while( pos < end_pos ) {
-         signed_block tmp;
-
-         try {
-            fc::raw::unpack(old_block_stream, tmp);
-         } catch( ... ) {
-            except_ptr = std::current_exception();
-            incomplete_block_data.resize( end_pos - pos );
-            old_block_stream.read( incomplete_block_data.data(), incomplete_block_data.size() );
-            break;
-         }
-
-         auto id = tmp.id();
-         if( block_header::num_from_id(previous) + 1 != block_header::num_from_id(id) ) {
-            elog( "Block ${num} (${id}) skips blocks. Previous block in block log is block ${prev_num} (${previous})",
-                  ("num", block_header::num_from_id(id))("id", id)
-                  ("prev_num", block_header::num_from_id(previous))("previous", previous) );
-         }
-         if( previous != tmp.previous ) {
-            elog( "Block ${num} (${id}) does not link back to previous block. "
-                  "Expected previous: ${expected}. Actual previous: ${actual}.",
-                  ("num", block_header::num_from_id(id))("id", id)("expected", previous)("actual", tmp.previous) );
-         }
-         previous = id;
-
-         uint64_t tmp_pos = std::numeric_limits<uint64_t>::max();
-         if( (static_cast<uint64_t>(old_block_stream.tellg()) + sizeof(pos)) <= end_pos ) {
-            old_block_stream.read( reinterpret_cast<char*>(&tmp_pos), sizeof(tmp_pos) );
-         }
-         if( pos != tmp_pos ) {
-            bad_block.emplace(std::move(tmp));
-            break;
-         }
-
-         auto data = fc::raw::pack(tmp);
-         new_block_stream.write( data.data(), data.size() );
-         new_block_stream.write( reinterpret_cast<char*>(&pos), sizeof(pos) );
-         block_num = tmp.block_num();
-         pos = new_block_stream.tellp();
-         if( block_num == truncate_at_block )
-            break;
-      }
-
-      if( bad_block.valid() ) {
-         ilog( "Recovered only up to block number ${num}. Last block in block log was not properly committed:\n${last_block}",
-               ("num", block_num)("last_block", *bad_block) );
-      } else if( except_ptr ) {
-         std::string error_msg;
-
-         try {
-            std::rethrow_exception(except_ptr);
-         } catch( const fc::exception& e ) {
-            error_msg = e.what();
-         } catch( const std::exception& e ) {
-            error_msg = e.what();
-         } catch( ... ) {
-            error_msg = "unrecognized exception";
-         }
-
-         ilog( "Recovered only up to block number ${num}. "
-               "The block ${next_num} could not be deserialized from the block log due to error:\n${error_msg}",
-               ("num", block_num)("next_num", block_num+1)("error_msg", error_msg) );
-
-         auto tail_path = blocks_dir / std::string("blocks-bad-tail-").append( now ).append(".log");
-         if( !fc::exists(tail_path) && incomplete_block_data.size() > 0 ) {
-            std::fstream tail_stream;
-            tail_stream.open( tail_path.generic_string().c_str(), LOG_WRITE );
-            tail_stream.write( incomplete_block_data.data(), incomplete_block_data.size() );
-
-            ilog( "Data at tail end of block log which should contain the (incomplete) serialization of block ${num} "
-                  "has been written out to '${tail_path}'.",
-                  ("num", block_num+1)("tail_path", tail_path) );
-         }
-      } else if( block_num == truncate_at_block && pos < end_pos ) {
-         ilog( "Stopped recovery of block log early at specified block number: ${stop}.", ("stop", truncate_at_block) );
-      } else {
-         ilog( "Existing block log was undamaged. Recovered all irreversible blocks up to block number ${num}.", ("num", block_num) );
-      }
-
-      return backup_dir;
-   }
-
-   genesis_state block_log::extract_genesis_state( const fc::path& data_dir ) {
-      EOS_ASSERT( fc::is_directory(data_dir) && fc::is_regular_file(data_dir / "blocks.log"), block_log_not_found,
-                 "Block log not found in '${blocks_dir}'", ("blocks_dir", data_dir)          );
-
-      std::fstream  block_stream;
-      block_stream.open( (data_dir / "blocks.log").generic_string().c_str(), LOG_READ );
-
-      uint32_t version = 0;
-      block_stream.read( (char*)&version, sizeof(version) );
-      EOS_ASSERT( version > 0, block_log_exception, "Block log was not setup properly." );
-      EOS_ASSERT( version >= min_supported_version && version <= max_supported_version, block_log_unsupported_version,
-                 "Unsupported version of block log. Block log version is ${version} while code supports version(s) [${min},${max}]",
-                 ("version", version)("min", block_log::min_supported_version)("max", block_log::max_supported_version) );
-
-      uint32_t first_block_num = 1;
-      if (version != 1) {
-         block_stream.read ( (char*)&first_block_num, sizeof(first_block_num) );
-      }
-
-      genesis_state gs;
-      fc::raw::unpack(block_stream, gs);
-      return gs;
-   }
+//   genesis_state block_log::extract_genesis_state( const fc::path& data_dir ) {
+//      EOS_ASSERT( fc::is_directory(data_dir) && fc::is_regular_file(data_dir / "blocks.log"), block_log_not_found,
+//                 "Block log not found in '${blocks_dir}'", ("blocks_dir", data_dir)          );
+//
+//      std::fstream  block_stream;
+//      block_stream.open( (data_dir / "blocks.log").generic_string().c_str(), LOG_READ );
+//
+//      uint32_t version = 0;
+//      block_stream.read( (char*)&version, sizeof(version) );
+//      EOS_ASSERT( version > 0, block_log_exception, "Block log was not setup properly." );
+//      EOS_ASSERT( version >= min_supported_version && version <= max_supported_version, block_log_unsupported_version,
+//                 "Unsupported version of block log. Block log version is ${version} while code supports version(s) [${min},${max}]",
+//                 ("version", version)("min", block_log::min_supported_version)("max", block_log::max_supported_version) );
+//
+//      uint32_t first_block_num = 1;
+//      if (version != 1) {
+//         block_stream.read ( (char*)&first_block_num, sizeof(first_block_num) );
+//      }
+//
+//      genesis_state gs;
+//      fc::raw::unpack(block_stream, gs);
+//      return gs;
+//   }
 
 } } /// eosio::chain

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -405,6 +405,8 @@ struct controller_impl {
    void init(std::function<bool()> shutdown, const snapshot_reader_ptr& snapshot) {
 
       bool report_integrity_hash = !!snapshot;
+
+      EOS_ASSERT( !snapshot, fork_database_exception, "Snapshot not supported");
       if (snapshot) {
          EOS_ASSERT( !head, fork_database_exception, "" );
          snapshot->validate();

--- a/libraries/chain/include/eosio/chain/block_log.hpp
+++ b/libraries/chain/include/eosio/chain/block_log.hpp
@@ -58,20 +58,16 @@ namespace eosio { namespace chain {
          uint64_t get_block_pos(uint32_t block_num) const;
          signed_block_ptr        read_head()const;
          const signed_block_ptr& head()const;
-         uint32_t                first_block_num() const;
+         uint32_t                first_block_num() const {return 1;}
 
          static const uint64_t npos = std::numeric_limits<uint64_t>::max();
 
-         static const uint32_t min_supported_version;
-         static const uint32_t max_supported_version;
-
-         static fc::path repair_log( const fc::path& data_dir, uint32_t truncate_at_block = 0 );
-
-         static genesis_state extract_genesis_state( const fc::path& data_dir );
+         // TODO: removed by CyberWay
+         //static fc::path repair_log( const fc::path& data_dir, uint32_t truncate_at_block = 0 );
+         //static genesis_state extract_genesis_state( const fc::path& data_dir );
 
       private:
          void open(const fc::path& data_dir);
-         void construct_index();
 
          std::unique_ptr<detail::block_log_impl> my;
    };

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -67,7 +67,7 @@ static const uint32_t block_size_average_window_ms         = 60*1000l;
 
 const static uint32_t   rate_limiting_precision        = 1000*1000;
 
-
+const static uint32_t   maximum_block_size                           = 2*1024*1024; // maximum block size for pack/unpack data in block_log
 const static uint32_t   default_max_block_net_usage                 = 1024 * 1024; /// at 500ms blocks and 200byte trx, this enables ~10,000 TPS burst
 const static uint32_t   default_target_block_net_usage_pct           = 10 * percent_1; /// we target 1000 TPS
 const static uint32_t   default_max_transaction_net_usage            = default_max_block_net_usage / 2;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -164,7 +164,7 @@ public:
    //txn_msg_rate_limits              rate_limits;
    fc::optional<vm_type>            wasm_runtime;
    fc::microseconds                 abi_serializer_max_time_ms;
-   fc::optional<bfs::path>          snapshot_path;
+   //fc::optional<bfs::path>          snapshot_path;   // TODO: removed by CyberWay
 
 
    // retained references to channels for easy publication
@@ -414,31 +414,33 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
       my->chain_config->allow_ram_billing_in_notify = options.at( "disable-ram-billing-notify-checks" ).as<bool>();
 
       if( options.count( "extract-genesis-json" ) || options.at( "print-genesis-json" ).as<bool>()) {
-         genesis_state gs;
-
-         if( fc::exists( my->blocks_dir / "blocks.log" )) {
-            gs = block_log::extract_genesis_state( my->blocks_dir );
-         } else {
-            wlog( "No blocks.log found at '${p}'. Using default genesis state.",
-                  ("p", (my->blocks_dir / "blocks.log").generic_string()));
-         }
-
-         if( options.at( "print-genesis-json" ).as<bool>()) {
-            ilog( "Genesis JSON:\n${genesis}", ("genesis", json::to_pretty_string( gs )));
-         }
-
-         if( options.count( "extract-genesis-json" )) {
-            auto p = options.at( "extract-genesis-json" ).as<bfs::path>();
-
-            if( p.is_relative()) {
-               p = bfs::current_path() / p;
-            }
-
-            fc::json::save_to_file( gs, p, true );
-            ilog( "Saved genesis JSON to '${path}'", ("path", p.generic_string()));
-         }
-
-         EOS_THROW( extract_genesis_state_exception, "extracted genesis state from blocks.log" );
+           ilog("Options 'extract-genesis-json' and 'print-genesis-json' doesn't work now");
+// TODO: removed by CyberWay
+//         genesis_state gs;
+//
+//         if( fc::exists( my->blocks_dir / "blocks.log" )) {
+//            gs = block_log::extract_genesis_state( my->blocks_dir );
+//         } else {
+//            wlog( "No blocks.log found at '${p}'. Using default genesis state.",
+//                  ("p", (my->blocks_dir / "blocks.log").generic_string()));
+//         }
+//
+//         if( options.at( "print-genesis-json" ).as<bool>()) {
+//            ilog( "Genesis JSON:\n${genesis}", ("genesis", json::to_pretty_string( gs )));
+//         }
+//
+//         if( options.count( "extract-genesis-json" )) {
+//            auto p = options.at( "extract-genesis-json" ).as<bfs::path>();
+//
+//            if( p.is_relative()) {
+//               p = bfs::current_path() / p;
+//            }
+//
+//            fc::json::save_to_file( gs, p, true );
+//            ilog( "Saved genesis JSON to '${path}'", ("path", p.generic_string()));
+//         }
+//
+//         EOS_THROW( extract_genesis_state_exception, "extracted genesis state from blocks.log" );
       }
 
       if( options.count("export-reversible-blocks") ) {
@@ -463,25 +465,26 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
          clear_directory_contents( my->chain_config->state_dir );
          fc::remove_all( my->blocks_dir );
       } else if( options.at( "hard-replay-blockchain" ).as<bool>()) {
-         ilog( "Hard replay requested: deleting state database" );
-         clear_directory_contents( my->chain_config->state_dir );
-         auto backup_dir = block_log::repair_log( my->blocks_dir, options.at( "truncate-at-block" ).as<uint32_t>());
-         if( fc::exists( backup_dir / config::reversible_blocks_dir_name ) ||
-             options.at( "fix-reversible-blocks" ).as<bool>()) {
-            // Do not try to recover reversible blocks if the directory does not exist, unless the option was explicitly provided.
-            if( !recover_reversible_blocks( backup_dir / config::reversible_blocks_dir_name,
-                                            my->chain_config->reversible_cache_size,
-                                            my->chain_config->blocks_dir / config::reversible_blocks_dir_name,
-                                            options.at( "truncate-at-block" ).as<uint32_t>())) {
-               ilog( "Reversible blocks database was not corrupted. Copying from backup to blocks directory." );
-               fc::copy( backup_dir / config::reversible_blocks_dir_name,
-                         my->chain_config->blocks_dir / config::reversible_blocks_dir_name );
-               fc::copy( backup_dir / config::reversible_blocks_dir_name / "shared_memory.bin",
-                         my->chain_config->blocks_dir / config::reversible_blocks_dir_name / "shared_memory.bin" );
-               fc::copy( backup_dir / config::reversible_blocks_dir_name / "shared_memory.meta",
-                         my->chain_config->blocks_dir / config::reversible_blocks_dir_name / "shared_memory.meta" );
-            }
-         }
+         ilog( "--hard-replay-blockchain doesn't work now");
+//         ilog( "Hard replay requested: deleting state database" );
+//         clear_directory_contents( my->chain_config->state_dir );
+//         auto backup_dir = block_log::repair_log( my->blocks_dir, options.at( "truncate-at-block" ).as<uint32_t>());
+//         if( fc::exists( backup_dir / config::reversible_blocks_dir_name ) ||
+//             options.at( "fix-reversible-blocks" ).as<bool>()) {
+//            // Do not try to recover reversible blocks if the directory does not exist, unless the option was explicitly provided.
+//            if( !recover_reversible_blocks( backup_dir / config::reversible_blocks_dir_name,
+//                                            my->chain_config->reversible_cache_size,
+//                                            my->chain_config->blocks_dir / config::reversible_blocks_dir_name,
+//                                            options.at( "truncate-at-block" ).as<uint32_t>())) {
+//               ilog( "Reversible blocks database was not corrupted. Copying from backup to blocks directory." );
+//               fc::copy( backup_dir / config::reversible_blocks_dir_name,
+//                         my->chain_config->blocks_dir / config::reversible_blocks_dir_name );
+//               fc::copy( backup_dir / config::reversible_blocks_dir_name / "shared_memory.bin",
+//                         my->chain_config->blocks_dir / config::reversible_blocks_dir_name / "shared_memory.bin" );
+//               fc::copy( backup_dir / config::reversible_blocks_dir_name / "shared_memory.meta",
+//                         my->chain_config->blocks_dir / config::reversible_blocks_dir_name / "shared_memory.meta" );
+//            }
+//         }
       } else if( options.at( "replay-blockchain" ).as<bool>()) {
          ilog( "Replay requested: deleting state database" );
          if( options.at( "truncate-at-block" ).as<uint32_t>() > 0 )
@@ -521,43 +524,47 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
       }
 
       if (options.count( "snapshot" )) {
-         my->snapshot_path = options.at( "snapshot" ).as<bfs::path>();
-         EOS_ASSERT( fc::exists(*my->snapshot_path), plugin_config_exception,
-                     "Cannot load snapshot, ${name} does not exist", ("name", my->snapshot_path->generic_string()) );
-
-         // recover genesis information from the snapshot
-         auto infile = std::ifstream(my->snapshot_path->generic_string(), (std::ios::in | std::ios::binary));
-         auto reader = std::make_shared<istream_snapshot_reader>(infile);
-         reader->validate();
-         reader->read_section<genesis_state>([this]( auto &section ){
-            section.read_row(my->chain_config->genesis);
-         });
-         infile.close();
-
-         EOS_ASSERT( options.count( "genesis-json" ) == 0 &&  options.count( "genesis-timestamp" ) == 0,
-                 plugin_config_exception,
-                 "--snapshot is incompatible with --genesis-json and --genesis-timestamp as the snapshot contains genesis information");
-
-         auto shared_mem_path = my->chain_config->state_dir / "shared_memory.bin";
-         EOS_ASSERT( !fc::exists(shared_mem_path),
-                 plugin_config_exception,
-                 "Snapshot can only be used to initialize an empty database." );
-
-         if( fc::is_regular_file( my->blocks_dir / "blocks.log" )) {
-            auto log_genesis = block_log::extract_genesis_state(my->blocks_dir);
-            EOS_ASSERT( log_genesis.compute_chain_id() == my->chain_config->genesis.compute_chain_id(),
-                    plugin_config_exception,
-                    "Genesis information in blocks.log does not match genesis information in the snapshot");
-         }
+         EOS_ASSERT( false, plugin_config_exception, "Snapshot options disabled");
+// TODO: removed by CyberWay
+//         my->snapshot_path = options.at( "snapshot" ).as<bfs::path>();
+//         EOS_ASSERT( fc::exists(*my->snapshot_path), plugin_config_exception,
+//                     "Cannot load snapshot, ${name} does not exist", ("name", my->snapshot_path->generic_string()) );
+//
+//         // recover genesis information from the snapshot
+//         auto infile = std::ifstream(my->snapshot_path->generic_string(), (std::ios::in | std::ios::binary));
+//         auto reader = std::make_shared<istream_snapshot_reader>(infile);
+//         reader->validate();
+//         reader->read_section<genesis_state>([this]( auto &section ){
+//            section.read_row(my->chain_config->genesis);
+//         });
+//         infile.close();
+//
+//         EOS_ASSERT( options.count( "genesis-json" ) == 0 &&  options.count( "genesis-timestamp" ) == 0,
+//                 plugin_config_exception,
+//                 "--snapshot is incompatible with --genesis-json and --genesis-timestamp as the snapshot contains genesis information");
+//
+//         auto shared_mem_path = my->chain_config->state_dir / "shared_memory.bin";
+//         EOS_ASSERT( !fc::exists(shared_mem_path),
+//                 plugin_config_exception,
+//                 "Snapshot can only be used to initialize an empty database." );
+//
+//         if( fc::is_regular_file( my->blocks_dir / "blocks.log" )) {
+//            auto log_genesis = block_log::extract_genesis_state(my->blocks_dir);
+//            EOS_ASSERT( log_genesis.compute_chain_id() == my->chain_config->genesis.compute_chain_id(),
+//                    plugin_config_exception,
+//                    "Genesis information in blocks.log does not match genesis information in the snapshot");
+//         }
 
       } else {
          bfs::path genesis_file;
          bool genesis_timestamp_specified = false;
-         fc::optional<genesis_state> existing_genesis;
+         //fc::optional<genesis_state> existing_genesis;
+         bool existing_genesis = false;
 
          if( fc::exists( my->blocks_dir / "blocks.log" ) ) {
-            my->chain_config->genesis = block_log::extract_genesis_state( my->blocks_dir );
-            existing_genesis = my->chain_config->genesis;
+            //my->chain_config->genesis = block_log::extract_genesis_state( my->blocks_dir );
+            //existing_genesis = my->chain_config->genesis;
+            existing_genesis = true;
          }
 
          if( options.count( "genesis-json" )) {
@@ -593,11 +600,12 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
             } else {
                wlog( "Starting up fresh blockchain with default genesis state." );
             }
-         } else {
-            EOS_ASSERT( my->chain_config->genesis == *existing_genesis, plugin_config_exception,
-                        "Genesis state provided via command line arguments does not match the existing genesis state in blocks.log. "
-                        "It is not necessary to provide genesis state arguments when a blocks.log file already exists."
-                      );
+// TODO: removed by CyberWay
+//         } else {
+//            EOS_ASSERT( genesis_file.empty() /*my->chain_config->genesis == *existing_genesis*/, plugin_config_exception,
+//                        //"Genesis state provided via command line arguments does not match the existing genesis state in blocks.log. "
+//                        "It is not necessary to provide genesis state arguments when a blocks.log file already exists."
+//                      );
          }
       }
 
@@ -684,14 +692,16 @@ void chain_plugin::plugin_startup()
 { try {
    try {
       auto shutdown = [](){ return app().is_quiting(); };
-      if (my->snapshot_path) {
-         auto infile = std::ifstream(my->snapshot_path->generic_string(), (std::ios::in | std::ios::binary));
-         auto reader = std::make_shared<istream_snapshot_reader>(infile);
-         my->chain->startup(shutdown, reader);
-         infile.close();
-      } else {
-         my->chain->startup(shutdown);
-      }
+// TODO: removed by CyberWay
+//      if (my->snapshot_path) {
+//         auto infile = std::ifstream(my->snapshot_path->generic_string(), (std::ios::in | std::ios::binary));
+//         auto reader = std::make_shared<istream_snapshot_reader>(infile);
+//         my->chain->startup(shutdown, reader);
+//         infile.close();
+//      } else {
+//         my->chain->startup(shutdown);
+//      }
+      my->chain->startup(shutdown);
    } catch (const database_guard_exception& e) {
       log_guard_exception(e);
       // make sure to properly close the db


### PR DESCRIPTION
Resolves #320
Integrate block_log implementation from Golos blockchain (base on memory mapped files).
To simplify implementation:
- disable snapshot's
- disable block_log version 2 (partial block log from snapshot)