### PR TITLE
Dots in table names. #286

### DIFF
--- a/.buildkite/steps/deploy-unit_test.sh
+++ b/.buildkite/steps/deploy-unit_test.sh
@@ -15,7 +15,7 @@ docker-compose up -d mongo
 
 # Run unit-tests
 sleep 10s
-docker run --rm --network docker_cyberway-net -ti cyberway/cyberway:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/cyberway/bin/unit_test -l message -r detailed -t "!api_tests/*" -t "!abi_tests/*" -t "!auth_tests/*" -t "!block_tests/*" -t "!bootseq_tests/*" -t "!block_timestamp_tests/*" -t "!currency_tests/*" -t "!database_tests/*" -t "!delay_tests/*" -t "!eosio_system_tests/*" -t "!forked_tests/*" -t "!identity_tests/*" -t "!misc_tests/*" -t "!multi_index_tests/*" -t "!payloadless_tests/*" -t "!producer_schedule_tests/*" -t "!ram_tests/*" -t "!providebw_tests/*" -t "!tic_tac_toe_tests/*" -t "!wasm_tests/*"'
+docker run --rm --network docker_cyberway-net -ti cyberway/cyberway:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/cyberway/bin/unit_test -l message -r detailed -t "!api_tests/*" -t "!abi_tests/*" -t "!block_tests/*" -t "!bootseq_tests/*" -t "!block_timestamp_tests/*" -t "!currency_tests/*" -t "!database_tests/*" -t "!delay_tests/*" -t "!eosio_system_tests/*" -t "!forked_tests/*" -t "!identity_tests/*" -t "!misc_tests/*" -t "!multi_index_tests/*" -t "!payloadless_tests/*" -t "!producer_schedule_tests/*" -t "!ram_tests/*" -t "!providebw_tests/*" -t "!tic_tac_toe_tests/*" -t "!wasm_tests/*"'
 result=$?
 
 docker-compose down

--- a/.buildkite/steps/deploy-unit_test.sh
+++ b/.buildkite/steps/deploy-unit_test.sh
@@ -15,7 +15,7 @@ docker-compose up -d mongo
 
 # Run unit-tests
 sleep 10s
-docker run --rm --network docker_cyberway-net -ti cyberway/cyberway:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/cyberway/bin/unit_test -l message -r detailed -t "!api_tests/*" -t "!abi_tests/*" -t "!bootseq_tests/*" -t "!block_timestamp_tests/*" -t "!currency_tests/*" -t "!database_tests/*" -t "!delay_tests/*" -t "!eosio_system_tests/*" -t "!forked_tests/*" -t "!identity_tests/*" -t "!misc_tests/*" -t "!multi_index_tests/*" -t "!payloadless_tests/*" -t "!producer_schedule_tests/*" -t "!ram_tests/*" -t "!providebw_tests/*" -t "!tic_tac_toe_tests/*" -t "!wasm_tests/*"'
+docker run --rm --network docker_cyberway-net -ti cyberway/cyberway:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/cyberway/bin/unit_test -l message -r detailed -t "!api_tests/*" -t "!abi_tests/*" -t "!bootseq_tests/*" -t "!currency_tests/*" -t "!database_tests/*" -t "!delay_tests/*" -t "!eosio_system_tests/*" -t "!forked_tests/*" -t "!identity_tests/*" -t "!misc_tests/*" -t "!multi_index_tests/*" -t "!payloadless_tests/*" -t "!producer_schedule_tests/*" -t "!ram_tests/*" -t "!providebw_tests/*" -t "!tic_tac_toe_tests/*" -t "!wasm_tests/*"'
 result=$?
 
 docker-compose down

--- a/.buildkite/steps/deploy-unit_test.sh
+++ b/.buildkite/steps/deploy-unit_test.sh
@@ -15,7 +15,7 @@ docker-compose up -d mongo
 
 # Run unit-tests
 sleep 10s
