### PR TITLE
Read genesis accounts on database initialization #315

### DIFF
--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -4,6 +4,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/genesis_state_root_key.cpp.in ${CMAKE
 file(GLOB HEADERS "include/eosio/chain/*.hpp"
                   "include/eosio/chain/webassembly/*.hpp"
                   "include/cyberway/chaindb/*.hpp"
+                  "include/cyberway/genesis/*.hpp"
                   "${CMAKE_CURRENT_BINARY_DIR}/include/eosio/chain/core_symbol.hpp" )
 
 include(ChaindbMongo)
@@ -50,8 +51,9 @@ add_library( eosio_chain
              chaindb/journal.cpp
              chaindb/abi_info.cpp
              chaindb/ram_calculator.cpp
-             
+
              domain_name.cpp
+             genesis/genesis_read.cpp
              ${CHAINDB_SRCS}
 
 #             get_config.cpp

--- a/libraries/chain/genesis/custom_unpack.hpp
+++ b/libraries/chain/genesis/custom_unpack.hpp
@@ -1,0 +1,15 @@
+#pragma once
+// declares types and unpackers before <fc/io/raw.hpp> included (to be visible by compiler)
+
+namespace cyberway { namespace golos {
+
+struct comment_object;
+
+}}
+
+
+namespace fc { namespace raw {
+
+template<typename S> void unpack(S&, cyberway::golos::comment_object&);
+
+}}

--- a/libraries/chain/genesis/genesis_container.hpp
+++ b/libraries/chain/genesis/genesis_container.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include <fc/reflect/reflect.hpp>
+
+namespace cyberway { namespace genesis {
+
+struct state_header {
+    char magic[12];
+    uint32_t version;
+
+    static constexpr auto expected_magic = "Golos\astatE";
+};
+
+struct table_header {
+    uint32_t type_id;
+    uint32_t records_count;
+};
+
+}} // cyberway::genesis
+
+// FC_REFLECT(cyberway::genesis::state_header, (magic)(version))    // won't work with char[12]
+FC_REFLECT(cyberway::genesis::table_header, (type_id)(records_count))

--- a/libraries/chain/genesis/genesis_read.cpp
+++ b/libraries/chain/genesis/genesis_read.cpp
@@ -1,0 +1,243 @@
+#include "custom_unpack.hpp"
+#include "golos_objects.hpp"
+#include "genesis_container.hpp"
+#include <cyberway/genesis/genesis_read.hpp>
+#include <eosio/chain/config.hpp>
+#include <eosio/chain/controller.hpp>
+#include <eosio/chain/authorization_manager.hpp>
+
+#include <fc/io/raw.hpp>
+#include <fc/variant.hpp>
+
+#include <boost/filesystem/path.hpp>
+#include <boost/filesystem/fstream.hpp>
+
+namespace fc { namespace raw {
+
+template<typename T> void unpack(T& s, cyberway::golos::comment_object& c) {
+    fc::raw::unpack(s, c.id);
+    fc::raw::unpack(s, c.parent_author);
+    fc::raw::unpack(s, c.parent_permlink);
+    fc::raw::unpack(s, c.author);
+    fc::raw::unpack(s, c.permlink);
+    fc::raw::unpack(s, c.mode);
+    if (c.mode != cyberway::golos::comment_mode::archived) {
+        fc::raw::unpack(s, c.active);
+    }
+}
+
+}} // fc::raw
+
+
+namespace cyberway { namespace genesis {
+
+using namespace eosio::chain;
+using namespace cyberway::chaindb;
+using std::string;
+using std::vector;
+
+constexpr auto posting_auth_name = "posting";
+constexpr auto golos_account_name = "golos";
+
+
+account_name generate_name(string n);
+string pubkey_string(const golos::public_key_type& k);
+
+
+struct genesis_read::genesis_read_impl final {
+    bfs::path _state_file;
+    controller& _control;
+    time_point _genesis_ts;
+    read_flags _flags;
+
+    vector<string> _accs_map;
+    vector<string> _plnk_map;
+
+    vector<golos::account_authority_object> _auths;
+
+    genesis_read_impl(const bfs::path& genesis_file, controller& ctrl, time_point genesis_ts)
+    :   _state_file(genesis_file),
+        _control(ctrl),
+        _genesis_ts(genesis_ts) {
+    }
+
+    void read_maps() {
+        auto map_file = _state_file;
+        map_file += ".map";
+        EOS_ASSERT(fc::is_regular_file(map_file), extract_genesis_state_exception,  // TODO: proper exception type
+            "Genesis state map file '${f}' does not exist.", ("f", map_file.generic_string()));
+        bfs::ifstream im(map_file);
+
+        auto read_map = [&](char type, vector<string>& map) {
+            std::cout << " reading map of type " << type << "... ";
+            char t;
+            uint32_t len;
+            im >> t;
+            im.read((char*)&len, sizeof(len));
+            EOS_ASSERT(im, extract_genesis_state_exception, "Unknown format of Genesis state map file.");
+            EOS_ASSERT(t == type, extract_genesis_state_exception, "Unexpected map type in Genesis state map file.");
+            std::cout << "count=" << len << "... ";
+            while (im && len) {
+                string a;
+                std::getline(im, a, '\0' );
+                map.emplace_back(a);
+                len--;
+            }
+            EOS_ASSERT(im, extract_genesis_state_exception, "Failed to read map from Genesis state map file.");
+            std::cout << "done, " << map.size() << " item(s) read" << std::endl;
+        };
+        read_map('A', _accs_map);
+        read_map('P', _plnk_map);
+        // TODO: checksum
+        im.close();
+    }
+
+    void read_state() {
+        // TODO: checksum
+        EOS_ASSERT(fc::is_regular_file(_state_file), extract_genesis_state_exception,
+            "Genesis state file '${f}' does not exist.", ("f", _state_file.generic_string()));
+        std::cout << "Reading state from " << _state_file << "..." << std::endl;
+        read_maps();
+
+        bfs::ifstream in(_state_file);
+        state_header h{"", 0};
+        in.read((char*)&h, sizeof(h));
+        EOS_ASSERT(string(h.magic) == state_header::expected_magic && h.version == 1, extract_genesis_state_exception,
+            "Unknown format of the Genesis state file.");
+        while (in) {
+            table_header t;
+            fc::raw::unpack(in, t);
+            if (!in)
+                break;
+            auto type = t.type_id;
+            std::cout << "Reading " << t.records_count << " record(s) from table with id=" << type << std::endl;
+            objects o;
+            o.set_which(type);
+            auto v = fc::raw::unpack_static_variant<decltype(in)>(in);
+            int i = 0;
+            for (; in && i < t.records_count; i++) {
+                o.visit(v);
+                if (type == account_authority_object_id) {
+                    _auths.emplace_back(o.get<golos::account_authority_object>());
+                }
+            }
+            std::cout << "  done, " << i << " record(s) read." << std::endl;
+            if ((_flags & read_flags::accounts) == read_flags::accounts && _auths.size() > 0)
+                break;              // we do not need other tables
+        }
+        std::cout << "Done reading Genesis state." << std::endl;
+        in.close();
+    }
+
+    void create_accounts() {
+        std::cout << "Creating accounts, authorities and usernames in Golos domain..." << std::endl;
+        auto& db = const_cast<chaindb_controller&>(_control.chaindb());
+        auto& auth_mgr = _control.get_mutable_authorization_manager();
+        std::unordered_map<string,account_name> names;
+        names.reserve(_auths.size());
+
+        // first fill names, we need them to check is authority account exists
+        for (const auto a: _auths) {
+            const auto n = a.account.value(_accs_map);
+            const auto name =
+                n.size() == 0 ? account_name() : generate_name(n);
+                // n == "null" ? account_name(config::null_account_name) : generate_name(n);
+                //txt_name == "temp"
+            names[n] = name;
+        }
+
+        // fill auths
+        for (const auto a: _auths) {
+            const auto n = a.account.value(_accs_map);
+            const auto& name = names[n];
+            db.emplace<account_object>([&](auto& a) {
+                a.name = name;
+                a.creation_date = _genesis_ts;
+            });
+            db.emplace<account_sequence_object>([&](auto & a) {
+                a.name = name;
+            });
+            if (n == golos_account_name) {
+                db.emplace<domain_object>([&](auto& a) {
+                    a.owner = name;
+                    a.linked_to = name;
+                    a.creation_date = _genesis_ts;
+                    a.name = n;
+                });
+            }
+            auto add_permission = [&](permission_name perm, const golos::shared_authority& a, auto id) {
+                uint32_t threshold = a.weight_threshold;
+                vector<key_weight> keys;
+                for (const auto& k: a.key_auths) {
+                    // can't construct public key directly, constructor is private. transform to string first:
+                    const auto key = string(fc::crypto::config::public_key_legacy_prefix) + pubkey_string(k.first);
+                    keys.emplace_back(key_weight{public_key_type(key), k.second});
+                }
+                vector<permission_level_weight> accounts;
+                for (const auto& p: a.account_auths) {
+                    auto auth_acc = p.first.value(_accs_map);
+                    if (names.count(auth_acc)) {
+                        accounts.emplace_back(permission_level_weight{{names[auth_acc], perm}, p.second});
+                    } else {
+                        std::cout << "Note: account " << n << " tried to add unexisting account " << auth_acc
+                            << " to it's " << perm << " authority. Skipped." << std::endl;
+                    }
+                }
+                return auth_mgr.create_permission({}, name, perm, id, authority{threshold, keys, accounts}, _genesis_ts);
+            };
+            const auto& owner_perm = add_permission(config::owner_name, a.owner, 0);
+            const auto& active_perm = add_permission(config::active_name, a.active, owner_perm.id);
+            const auto& posting_perm = add_permission(posting_auth_name, a.posting, active_perm.id);
+            // TODO: do we need memo key ?
+        }
+
+        // add usernames
+        const auto app = names[golos_account_name];
+        for (const auto& auth : _auths) {                // loop through auths to preserve names order
+            const auto& n = auth.account.value(_accs_map);
+            db.emplace<username_object>([&](auto& u) {
+                u.owner = names[n]; //generate_name(n);
+                u.scope = app;
+                u.name = n;
+            });
+        }
+        std::cout << "Done." << std::endl;
+    }
+
+};
+
+genesis_read::genesis_read(const bfs::path& genesis_file, controller& ctrl, time_point genesis_ts)
+: _impl(new genesis_read_impl(genesis_file, ctrl, genesis_ts)) {
+}
+genesis_read::~genesis_read() {
+}
+
+void genesis_read::read(const read_flags flags) {
+    _impl->_flags = flags;
+    _impl->read_state();
+    if (flags & accounts) {
+        _impl->create_accounts();
+    }
+    // TODO: balances, witnesses
+}
+
+
+
+account_name generate_name(string n) {
+    // TODO: replace with better function
+    // TODO: remove dots from result (+append trailing to length of 12 characters)
+    uint64_t h = std::hash<std::string>()(n);
+    return account_name(h & 0xFFFFFFFFFFFFFFF0);
+}
+
+string pubkey_string(const golos::public_key_type& k) {
+    using checksummer = fc::crypto::checksummed_data<golos::public_key_type>;
+    checksummer wrapper;
+    wrapper.data = k;
+    wrapper.check = checksummer::calculate_checksum(wrapper.data);
+    auto packed = raw::pack(wrapper);
+    return fc::to_base58(packed.data(), packed.size());
+}
+
+
+}} // cyberway

--- a/libraries/chain/genesis/golos_objects.hpp
+++ b/libraries/chain/genesis/golos_objects.hpp
@@ -1,0 +1,478 @@
+#pragma once
+#include "golos_types.hpp"
+
+namespace cyberway { namespace golos {
+
+
+struct dynamic_global_property_object {
+    id_type id;
+    uint32_t head_block_number;
+    block_id_type head_block_id;
+    time_point_sec time;
+    account_name_type current_witness;
+    uint64_t total_pow;
+    uint32_t num_pow_witnesses;
+    asset virtual_supply;
+    asset current_supply;
+    asset confidential_supply;
+    asset current_sbd_supply;
+    asset confidential_sbd_supply;
+    asset total_vesting_fund_steem;
+    asset total_vesting_shares;
+    asset total_reward_fund_steem;
+    uint128_t total_reward_shares2;
+    uint16_t sbd_interest_rate;
+    uint16_t sbd_print_rate;
+    bool is_forced_min_price;
+    uint32_t average_block_size;
+    uint32_t maximum_block_size;
+    uint64_t current_aslot;
+    uint128_t recent_slots_filled;
+    uint8_t participation_count;
+    uint32_t last_irreversible_block_num;
+    uint64_t max_virtual_bandwidth;
+    uint64_t current_reserve_ratio;
+    uint32_t vote_regeneration_per_day;
+    uint16_t custom_ops_bandwidth_multiplier;
+};
+
+
+// account
+struct account_object {
+    id_type id;
+    account_name_type name;
+    public_key_type memo_key;
+    account_name_type proxy;
+    time_point_sec last_account_update;
+    time_point_sec created;
+    bool mined;
+    bool owner_challenged;
+    bool active_challenged;
+    time_point_sec last_owner_proved;
+    time_point_sec last_active_proved;
+    account_name_type recovery_account;
+    account_name_type reset_account;
+    time_point_sec last_account_recovery;
+    uint32_t comment_count;
+    uint32_t lifetime_vote_count;
+    uint32_t post_count;
+    bool can_vote;
+    uint16_t voting_power;
+    uint16_t posts_capacity;
+    uint16_t comments_capacity;
+    uint16_t voting_capacity;
+    time_point_sec last_vote_time;
+    asset balance;
+    asset savings_balance;
+    asset sbd_balance;
+    uint128_t sbd_seconds;
+    time_point_sec sbd_seconds_last_update;
+    time_point_sec sbd_last_interest_payment;
+    asset savings_sbd_balance;
+    uint128_t savings_sbd_seconds;
+    time_point_sec savings_sbd_seconds_last_update;
+    time_point_sec savings_sbd_last_interest_payment;
+    uint8_t savings_withdraw_requests;
+    share_type benefaction_rewards;
+    share_type curation_rewards;
+    share_type delegation_rewards;
+    share_type posting_rewards;
+    asset vesting_shares;
+    asset delegated_vesting_shares;
+    asset received_vesting_shares;
+    asset vesting_withdraw_rate;
+    time_point_sec next_vesting_withdrawal;
+    share_type withdrawn;
+    share_type to_withdraw;
+    uint16_t withdraw_routes;
+    fc::array<share_type, 4> proxied_vsf_votes;
+    uint16_t witnesses_voted_for;
+    time_point_sec last_post;
+    account_name_type referrer_account;
+    uint16_t referrer_interest_rate;
+    time_point_sec referral_end_date;
+    asset referral_break_fee;
+};
+struct account_authority_object {
+    id_type id;
+    account_name_type account;
+    shared_authority owner;
+    shared_authority active;
+    shared_authority posting;
+    time_point_sec last_owner_update;
+};
+struct account_bandwidth_object {
+    id_type id;
+    account_name_type account;
+    bandwidth_type type;
+    share_type average_bandwidth;
+    share_type lifetime_bandwidth;
+    time_point_sec last_bandwidth_update;
+};
+struct account_metadata_object {
+    id_type id;
+    account_name_type account;
+    shared_string json_metadata;
+};
+
+struct vesting_delegation_object {
+    id_type id;
+    account_name_type delegator;
+    account_name_type delegatee;
+    asset vesting_shares;
+    uint16_t interest_rate;
+    delegator_payout_strategy payout_strategy;
+    time_point_sec min_delegation_time;
+};
+struct vesting_delegation_expiration_object {
+    id_type id;
+    account_name_type delegator;
+    asset vesting_shares;
+    time_point_sec expiration;
+};
+
+struct owner_authority_history_object {
+    id_type id;
+    account_name_type account;
+    shared_authority previous_owner_authority;
+    time_point_sec last_valid_time;
+};
+
+struct account_recovery_request_object {
+    id_type id;
+    account_name_type account_to_recover;
+    shared_authority new_owner_authority;
+    time_point_sec expires;
+};
+struct change_recovery_account_request_object {
+    id_type id;
+    account_name_type account_to_recover;
+    account_name_type recovery_account;
+    time_point_sec effective_on;
+};
+
+
+// witness
+struct witness_object {
+    id_type id;
+    account_name_type owner;
+    time_point_sec created;
+    shared_string url;
+    uint32_t total_missed;
+    uint64_t last_aslot;
+    uint64_t last_confirmed_block_num;
+    uint64_t pow_worker;
+    public_key_type signing_key;
+    chain_properties props;
+    price sbd_exchange_rate;
+    time_point_sec last_sbd_exchange_update;
+    share_type votes;
+    witness_schedule_type schedule;
+    uint128_t virtual_last_update;
+    uint128_t virtual_position;
+    uint128_t virtual_scheduled_time;
+    digest_type last_work;
+    version running_version;
+    hardfork_version hardfork_version_vote;
+    time_point_sec hardfork_time_vote;
+};
+struct witness_vote_object {
+    id_type id;
+    witness_id_type witness;
+    account_id_type account;
+};
+struct witness_schedule_object {
+    id_type id;
+    uint128_t current_virtual_time;
+    uint32_t next_shuffle_block_num;
+    // fc::array<account_name_type, 21/*STEEMIT_MAX_WITNESSES*/> current_shuffled_witnesses;
+    fc::array<uint128_t, 21/*STEEMIT_MAX_WITNESSES*/> current_shuffled_witnesses;
+    uint8_t num_scheduled_witnesses;
+    uint8_t top19_weight;
+    uint8_t timeshare_weight;
+    uint8_t miner_weight;
+    uint32_t witness_pay_normalization_factor;
+    chain_properties median_props;
+    version majority_version;
+};
+
+
+//block_summary
+struct block_summary_object {
+    id_type id;
+    block_id_type block_id;
+};
+
+
+// comment
+// this part of comment object is absent in archived comments
+struct active_comment_data {
+    time_point_sec created;
+    time_point_sec last_payout;
+    uint16_t depth;
+    uint32_t children;
+    uint128_t children_rshares2;
+    share_type net_rshares;
+    share_type abs_rshares;
+    share_type vote_rshares;
+    share_type children_abs_rshares;
+    time_point_sec cashout_time;
+    time_point_sec max_cashout_time;
+    uint16_t reward_weight;
+    int32_t net_votes;
+    uint32_t total_votes;
+    id_type root_comment;
+    curation_curve curation_reward_curve;
+    auction_window_reward_destination_type auction_window_reward_destination;
+    uint16_t auction_window_size;
+    asset max_accepted_payout;
+    uint16_t percent_steem_dollars;
+    bool allow_replies;
+    bool allow_votes;
+    bool allow_curation_rewards;
+    uint16_t curation_rewards_percent;
+    std::vector<beneficiary_route_type> beneficiaries;
+};
+struct comment_object {
+    id_type id;
+    account_name_type parent_author;
+    shared_permlink parent_permlink;
+    account_name_type author;
+    shared_permlink permlink;
+    comment_mode mode;
+    active_comment_data active;
+};
+struct comment_vote_object {
+    id_type id;
+    account_id_type voter;
+    comment_id_type comment;
+    int64_t orig_rshares;
+    int64_t rshares;
+    int16_t vote_percent;
+    uint16_t auction_time;
+    time_point_sec last_update;
+    int8_t num_changes;
+    std::vector<delegator_vote_interest_rate> delegator_vote_interest_rates;
+};
+
+
+// other
+struct limit_order_object {
+    id_type id;
+    time_point_sec created;
+    time_point_sec expiration;
+    account_name_type seller;
+    uint32_t orderid;
+    share_type for_sale;
+    price sell_price;
+};
+struct convert_request_object {
+    id_type id;
+    account_name_type owner;
+    uint32_t requestid;
+    asset amount;
+    time_point_sec conversion_date;
+};
+struct liquidity_reward_balance_object {
+    id_type id;
+    account_id_type owner;
+    int64_t steem_volume;
+    int64_t sbd_volume;
+    uint128_t weight;
+    time_point_sec last_update;
+};
+struct withdraw_vesting_route_object {
+    id_type id;
+    account_id_type from_account;
+    account_id_type to_account;
+    uint16_t percent;
+    bool auto_vest;
+};
+struct escrow_object {
+    id_type id;
+    uint32_t escrow_id;
+    account_name_type from;
+    account_name_type to;
+    account_name_type agent;
+    time_point_sec ratification_deadline;
+    time_point_sec escrow_expiration;
+    asset sbd_balance;
+    asset steem_balance;
+    asset pending_fee;
+    bool to_approved;
+    bool agent_approved;
+    bool disputed;
+};
+struct savings_withdraw_object {
+    id_type id;
+    account_name_type from;
+    account_name_type to;
+    shared_string memo;
+    uint32_t request_id;
+    asset amount;
+    time_point_sec complete;
+};
+struct decline_voting_rights_request_object {
+    id_type id;
+    account_id_type account;
+    time_point_sec effective_date;
+};
+
+
+// empty; unsupported, must not exist in serialized state; TODO: remove
+struct transaction_object {};
+struct feed_history_object {};
+struct hardfork_property_object {};
+struct block_stats_object {};
+struct proposal_object {};
+struct required_approval_object {};
+
+} // golos
+
+
+enum object_type {
+    dynamic_global_property_object_id,
+    account_object_id,
+    account_authority_object_id,
+    account_bandwidth_object_id,
+    witness_object_id,
+    transaction_object_id,
+    block_summary_object_id,
+    witness_schedule_object_id,
+    comment_object_id,
+    comment_vote_object_id,
+    witness_vote_object_id,
+    limit_order_object_id,
+    feed_history_object_id,
+    convert_request_object_id,
+    liquidity_reward_balance_object_id,
+    hardfork_property_object_id,
+    withdraw_vesting_route_object_id,
+    owner_authority_history_object_id,
+    account_recovery_request_object_id,
+    change_recovery_account_request_object_id,
+    escrow_object_id,
+    savings_withdraw_object_id,
+    decline_voting_rights_request_object_id,
+    block_stats_object_id,
+    vesting_delegation_object_id,
+    vesting_delegation_expiration_object_id,
+    account_metadata_object_id,
+    proposal_object_id,
+    required_approval_object_id
+};
+
+// variant must be ordered the same way as enum (including not required objects):
+using objects = fc::static_variant<
+    golos::dynamic_global_property_object,
+    golos::account_object,
+    golos::account_authority_object,
+    golos::account_bandwidth_object,
+    golos::witness_object,
+    golos::transaction_object,
+    golos::block_summary_object,
+    golos::witness_schedule_object,
+    golos::comment_object,
+    golos::comment_vote_object,
+    golos::witness_vote_object,
+    golos::limit_order_object,
+    golos::feed_history_object,
+    golos::convert_request_object,
+    golos::liquidity_reward_balance_object,
+    golos::hardfork_property_object,
+    golos::withdraw_vesting_route_object,
+    golos::owner_authority_history_object,
+    golos::account_recovery_request_object,
+    golos::change_recovery_account_request_object,
+    golos::escrow_object,
+    golos::savings_withdraw_object,
+    golos::decline_voting_rights_request_object,
+    golos::block_stats_object,
+    golos::vesting_delegation_object,
+    golos::vesting_delegation_expiration_object,
+    golos::account_metadata_object,
+    golos::proposal_object,
+    golos::required_approval_object
+>;
+
+} // cyberway
+
+
+FC_REFLECT(cyberway::golos::dynamic_global_property_object,
+    (id)(head_block_number)(head_block_id)(time)(current_witness)(total_pow)(num_pow_witnesses)
+    (virtual_supply)(current_supply)(confidential_supply)(current_sbd_supply)(confidential_sbd_supply)
+    (total_vesting_fund_steem)(total_vesting_shares)(total_reward_fund_steem)(total_reward_shares2)
+    (sbd_interest_rate)(sbd_print_rate)(average_block_size)(maximum_block_size)
+    (current_aslot)(recent_slots_filled)(participation_count)(last_irreversible_block_num)(max_virtual_bandwidth)
+    (current_reserve_ratio)(vote_regeneration_per_day)(custom_ops_bandwidth_multiplier)(is_forced_min_price)
+)
+
+FC_REFLECT(cyberway::golos::account_object,
+    (id)(name)(memo_key)(proxy)(last_account_update)(created)(mined)
+    (owner_challenged)(active_challenged)(last_owner_proved)(last_active_proved)
+    (recovery_account)(last_account_recovery)(reset_account)
+    (comment_count)(lifetime_vote_count)(post_count)(can_vote)(voting_power)(last_vote_time)
+    (balance)(savings_balance)(sbd_balance)(sbd_seconds)(sbd_seconds_last_update)(sbd_last_interest_payment)
+    (savings_sbd_balance)(savings_sbd_seconds)(savings_sbd_seconds_last_update)
+    (savings_sbd_last_interest_payment)(savings_withdraw_requests)
+    (vesting_shares)(delegated_vesting_shares)(received_vesting_shares)
+    (vesting_withdraw_rate)(next_vesting_withdrawal)(withdrawn)(to_withdraw)(withdraw_routes)
+    (benefaction_rewards)(curation_rewards)(delegation_rewards)(posting_rewards)
+    (proxied_vsf_votes)(witnesses_voted_for)
+    (last_post)
+    (referrer_account)(referrer_interest_rate)(referral_end_date)(referral_break_fee)
+)
+FC_REFLECT(cyberway::golos::account_authority_object, (id)(account)(owner)(active)(posting)(last_owner_update))
+FC_REFLECT(cyberway::golos::account_bandwidth_object,
+    (id)(account)(type)(average_bandwidth)(lifetime_bandwidth)(last_bandwidth_update))
+FC_REFLECT(cyberway::golos::account_metadata_object, (id)(account)(json_metadata))
+FC_REFLECT(cyberway::golos::vesting_delegation_object,
+    (id)(delegator)(delegatee)(vesting_shares)(interest_rate)(min_delegation_time))
+FC_REFLECT(cyberway::golos::vesting_delegation_expiration_object, (id)(delegator)(vesting_shares)(expiration))
+FC_REFLECT(cyberway::golos::owner_authority_history_object, (id)(account)(previous_owner_authority)(last_valid_time))
+FC_REFLECT(cyberway::golos::account_recovery_request_object, (id)(account_to_recover)(new_owner_authority)(expires))
+FC_REFLECT(cyberway::golos::change_recovery_account_request_object,
+    (id)(account_to_recover)(recovery_account)(effective_on))
+
+FC_REFLECT(cyberway::golos::witness_object,
+    (id)(owner)(created)(url)(votes)(schedule)(virtual_last_update)(virtual_position)(virtual_scheduled_time)(total_missed)
+    (last_aslot)(last_confirmed_block_num)(pow_worker)(signing_key)(props)(sbd_exchange_rate)(last_sbd_exchange_update)
+    (last_work)(running_version)(hardfork_version_vote)(hardfork_time_vote))
+FC_REFLECT(cyberway::golos::witness_schedule_object,
+    (id)(current_virtual_time)(next_shuffle_block_num)(current_shuffled_witnesses)(num_scheduled_witnesses)
+    (top19_weight)(timeshare_weight)(miner_weight)(witness_pay_normalization_factor)
+    (median_props)(majority_version))
+FC_REFLECT(cyberway::golos::witness_vote_object, (id)(witness)(account))
+
+FC_REFLECT(cyberway::golos::block_summary_object, (id)(block_id))
+
+// comment must be unpacked manually
+// FC_REFLECT(cyberway::golos::comment_object, (id)(parent_author)(parent_permlink)(author)(permlink)(mode))
+FC_REFLECT(cyberway::golos::active_comment_data,
+    (created)(last_payout)(depth)(children)
+    (children_rshares2)(net_rshares)(abs_rshares)(vote_rshares)(children_abs_rshares)(cashout_time)(max_cashout_time)
+    (reward_weight)(net_votes)(total_votes)(root_comment)
+    (curation_reward_curve)(auction_window_reward_destination)(auction_window_size)(max_accepted_payout)
+    (percent_steem_dollars)(allow_replies)(allow_votes)(allow_curation_rewards)(curation_rewards_percent)
+    (beneficiaries))
+FC_REFLECT(cyberway::golos::comment_vote_object,
+    (id)(voter)(comment)(orig_rshares)(rshares)(vote_percent)(auction_time)(last_update)(num_changes)
+    (delegator_vote_interest_rates))
+
+
+FC_REFLECT(cyberway::golos::limit_order_object, (id)(created)(expiration)(seller)(orderid)(for_sale)(sell_price))
+FC_REFLECT(cyberway::golos::convert_request_object, (id)(owner)(requestid)(amount)(conversion_date))
+FC_REFLECT(cyberway::golos::liquidity_reward_balance_object, (id)(owner)(steem_volume)(sbd_volume)(weight)(last_update))
+FC_REFLECT(cyberway::golos::withdraw_vesting_route_object, (id)(from_account)(to_account)(percent)(auto_vest))
+FC_REFLECT(cyberway::golos::escrow_object,
+    (id)(escrow_id)(from)(to)(agent)(ratification_deadline)(escrow_expiration)
+    (sbd_balance)(steem_balance)(pending_fee)(to_approved)(agent_approved)(disputed))
+FC_REFLECT(cyberway::golos::savings_withdraw_object, (id)(from)(to)(memo)(request_id)(amount)(complete))
+FC_REFLECT(cyberway::golos::decline_voting_rights_request_object, (id)(account)(effective_date))
+
+FC_REFLECT(cyberway::golos::transaction_object,       BOOST_PP_SEQ_NIL)
+FC_REFLECT(cyberway::golos::feed_history_object,      BOOST_PP_SEQ_NIL)
+FC_REFLECT(cyberway::golos::hardfork_property_object, BOOST_PP_SEQ_NIL)
+FC_REFLECT(cyberway::golos::block_stats_object,       BOOST_PP_SEQ_NIL)
+FC_REFLECT(cyberway::golos::proposal_object,          BOOST_PP_SEQ_NIL)
+FC_REFLECT(cyberway::golos::required_approval_object, BOOST_PP_SEQ_NIL)

--- a/libraries/chain/genesis/golos_types.hpp
+++ b/libraries/chain/genesis/golos_types.hpp
@@ -1,0 +1,132 @@
+#pragma once
+#include <eosio/chain/asset.hpp>
+#include <fc/crypto/sha256.hpp>
+#include <fc/crypto/ripemd160.hpp>
+#include <fc/crypto/public_key.hpp>
+
+namespace cyberway { namespace golos {
+
+
+struct gls_shared_str {
+    std::string value;
+};
+struct gls_mapped_str {
+    fc::unsigned_int id;
+
+    std::string value(const std::vector<std::string>& lookup) const {
+        return lookup.at(id.value);
+    };
+};
+
+using fc::uint128_t;
+using fc::time_point_sec;
+using eosio::chain::asset;
+using eosio::chain::share_type;
+
+using account_name_type = gls_mapped_str;//gls_acc_name;
+using shared_permlink   = gls_mapped_str;
+using shared_string     = gls_shared_str;
+using id_type       = int64_t;
+using digest_type   = fc::sha256;
+using block_id_type = fc::ripemd160;
+using weight_type   = uint16_t;
+
+using public_key_type = fc::ecc::public_key_data;   // eosio public key is static variant: ecc/r1
+
+using witness_id_type = id_type;
+using account_id_type = id_type;
+using comment_id_type = id_type;
+
+struct shared_authority {
+    uint32_t weight_threshold;
+    std::vector<std::pair<account_name_type, weight_type>> account_auths;   // was map, but it requires to have operator< for accs
+    std::map<public_key_type, weight_type> key_auths;
+};
+
+
+struct chain_properties_17 {
+    asset account_creation_fee;
+    uint32_t maximum_block_size;
+    uint16_t sbd_interest_rate;
+};
+struct chain_properties_18: public chain_properties_17 {
+    asset create_account_min_golos_fee;
+    asset create_account_min_delegation;
+    uint32_t create_account_delegation_time;
+    asset min_delegation;
+};
+enum class curation_curve: uint8_t {bounded, linear, square_root, _size, detect = 100};
+struct chain_properties_19: public chain_properties_18 {
+    uint16_t max_referral_interest_rate;
+    uint32_t max_referral_term_sec;
+    asset min_referral_break_fee;
+    asset max_referral_break_fee;
+    uint16_t posts_window;
+    uint16_t posts_per_window;
+    uint16_t comments_window;
+    uint16_t comments_per_window;
+    uint16_t votes_window;
+    uint16_t votes_per_window;
+    uint16_t auction_window_size;
+    uint16_t max_delegated_vesting_interest_rate;
+    uint16_t custom_ops_bandwidth_multiplier;
+    uint16_t min_curation_percent;
+    uint16_t max_curation_percent;
+    curation_curve curation_reward_curve;
+    bool allow_return_auction_reward_to_fund;
+    bool allow_distribute_auction_reward;
+};
+using chain_properties = chain_properties_19;
+
+struct price {
+    asset base;
+    asset quote;
+};
+
+using version = uint32_t;
+using hardfork_version = version;
+
+struct beneficiary_route_type {
+    account_name_type account;
+    uint16_t weight;
+};
+
+enum bandwidth_type {post, forum, market, custom_json};
+enum delegator_payout_strategy {to_delegator, to_delegated_vesting, _size};
+enum witness_schedule_type {top19, timeshare, miner, none};
+enum comment_mode {not_set, first_payout, second_payout, archived};
+enum auction_window_reward_destination_type {to_reward_fund, to_curators, to_author};
+
+struct delegator_vote_interest_rate {
+    account_name_type account;
+    uint16_t interest_rate;
+    delegator_payout_strategy payout_strategy;
+};
+
+
+}} // cyberway::golos
+
+
+FC_REFLECT(cyberway::golos::gls_mapped_str, (id))
+FC_REFLECT(cyberway::golos::gls_shared_str, (value))
+
+FC_REFLECT(cyberway::golos::shared_authority, (weight_threshold)(account_auths)(key_auths))
+FC_REFLECT(cyberway::golos::chain_properties_17, (account_creation_fee)(maximum_block_size)(sbd_interest_rate))
+FC_REFLECT_DERIVED(cyberway::golos::chain_properties_18, (cyberway::golos::chain_properties_17),
+    (create_account_min_golos_fee)(create_account_min_delegation)(create_account_delegation_time)(min_delegation))
+FC_REFLECT_DERIVED(cyberway::golos::chain_properties_19, (cyberway::golos::chain_properties_18),
+    (max_referral_interest_rate)(max_referral_term_sec)(min_referral_break_fee)(max_referral_break_fee)
+    (posts_window)(posts_per_window)(comments_window)(comments_per_window)(votes_window)(votes_per_window)
+    (auction_window_size)(max_delegated_vesting_interest_rate)(custom_ops_bandwidth_multiplier)
+    (min_curation_percent)(max_curation_percent)(curation_reward_curve)
+    (allow_distribute_auction_reward)(allow_return_auction_reward_to_fund))
+FC_REFLECT(cyberway::golos::price, (base)(quote))
+FC_REFLECT(cyberway::golos::beneficiary_route_type, (account)(weight))
+FC_REFLECT(cyberway::golos::delegator_vote_interest_rate, (account)(interest_rate)(payout_strategy))
+
+FC_REFLECT_ENUM(cyberway::golos::comment_mode,    (not_set)(first_payout)(second_payout)(archived))
+FC_REFLECT_ENUM(cyberway::golos::bandwidth_type,  (post)(forum)(market)(custom_json))
+FC_REFLECT_ENUM(cyberway::golos::curation_curve,  (detect)(bounded)(linear)(square_root)(_size))
+FC_REFLECT_ENUM(cyberway::golos::witness_schedule_type, (top19)(timeshare)(miner)(none))
+FC_REFLECT_ENUM(cyberway::golos::delegator_payout_strategy, (to_delegator)(to_delegated_vesting))
+FC_REFLECT_ENUM(cyberway::golos::auction_window_reward_destination_type, (to_reward_fund)(to_curators)(to_author))

--- a/libraries/chain/include/cyberway/genesis/genesis_read.hpp
+++ b/libraries/chain/include/cyberway/genesis/genesis_read.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <eosio/chain/controller.hpp>
+
+#include <boost/filesystem.hpp>
+
+namespace cyberway { namespace genesis {
+
+using namespace eosio::chain;
+namespace bfs = boost::filesystem;
+
+enum read_flags {
+    accounts = 1 << 0,
+    balances = 1 << 1,
+    witnesses = 2 << 2
+};
+
+class genesis_read final {
+public:
+    genesis_read() = delete;
+    genesis_read(const genesis_read&) = delete;
+
+    genesis_read(const bfs::path& genesis_file, controller& ctrl, time_point genesis_ts);
+    ~genesis_read();
+
+    void read(const read_flags flags);
+
+private:
+    struct genesis_read_impl;
+    std::unique_ptr<genesis_read_impl> _impl;
+};
+
+
+}} // cyberway::genesis

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -85,6 +85,9 @@ namespace eosio { namespace chain {
 
             chaindb_type             chaindb_address_type = chaindb_type::MongoDB;
             string                   chaindb_address;
+
+            path                     genesis_file;                // Golos state
+            bool                     read_genesis = false;
          };
 
          enum class block_status {
@@ -302,4 +305,5 @@ FC_REFLECT( eosio::chain::controller::config,
             (genesis)
             (wasm_runtime)
             (trusted_producers)
+            (genesis_file)(read_genesis)
           )

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -241,6 +241,8 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "Type of chaindb connection")
          ("chaindb_address", bpo::value<string>()->default_value("mongodb://127.0.0.1:27017"),
           "Connection address to chaindb")
+         ("genesis-file", bpo::value<bfs::path>(),
+             "The location of the Genesis state file (absolute path or relative to the current directory)")
          ("trusted-producer", bpo::value<vector<string>>()->composing(), "Indicate a producer whose blocks headers signed by it will be fully validated, but transactions in those validated blocks will be trusted.")
          ;
 
@@ -368,6 +370,12 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
 
       if (options.count("chaindb_address"))
          my->chain_config->chaindb_address = options.at("chaindb_address").as<string>();
+
+      my->chain_config->read_genesis = options.count("genesis-file");
+      if (my->chain_config->read_genesis) {
+          auto path = options.at("genesis-file").as<bfs::path>();
+          my->chain_config->genesis_file = path.is_relative() ? bfs::current_path() / path : path;
+      }
 
       if( options.count( "wasm-runtime" ))
          my->wasm_runtime = options.at( "wasm-runtime" ).as<vm_type>();


### PR DESCRIPTION
`--genesis-file` command line option added. It sets path of a genesis file (generated with GolosChain/golos#1154), which will be used on database initializaion to create accounts, authorities, Golos domain and usernames.

Note: some `.hpp` files are not in `include` dir, because they only needed for genesis and can interfere with other code.
