### PR TITLE
Fill balances from genesis #316

### DIFF
--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -274,6 +274,13 @@ namespace cyberway { namespace chaindb {
             return delta;
         }
 
+        // From genesis
+        int64_t insert(const table_request& request, primary_key_t pk, variant value, const ram_payer_info& ram) {
+            auto table = get_table(request);
+            auto obj = object_value{{table, pk}, std::move(value)};
+            return insert(table, ram, obj);
+        }
+
         // From contracts
         int64_t update(
             const table_request& request, const ram_payer_info& ram,
@@ -726,6 +733,12 @@ namespace cyberway { namespace chaindb {
 
     int64_t chaindb_controller::remove(const table_request& request, const ram_payer_info& ram, primary_key_t pk) {
         return impl_->remove(request, ram, pk);
+    }
+
+    int64_t chaindb_controller::insert(
+        const table_request& request, primary_key_t pk, variant data, const ram_payer_info& ram
+    ) {
+         return impl_->insert(request, pk, std::move(data), ram);
     }
 
     int64_t chaindb_controller::insert(cache_item& itm, variant data, const ram_payer_info& ram) {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -544,6 +544,8 @@ struct controller_impl {
 
     void read_genesis() {
         if (conf.read_genesis) {
+            chaindb.add_abi(config::token_account_name, token_contract_abi());   // need to add here again
+            chaindb.add_abi(config::gls_vest_account_name, golos_vesting_contract_abi());
             cyberway::genesis::genesis_read reader(conf.genesis_file, self, conf.genesis.initial_timestamp);
             reader.read();
         }
@@ -585,6 +587,10 @@ struct controller_impl {
             a.set_abi(eosio_contract_abi());
          } else if (name == config::domain_account_name) {
             a.set_abi(domain_contract_abi());
+         } else if (name == config::token_account_name) {
+            a.set_abi(token_contract_abi());
+         } else if (name == config::gls_vest_account_name) {
+            a.set_abi(golos_vesting_contract_abi());
          }
       });
       chaindb.emplace<account_sequence_object>([&](auto & a) {
@@ -662,6 +668,14 @@ struct controller_impl {
                                                                              majority_permission.id,
                                                                              active_producers_authority,
                                                                              conf.genesis.initial_timestamp );
+
+     if (conf.read_genesis) {
+        create_native_account(config::token_account_name, system_auth, system_auth);
+        // TODO: gls auths must be changed here or at startup
+        create_native_account(config::gls_ctrl_account_name, system_auth, system_auth);
+        create_native_account(config::gls_vest_account_name, system_auth, system_auth);
+        create_native_account(config::gls_post_account_name, system_auth, system_auth);
+     }
    }
 
 

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -727,10 +727,10 @@ abi_def token_contract_abi(abi_def abi) {
     }
     fc::move_append(abi.types, common_type_defs());
 
-    abi.structs.emplace_back(struct_def {"account", "", {
+    abi.structs.emplace_back(struct_def{"account", "", {
         {"balance", "asset"}}
     });
-    abi.structs.emplace_back(struct_def {"currency_stats", "", {
+    abi.structs.emplace_back(struct_def{"currency_stats", "", {
         {"supply", "asset"},
         {"max_supply", "asset"},
         {"issuer", "name"}}
@@ -752,6 +752,23 @@ abi_def golos_vesting_contract_abi(abi_def abi) {
     }
     fc::move_append(abi.types, common_type_defs());
 
+    abi.structs.emplace_back(struct_def{"user_balance", "", {
+        {"vesting", "asset"},
+        {"delegate_vesting", "asset"},
+        {"received_vesting", "asset"},
+        {"unlocked_limit", "asset"}}
+    });
+    abi.structs.emplace_back(struct_def{"balance_vesting", "", {  // TODO: rename…
+        {"supply", "asset"},
+        {"notify_acc", "name"}}
+    });
+
+    abi.tables.emplace_back(table_def{"accounts", "user_balance", {
+        {"primary", true, {{"vesting.sym", "asc"}}}
+    }});
+    abi.tables.emplace_back(table_def{"vesting", "balance_vesting", {
+        {"primary", true, {{"supply.sym", "asc"}}}
+    }});
     return abi;
 }
 

--- a/libraries/chain/genesis/genesis_read.cpp
+++ b/libraries/chain/genesis/genesis_read.cpp
@@ -13,6 +13,8 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/fstream.hpp>
 
+//#define IMPORT_SYS_BALANCES
+
 namespace fc { namespace raw {
 
 template<typename T> void unpack(T& s, cyberway::golos::comment_object& c) {
@@ -39,14 +41,128 @@ using std::string;
 using std::vector;
 
 
+constexpr auto GBG = SY(3,GBG);
+constexpr auto GLS = SY(3,GOLOS);
+constexpr auto GESTS = SY(6,GESTS);
 constexpr auto posting_auth_name = "posting";
 constexpr auto golos_account_name = "golos";
-constexpr auto issuer_account_name = "cyber";   // ?cyberfounder
-constexpr int64_t golos_max_supply = 1'000'000'000ll * 1'000; // 3 symbols precision
+constexpr auto issuer_account_name = config::system_account_name;   // ?cyberfounder
+constexpr auto notify_account_name = config::gls_ctrl_account_name;
+constexpr auto posting_account_name = config::gls_post_account_name;
+constexpr int64_t system_max_supply = 1'000'000'000ll * 10000; // 4 digits precision
+constexpr int64_t golos_max_supply = 1'000'000'000ll * 1000; // 3 digits precision
+
 
 account_name generate_name(string n);
 string pubkey_string(const golos::public_key_type& k);
+asset gbg2golos(const asset& gbg, const golos::price& price);
+asset golos2sys(const asset& golos);
 
+
+struct state_object_visitor {
+    using result_type = void;
+
+    enum balance_type {
+        account, savings, order, conversion, escrow, escrow_fee, savings_withdraw, _size
+    };
+    static string balance_name(balance_type t) {
+        switch (t) {
+            case account:       return "accounts";
+            case savings:       return "savings";
+            case order:         return "orders";
+            case conversion:    return "conversions";
+            case escrow:        return "escrows";
+            case escrow_fee:    return "escrow fees";
+            case savings_withdraw: return "savings withdraws";
+            case _size:         return "Total";
+        }
+        EOS_ASSERT(false, extract_genesis_state_exception, "Invalid balance type ${t}", ("t", int(t)));
+    }
+
+    state_object_visitor() {
+        for (int t = 0; t <= balance_type::_size; t++) {
+            gls_by_type[balance_type(t)] = asset(0, symbol(GLS));
+            gbg_by_type[balance_type(t)] = asset(0, symbol(GBG));
+        }
+        total_gests = asset(0, symbol(GESTS));
+    }
+
+    bool early_exit = false;
+    golos::dynamic_global_property_object   gpo;
+    vector<golos::account_object>           accounts;
+    vector<golos::account_authority_object> auths;
+
+    fc::flat_map<uint32_t, asset> gbg;
+    fc::flat_map<uint32_t, asset> gls;
+    fc::flat_map<uint32_t, asset> gests;
+    asset total_gests;
+    fc::flat_map<balance_type, asset> gbg_by_type;
+    fc::flat_map<balance_type, asset> gls_by_type;
+
+    template<typename T>
+    void operator()(const T& x) {}
+
+    void operator()(const golos::dynamic_global_property_object& x) {
+        gpo = x;
+    }
+
+    void operator()(const golos::account_authority_object& auth) {
+        auths.emplace_back(auth);
+    }
+
+    void operator()(const golos::account_object& acc) {
+        accounts.emplace_back(acc);
+        gls[acc.name.id] = acc.balance + acc.savings_balance;
+        gbg[acc.name.id] = acc.sbd_balance + acc.savings_sbd_balance;
+        gests[acc.name.id] = acc.vesting_shares;
+        total_gests          += acc.vesting_shares;
+        gls_by_type[account] += acc.balance;
+        gbg_by_type[account] += acc.sbd_balance;
+        gls_by_type[savings] += acc.savings_balance;
+        gbg_by_type[savings] += acc.savings_sbd_balance;
+    }
+
+    void operator()(const golos::limit_order_object& o) {
+        switch (o.sell_price.base.get_symbol().value()) {
+        case GBG: {auto a = asset(o.for_sale, symbol(GBG)); gbg[o.seller.id] += a; gbg_by_type[order] += a;} break;
+        case GLS: {auto a = asset(o.for_sale, symbol(GLS)); gls[o.seller.id] += a; gls_by_type[order] += a;} break;
+        default:
+            EOS_ASSERT(false, extract_genesis_state_exception,
+                "Unknown asset ${a} in limit order", ("a", o.sell_price.base));
+        }
+    }
+
+    void operator()(const golos::convert_request_object& obj) {
+        add_asset_balance(obj, &golos::convert_request_object::owner, &golos::convert_request_object::amount, conversion);
+    }
+
+    void operator()(const golos::escrow_object& e) {
+        gls[e.from.id] += e.steem_balance;
+        gbg[e.from.id] += e.sbd_balance;
+        gls_by_type[escrow] += e.steem_balance;
+        gbg_by_type[escrow] += e.sbd_balance;
+        add_asset_balance(e, &golos::escrow_object::from, &golos::escrow_object::pending_fee, escrow_fee);
+    }
+
+    void operator()(const golos::savings_withdraw_object& sw) {
+        add_asset_balance(sw, &golos::savings_withdraw_object::to, &golos::savings_withdraw_object::amount, savings_withdraw);
+        early_exit = true;
+    }
+
+    template<typename T, typename A, typename F>
+    void add_asset_balance(const T& item, A account, F field, balance_type type) {
+        const auto acc = (item.*account).id;
+        const auto val = item.*field;
+        switch (val.get_symbol().value()) {
+        case GBG: gbg[acc] += val; gbg_by_type[type] += val; break;
+        case GLS: gls[acc] += val; gls_by_type[type] += val; break;
+        default:
+            EOS_ASSERT(false, extract_genesis_state_exception,
+                string("Unknown asset ${a} in ") + balance_name(type), ("a", val));
+        }
+    };
+
+};
 
 struct genesis_read::genesis_read_impl final {
     bfs::path _state_file;
@@ -56,8 +172,7 @@ struct genesis_read::genesis_read_impl final {
     vector<string> _accs_map;
     vector<string> _plnk_map;
 
-    vector<golos::account_object> _accounts;
-    vector<golos::account_authority_object> _auths;
+    state_object_visitor _visitor;
 
     genesis_read_impl(const bfs::path& genesis_file, controller& ctrl, time_point genesis_ts)
     :   _state_file(genesis_file),
@@ -108,7 +223,8 @@ struct genesis_read::genesis_read_impl final {
         in.read((char*)&h, sizeof(h));
         EOS_ASSERT(string(h.magic) == state_header::expected_magic && h.version == 1, extract_genesis_state_exception,
             "Unknown format of the Genesis state file.");
-        while (in) {
+
+        while (in && !_visitor.early_exit) {
             table_header t;
             fc::raw::unpack(in, t);
             if (!in)
@@ -117,24 +233,13 @@ struct genesis_read::genesis_read_impl final {
             std::cout << "Reading " << t.records_count << " record(s) from table with id=" << type << std::endl;
             objects o;
             o.set_which(type);
-            auto v = fc::raw::unpack_static_variant<decltype(in)>(in);
+            auto unpacker = fc::raw::unpack_static_variant<decltype(in)>(in);
             int i = 0;
             for (; in && i < t.records_count; i++) {
-                o.visit(v);
-                switch (type) {
-                case account_object_id:
-                    _accounts.emplace_back(o.get<golos::account_object>());
-                    break;
-                case account_authority_object_id:
-                    _auths.emplace_back(o.get<golos::account_authority_object>());
-                    break;
-                default:
-                    break;
-                }
+                o.visit(unpacker);
+                o.visit(_visitor);
             }
             std::cout << "  done, " << i << " record(s) read." << std::endl;
-            if (_auths.size() > 0)
-                break;              // we do not need other tables
         }
         std::cout << "Done reading Genesis state." << std::endl;
         in.close();
@@ -146,21 +251,18 @@ struct genesis_read::genesis_read_impl final {
         auto& auth_mgr = _control.get_mutable_authorization_manager();
         auto& reslim_mgr = _control.get_mutable_resource_limits_manager();
         std::unordered_map<string,account_name> names;
-        names.reserve(_auths.size());
+        names.reserve(_visitor.auths.size());
 
         // first fill names, we need them to check is authority account exists
-        for (const auto a: _auths) {
+        for (const auto a: _visitor.auths) {
             const auto n = a.account.value(_accs_map);
-            const auto name =
-                n.size() == 0 ? account_name() : generate_name(n);
-                // n == "null" ? account_name(config::null_account_name) : generate_name(n);
-                //txt_name == "temp"
+            const auto name = n.size() == 0 ? account_name() : generate_name(n);    //?config::null_account_name
             names[n] = name;
         }
 
         // fill auths
         int i = 0;
-        for (const auto a: _auths) {
+        for (const auto a: _visitor.auths) {
             const auto n = a.account.value(_accs_map);
             const auto& name = names[n];
             db.emplace<account_object>([&](auto& a) {
@@ -212,7 +314,7 @@ struct genesis_read::genesis_read_impl final {
 
         // add usernames
         const auto app = names[golos_account_name];
-        for (const auto& auth : _auths) {                // loop through auths to preserve names order
+        for (const auto& auth : _visitor.auths) {                // loop through auths to preserve names order
             const auto& n = auth.account.value(_accs_map);
             db.emplace<username_object>([&](auto& u) {
                 u.owner = names[n]; //generate_name(n);
@@ -225,11 +327,124 @@ struct genesis_read::genesis_read_impl final {
             }
         }
 
-        _auths.clear();
+        _visitor.auths.clear();
         std::cout << "Done." << std::endl;
     }
 
     void create_balances() {
+        std::cout << "Creating balances..." << std::endl;
+        auto& db = const_cast<chaindb_controller&>(_control.chaindb());
+
+        // check invariants first
+        auto& data = _visitor;
+        const auto& gp = data.gpo;
+        std::cout << " Global Properties:" << std::endl;
+        std::cout << "  current_supply = " << gp.current_supply << std::endl;
+        std::cout << "  current_sbd_supply = " << gp.current_sbd_supply << std::endl;
+        std::cout << "  total_vesting_shares = " << gp.total_vesting_shares << std::endl;
+        std::cout << "  total_reward_fund_steem = " << gp.total_reward_fund_steem << std::endl;
+        std::cout << "  total_vesting_fund_steem = " << gp.total_vesting_fund_steem << std::endl;
+
+        std::cout << " GESTS total: " << data.total_gests << std::endl;
+        auto total_idx = state_object_visitor::balance_type::_size;
+        for (const auto& t: data.gbg_by_type) {
+            auto& type = t.first;
+            auto& gbg = t.second;
+            auto& gls = data.gls_by_type[type];
+            std::cout << std::setw(19) << std::left << (" " + data.balance_name(type) + ":")
+                << std::setw(19) << std::right << gls << std::setw(17) << gbg << std::endl;
+            if (type < total_idx) {
+                data.gls_by_type[total_idx] += gls;
+                data.gbg_by_type[total_idx] += gbg;
+            }
+        }
+        auto gests_diff = gp.total_vesting_shares - data.total_gests;
+        auto gls_diff = gp.current_supply -
+            (gp.total_vesting_fund_steem + gp.total_reward_fund_steem + data.gls_by_type[total_idx]);
+        auto gbg_diff = gp.current_sbd_supply - data.gbg_by_type[total_idx];
+        EOS_ASSERT(gests_diff.get_amount() == 0 && gls_diff.get_amount() == 0 && gbg_diff.get_amount() == 0, extract_genesis_state_exception,
+            "Failed while check balances invariants", ("gests", gests_diff)("golos", gls_diff)("gbg", gbg_diff));
+
+        golos::price price;
+        if (gp.is_forced_min_price) {
+            // This price limits SBD to 10% market cap
+            price = golos::price{asset(9 * gp.current_sbd_supply.get_amount(), symbol(GBG)), gp.current_supply};
+        } else {
+            EOS_ASSERT(false, extract_genesis_state_exception, "Not implemented");
+        }
+        auto gbg2gls = gbg2golos(gp.current_sbd_supply, price);
+        std::cout << "GBG 2 GOLOS = " << gbg2gls << std::endl;
+
+        // token stats
+        auto supply = gp.current_supply + gbg2gls;
+        ram_payer_info ram_payer{};
+        auto insert_stat_record = [&](const symbol& sym, const asset& supply, int64_t max_supply, name issuer) {
+            table_request tbl{config::token_account_name, sym.value(), N(stat)};
+            primary_key_t pk = sym.value() >> 8;
+            auto stat = mvo
+                ("supply", supply)
+                ("maximum_supply", asset(max_supply, sym))
+                ("issuer", issuer);
+            db.insert(tbl, pk, stat, ram_payer);
+            return pk;
+        };
+
+        const auto sys_sym = asset().get_symbol();
+        const auto golos_sym = symbol(GLS);
+        const auto vests_sym = symbol(6,"GOLOS");   // Cyberway vesting
+#ifdef IMPORT_SYS_BALANCES
+        auto sys_pk = insert_stat_record(sys_sym, golos2sys(supply), system_max_supply, config::system_account_name);
+#endif
+        auto gls_pk = insert_stat_record(golos_sym, supply, golos_max_supply, issuer_account_name);
+
+        // vesting info
+        // table_request tbl{config::gls_vest_account_name, vests_sym.value(), N(vesting)}; // TODO change scope
+        table_request tbl{config::gls_vest_account_name, config::gls_vest_account_name, N(vesting)};
+        primary_key_t vests_pk = vests_sym.value() >> 8;
+        auto vests_info = mvo
+            ("supply", asset(data.total_gests.get_amount(), vests_sym))
+            ("notify_acc", notify_account_name);
+        db.insert(tbl, vests_pk, vests_info, ram_payer);
+
+        // funds
+        // TODO: convert vesting to staking and burn system tokens in reward pool?
+        db.insert({config::token_account_name, config::gls_vest_account_name, N(accounts)}, gls_pk,
+            mvo("balance", gp.total_vesting_fund_steem), ram_payer);
+        db.insert({config::token_account_name, config::gls_post_account_name, N(accounts)}, gls_pk,
+            mvo("balance", gp.total_reward_fund_steem), ram_payer);
+        // TODO: internal pool of posting contract
+
+        // accounts GOLOS/GESTS
+        auto vests_obj = mvo
+            ("delegate_vesting", asset(0, vests_sym))
+            ("received_vesting", asset(0, vests_sym))
+            ("unlocked_limit", asset(0, vests_sym));
+        asset total_gls = asset(0, golos_sym);
+        int i = 0;
+        for (const auto& balance: data.gbg) {
+            auto acc = balance.first;
+            auto gbg = balance.second;
+            auto gls = data.gls[acc] + gbg2golos(gbg, price);
+            total_gls += gls;
+            auto n = generate_name(_accs_map[acc]);
+            db.insert({config::token_account_name, n, N(accounts)}, gls_pk, mvo("balance", gls), ram_payer);
+#ifdef IMPORT_SYS_BALANCES
+            db.insert({config::token_account_name, n, N(accounts)}, sys_pk, mvo("balance", golos2sys(gls)), ram_payer);
+#endif
+            db.insert({config::gls_vest_account_name, n, N(accounts)}, vests_pk,
+                vests_obj("vesting", asset(data.gests[acc].get_amount(), vests_sym)), ram_payer);
+            if ((++i & 0xFF) == 0) {
+                db.apply_all_changes();
+                db.clear_cache();
+            }
+        }
+        // TODO: update gbg2golos to uniformly distribute rounded amount
+        std::cout << " Total accounts' GOLOS + converted GBG = " << total_gls << "; diff = " <<
+            (supply - (gp.total_vesting_fund_steem + gp.total_reward_fund_steem) - total_gls) << std::endl;
+
+        // TODO: delegation / vesting withdraws
+
+        std::cout << "Done." << std::endl;
     }
 };
 
@@ -264,5 +479,15 @@ string pubkey_string(const golos::public_key_type& k) {
     return fc::to_base58(packed.data(), packed.size());
 }
 
+asset gbg2golos(const asset& gbg, const golos::price& price) {
+    return asset(
+        static_cast<int64_t>(static_cast<eosio::chain::int128_t>(gbg.get_amount()) * price.quote.get_amount() / price.base.get_amount()),
+        price.quote.get_symbol()
+    );
+}
+
+asset golos2sys(const asset& golos) {
+    return asset(golos.get_amount() * (10000/1000));
+}
 
 }} // cyberway

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -215,6 +215,8 @@ namespace cyberway { namespace chaindb {
         int64_t update(const table_request&, const ram_payer_info&, primary_key_t, const char*, size_t);
         int64_t remove(const table_request&, const ram_payer_info&, primary_key_t);
 
+        int64_t insert(const table_request&, primary_key_t, variant, const ram_payer_info&);
+
         int64_t insert(cache_item&, variant, const ram_payer_info&);
         int64_t update(cache_item&, variant, const ram_payer_info&);
         int64_t remove(cache_item&, const ram_payer_info&);

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -32,7 +32,9 @@ const static uint64_t domain_account_name    = N(cyber.domain);
 const static uint64_t govern_account_name    = N(cyber.govern);
 const static uint64_t stake_account_name     = N(cyber.stake);
 // genesis
+const static uint64_t gls_ctrl_account_name  = N(gls.ctrl);
 const static uint64_t gls_vest_account_name  = N(gls.vesting);
+const static uint64_t gls_post_account_name  = N(gls.publish);
 
 // Active permission of producers account requires greater than 2/3 of the producers to authorize
 const static uint64_t majority_producers_permission_name = N(prod.major); // greater than 1/2 of producers needed to authorize


### PR DESCRIPTION
+ GBG converted to GOLOS at current (state file) price
+ GESTS converted to vesting GOLOS (6 digits precision)
+ additional `insert` function added to chaindb controller
+ creating SYS token balances temporary disabled (needs to fix supply)
+ `gls.vesting`, `gls.ctrl` and `gls.publish` accounts created (required to store balances and have consistent db)