-docker run --rm --network docker_cyberway-net -ti cyberway/cyberway:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/cyberway/bin/unit_test -l message -r detailed -t "!api_tests/*" -t "!abi_tests/*" -t "!block_tests/*" -t "!bootseq_tests/*" -t "!block_timestamp_tests/*" -t "!currency_tests/*" -t "!database_tests/*" -t "!delay_tests/*" -t "!eosio_system_tests/*" -t "!forked_tests/*" -t "!identity_tests/*" -t "!misc_tests/*" -t "!multi_index_tests/*" -t "!payloadless_tests/*" -t "!producer_schedule_tests/*" -t "!ram_tests/*" -t "!providebw_tests/*" -t "!tic_tac_toe_tests/*" -t "!wasm_tests/*"'
+docker run --rm --network docker_cyberway-net -ti cyberway/cyberway:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/cyberway/bin/unit_test -l message -r detailed -t "!api_tests/*" -t "!abi_tests/*" -t "!bootseq_tests/*" -t "!block_timestamp_tests/*" -t "!currency_tests/*" -t "!database_tests/*" -t "!delay_tests/*" -t "!eosio_system_tests/*" -t "!forked_tests/*" -t "!identity_tests/*" -t "!misc_tests/*" -t "!multi_index_tests/*" -t "!payloadless_tests/*" -t "!producer_schedule_tests/*" -t "!ram_tests/*" -t "!providebw_tests/*" -t "!tic_tac_toe_tests/*" -t "!wasm_tests/*"'
 result=$?
 
 docker-compose down

