### PR TITLE
Optimize data inserts while read genesis #334

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -537,7 +537,7 @@ struct controller_impl {
     void read_genesis() {
         if (conf.read_genesis) {
             cyberway::genesis::genesis_read reader(conf.genesis_file, self, conf.genesis.initial_timestamp);
-            reader.read(cyberway::genesis::read_flags::accounts);
+            reader.read();
         }
     }
 

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -720,4 +720,39 @@ abi_def domain_contract_abi(abi_def abi) {
     return abi;
 }
 
+// this abi contains only tables needed for genesis
+abi_def token_contract_abi(abi_def abi) {
+    if (abi.version.size() == 0) {
+        abi.version = "cyberway::abi/1.0";
+    }
+    fc::move_append(abi.types, common_type_defs());
+
+    abi.structs.emplace_back(struct_def {"account", "", {
+        {"balance", "asset"}}
+    });
+    abi.structs.emplace_back(struct_def {"currency_stats", "", {
+        {"supply", "asset"},
+        {"max_supply", "asset"},
+        {"issuer", "name"}}
+    });
+
+    abi.tables.emplace_back(table_def{"accounts", "account", {
+        {"primary", true, {{"balance.sym", "asc"}}}
+    }});
+    abi.tables.emplace_back(table_def{"stat", "currency_stats", {
+        {"primary", true, {{"supply.sym", "asc"}}}
+    }});
+
+    return abi;
+}
+
+abi_def golos_vesting_contract_abi(abi_def abi) {
+    if (abi.version.size() == 0) {
+        abi.version = "cyberway::abi/1.0";
+    }
+    fc::move_append(abi.types, common_type_defs());
+
+    return abi;
+}
+
 } } /// eosio::chain

--- a/libraries/chain/include/cyberway/genesis/genesis_read.hpp
+++ b/libraries/chain/include/cyberway/genesis/genesis_read.hpp
@@ -8,12 +8,6 @@ namespace cyberway { namespace genesis {
 using namespace eosio::chain;
 namespace bfs = boost::filesystem;
 
-enum read_flags {
-    accounts = 1 << 0,
-    balances = 1 << 1,
-    witnesses = 2 << 2
-};
-
 class genesis_read final {
 public:
     genesis_read() = delete;
@@ -22,7 +16,7 @@ public:
     genesis_read(const bfs::path& genesis_file, controller& ctrl, time_point genesis_ts);
     ~genesis_read();
 
-    void read(const read_flags flags);
+    void read();
 
 private:
     struct genesis_read_impl;

--- a/libraries/chain/include/eosio/chain/abi_def.hpp
+++ b/libraries/chain/include/eosio/chain/abi_def.hpp
@@ -154,6 +154,8 @@ struct abi_def {
 
 abi_def eosio_contract_abi(abi_def abi = abi_def());
 abi_def domain_contract_abi(abi_def abi = abi_def());
+abi_def token_contract_abi(abi_def abi = abi_def());
+abi_def golos_vesting_contract_abi(abi_def abi = abi_def());
 vector<type_def> common_type_defs();
 
 } } /// namespace eosio::chain

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -31,6 +31,8 @@ const static uint64_t token_account_name     = N(cyber.token);
 const static uint64_t domain_account_name    = N(cyber.domain);
 const static uint64_t govern_account_name    = N(cyber.govern);
 const static uint64_t stake_account_name     = N(cyber.stake);
+// genesis
+const static uint64_t gls_vest_account_name  = N(gls.vesting);
 
 // Active permission of producers account requires greater than 2/3 of the producers to authorize
 const static uint64_t majority_producers_permission_name = N(prod.major); // greater than 1/2 of producers needed to authorize

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -241,7 +241,7 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "Type of chaindb connection")
          ("chaindb_address", bpo::value<string>()->default_value("mongodb://127.0.0.1:27017"),
           "Connection address to chaindb")
-         ("genesis-file", bpo::value<bfs::path>(),
+         ("genesis-data", bpo::value<bfs::path>(),
              "The location of the Genesis state file (absolute path or relative to the current directory)")
          ("trusted-producer", bpo::value<vector<string>>()->composing(), "Indicate a producer whose blocks headers signed by it will be fully validated, but transactions in those validated blocks will be trusted.")
          ;
@@ -371,9 +371,9 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
       if (options.count("chaindb_address"))
          my->chain_config->chaindb_address = options.at("chaindb_address").as<string>();
 
-      my->chain_config->read_genesis = options.count("genesis-file");
+      my->chain_config->read_genesis = options.count("genesis-data");
       if (my->chain_config->read_genesis) {
-          auto path = options.at("genesis-file").as<bfs::path>();
+          auto path = options.at("genesis-data").as<bfs::path>();
           my->chain_config->genesis_file = path.is_relative() ? bfs::current_path() / path : path;
       }
 


### PR DESCRIPTION
+ force save changes to db and clear cache to reduce memory consumption
+ rename `--genesis-file` option to `--genesis-data`
+ added partial abi (only tables) for token contract (not used now, for next PR)
+ removed read_genesis flags