--- a/libraries/chain/chaindb/mongo_driver.cpp
+++ b/libraries/chain/chaindb/mongo_driver.cpp
@@ -467,13 +467,15 @@ namespace cyberway { namespace chaindb {
 
     struct mongodb_driver::mongodb_impl_ {
         journal& journal_;
+        string sys_code_name_;
         mongocxx::client mongo_conn_;
         code_cursor_map code_cursor_map_;
 
-        mongodb_impl_(journal& jrnl, const std::string& p)
-        : journal_(jrnl) {
+        mongodb_impl_(journal& jrnl, string address, string sys_name)
+        : journal_(jrnl),
+          sys_code_name_(std::move(sys_name)) {
             init_instance();
-            mongocxx::uri uri{p};
+            mongocxx::uri uri{address};
             mongo_conn_ = mongocxx::client{uri};
         }
 
@@ -582,7 +584,7 @@ namespace cyberway { namespace chaindb {
             tables.reserve(abi_info::max_table_cnt * 2);
             _detail::auto_reconnect([&]() {
                 tables.clear();
-                auto db = mongo_conn_.database(get_code_name(code));
+                auto db = mongo_conn_.database(get_code_name(sys_code_name_, code));
                 auto names = db.list_collection_names();
                 for (auto& tname: names) {
                     table_def table;
@@ -669,7 +671,7 @@ namespace cyberway { namespace chaindb {
             auto db_list = mongo_conn_.list_databases();
             for (auto& db: db_list) {
                 auto db_name = db["name"].get_utf8().value;
-                if (!db_name.starts_with(names::system_code)) continue;
+                if (!db_name.starts_with(sys_code_name_)) continue;
 
                 mongo_conn_.database(db_name).drop();
             }
@@ -726,11 +728,11 @@ namespace cyberway { namespace chaindb {
         }
 
         collection get_db_table(const table_info& table) const {
-            return mongo_conn_.database(get_code_name(table)).collection(get_table_name(table));
+            return mongo_conn_.database(get_code_name(sys_code_name_, table.code)).collection(get_table_name(table));
         }
 
         collection get_undo_db_table() const {
-            return mongo_conn_.database(names::system_code).collection(names::undo_table);
+            return mongo_conn_.database(get_code_name(sys_code_name_, account_name())).collection(names::undo_table);
         }
 
         cursor_t get_next_cursor_id(code_cursor_map::iterator itr) {
@@ -904,8 +906,8 @@ namespace cyberway { namespace chaindb {
 
     ///----
 
-    mongodb_driver::mongodb_driver(journal& jrnl, const std::string& p)
-    : impl_(new mongodb_impl_(jrnl, p)) {
+    mongodb_driver::mongodb_driver(journal& jrnl, string address, string sys_name)
+    : impl_(new mongodb_impl_(jrnl, std::move(address), std::move(sys_name))) {
     }
 
     mongodb_driver::~mongodb_driver() = default;

--- a/libraries/chain/chaindb/mongo_fail_driver.cpp
+++ b/libraries/chain/chaindb/mongo_fail_driver.cpp
@@ -7,7 +7,7 @@ namespace cyberway { namespace chaindb {
     struct mongodb_driver::mongodb_impl_ {
     }; // struct mongodb_driver::mongodb_impl_
 
-    mongodb_driver::mongodb_driver(const std::string&) {
+    mongodb_driver::mongodb_driver(string, string) {
         NOT_SUPPORTED;
     }
 

--- a/libraries/chain/chaindb/names.cpp
+++ b/libraries/chain/chaindb/names.cpp
@@ -1,6 +1,29 @@
 #include <cyberway/chaindb/names.hpp>
+#include <boost/algorithm/string.hpp>
 
 namespace cyberway { namespace chaindb {
+
+    string db_name_to_string(const uint64_t& value) {
+        // Copy-paste of eosio::name::to_string(),
+        //     but instead of the symbol '.' the symbol '_' is used
+        static const char* charmap = "_12345abcdefghijklmnopqrstuvwxyz";
+
+        string str(13,'_');
+
+        uint64_t tmp = value;
+
+        str[12] = charmap[tmp & 0x0f];
+        tmp >>= 4;
+
+        for (uint32_t i = 1; i <= 12; ++i) {
+            char c = charmap[tmp & 0x1f];
+            str[12-i] = c;
+            tmp >>= 5;
+        }
+
+        boost::algorithm::trim_right_if( str, [](char c){ return c == '_'; } );
+        return str;
+    }
 
     // name can't contains _ that is why they are used for internal db and key names
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -208,7 +208,7 @@ struct controller_impl {
 
    controller_impl( const controller::config& cfg, controller& s  )
    :self(s),
-    chaindb(cfg.chaindb_address_type, cfg.chaindb_address),
+    chaindb(cfg.chaindb_address_type, cfg.chaindb_address, cfg.chaindb_sys_name),
 // TODO: removed by CyberWay
 //    db( cfg.state_dir,
 //        cfg.read_only ? database::read_only : database::read_write,

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -62,7 +62,7 @@ namespace cyberway { namespace chaindb {
         chaindb_controller() = delete;
         chaindb_controller(const chaindb_controller&) = delete;
 
-        chaindb_controller(chaindb_type, string);
+        chaindb_controller(chaindb_type, string, string);
         ~chaindb_controller();
 
         template<typename Object>

--- a/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
+++ b/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
@@ -10,7 +10,7 @@ namespace cyberway { namespace chaindb {
 
     class mongodb_driver final: public driver_interface {
     public:
-        mongodb_driver(journal&, const std::string&);
+        mongodb_driver(journal&, string, string);
         ~mongodb_driver();
 
         std::vector<table_def> db_tables(const account_name& code) const override;

--- a/libraries/chain/include/cyberway/chaindb/names.hpp
+++ b/libraries/chain/include/cyberway/chaindb/names.hpp
@@ -39,6 +39,8 @@ namespace cyberway { namespace chaindb {
 
     ///----
 
+    string db_name_to_string(const uint64_t&);
+
     inline account_name get_system_code() {
         return account_name();
     }
@@ -51,8 +53,7 @@ namespace cyberway { namespace chaindb {
         if (is_system_code(code)) return names::system_code;
 
         string str;
-        str.append(names::system_code).append(code.to_string());
-        std::replace(str.begin(), str.end(), '.', '-');
+        str.append(names::system_code).append(db_name_to_string(code.value));
         return str;
     }
 
@@ -86,7 +87,7 @@ namespace cyberway { namespace chaindb {
 
     inline string get_table_name(const table_name& table) {
         if (!table.empty()) {
-            return table.to_string();
+            return db_name_to_string(table.value);
         }
         return names::unknown;
     }
@@ -125,7 +126,7 @@ namespace cyberway { namespace chaindb {
 
     inline string get_index_name(const index_name& index) {
         if (!index.empty()) {
-            return index.to_string();
+            return db_name_to_string(index.value);
         }
         return names::unknown;
     }

--- a/libraries/chain/include/cyberway/chaindb/names.hpp
+++ b/libraries/chain/include/cyberway/chaindb/names.hpp
@@ -49,12 +49,13 @@ namespace cyberway { namespace chaindb {
         return (code.empty());
     }
 
-    inline string get_code_name(const account_name& code) {
-        if (is_system_code(code)) return names::system_code;
+    inline string get_code_name(string name, const account_name& code) {
+        if (!is_system_code(code)) name.append(db_name_to_string(code.value));
+        return name;
+    }
 
-        string str;
-        str.append(names::system_code).append(db_name_to_string(code.value));
-        return str;
+    inline string get_code_name(const account_name& code) {
+        return get_code_name(names::system_code, code);
     }
 
     inline string get_code_name(const account_name_t code) {

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -85,6 +85,7 @@ namespace eosio { namespace chain {
 
             chaindb_type             chaindb_address_type = chaindb_type::MongoDB;
             string                   chaindb_address;
+            string                   chaindb_sys_name; // if empty, than initialize default
 
             path                     genesis_file;                // Golos state
             bool                     read_genesis = false;

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -340,6 +340,7 @@ namespace eosio { namespace testing {
          vcfg = default_config();
 
          vcfg.trusted_producers = trusted_producers;
+         vcfg.chaindb_sys_name = "_VALIDATE_";
 
          validating_node = std::make_unique<controller>(vcfg);
          validating_node->add_indices();
@@ -355,6 +356,7 @@ namespace eosio { namespace testing {
          vcfg = config;
          vcfg.blocks_dir = vcfg.blocks_dir.parent_path() / std::string("v_").append( vcfg.blocks_dir.filename().generic_string() );
          vcfg.state_dir  = vcfg.state_dir.parent_path() / std::string("v_").append( vcfg.state_dir.filename().generic_string() );
+         vcfg.chaindb_sys_name = "_VALIDATE_";
 
          validating_node = std::make_unique<controller>(vcfg);
          validating_node->add_indices();

--- a/unittests/auth_tests.cpp
+++ b/unittests/auth_tests.cpp
@@ -502,7 +502,7 @@ BOOST_AUTO_TEST_CASE( linkauth_special ) { try {
       BOOST_REQUIRE_EXCEPTION(
          chain.push_action(config::system_account_name, linkauth::get_name(), tester_account, fc::mutable_variant_object()
                ("account", "tester")
-               ("code", config::system_account_name)
+               ("code", name(config::system_account_name))
                ("type", type)
                ("requirement", "first")),
          action_validate_exception,

--- a/unittests/block_tests.cpp
+++ b/unittests/block_tests.cpp
@@ -153,7 +153,8 @@ BOOST_AUTO_TEST_CASE(untrusted_producer_test)
    std::vector<account_name> schedule(producers.cbegin(), producers.cend());
    auto trace = main.set_producers(schedule);
 
-   while (b->producer != N(defproducerb)) {
+   // Depends on blocks per producer, fix if change it
+   while (b->producer != N(defproducerd)) {
       b = main.produce_block();
    }
 

--- a/unittests/block_timestamp_tests.cpp
+++ b/unittests/block_timestamp_tests.cpp
@@ -22,7 +22,7 @@ BOOST_AUTO_TEST_CASE(constructor_test) {
         
 	fc::time_point t(fc::seconds(978307200));	
 	block_timestamp_type bt2(t);
-	BOOST_TEST( bt2.slot == (978307200 - 946684800)*2, "Time point constructor gives wrong value");
+	BOOST_TEST( bt2.slot == (978307200 - 946684800)/3, "Time point constructor gives wrong value");
 }
 
 BOOST_AUTO_TEST_CASE(conversion_test) {
@@ -31,8 +31,8 @@ BOOST_AUTO_TEST_CASE(conversion_test) {
 	BOOST_TEST(t.time_since_epoch().to_seconds() == 946684800ll, "Time point conversion failed");
 
 	block_timestamp_type bt1(200);
-	t = (fc::time_point)bt1;
-	BOOST_TEST(t.time_since_epoch().to_seconds() == 946684900ll, "Time point conversion failed");
+	fc::time_point t1 = (fc::time_point)bt1;
+	BOOST_TEST(t1.time_since_epoch().to_seconds() == t.time_since_epoch().to_seconds() + 3 * 200, "Time point conversion failed");
 
 }
 


### PR DESCRIPTION
This PR closes:
1. #286 - dots in table names, all dots are replaced by '_'
1. #361 - ability to change system name, useful for tests
1. #341 - fixes for auth_tests, accounts can't be passed as numbers, they should be passed as strings
1. #342 - fixes for block_tests, cyberway generate 3 blocks per user instead of 12 blocks per user in EOS
1. #345 - fixes for block_timestamp, each block every 3 seconds instead of 0.5 second in EOS