### PR TITLE
Enable unit tests

### DIFF
--- a/.buildkite/steps/deploy-unit_test.sh
+++ b/.buildkite/steps/deploy-unit_test.sh
@@ -15,7 +15,7 @@ docker-compose up -d mongo
 
 # Run unit-tests
 sleep 10s
-docker run --rm --network docker_cyberway-net -ti cyberway/cyberway:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/cyberway/bin/unit_test -l message -r detailed -t "!api_tests/*" -t "!abi_tests/*" -t "!bootseq_tests/*" -t "!eosio_system_tests/*" -t "!forked_tests/*" -t "!identity_tests/*" -t "!multi_index_tests/*" -t "!ram_tests/*" -t "!providebw_tests/*"'
+docker run --rm --network docker_cyberway-net -ti cyberway/cyberway:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/cyberway/bin/unit_test -l message -r detailed -t "!api_tests/*" -t "!abi_tests/*" -t "!bootseq_tests/*" -t "!eosio_system_tests/*" -t "!forked_tests/*" -t "!multi_index_tests/*" -t "!ram_tests/*" -t "!providebw_tests/*"'
 result=$?
 
 docker-compose down

--- a/.buildkite/steps/deploy-unit_test.sh
+++ b/.buildkite/steps/deploy-unit_test.sh
@@ -15,7 +15,7 @@ docker-compose up -d mongo
 
 # Run unit-tests
 sleep 10s
-docker run --rm --network docker_cyberway-net -ti cyberway/cyberway:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/cyberway/bin/unit_test -l message -r detailed -t "!api_tests/*" -t "!abi_tests/*" -t "!bootseq_tests/*" -t "!eosio_system_tests/*" -t "!forked_tests/*" -t "!multi_index_tests/*" -t "!ram_tests/*" -t "!providebw_tests/*"'
+docker run --rm --network docker_cyberway-net -ti cyberway/cyberway:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/cyberway/bin/unit_test -l message -r detailed -t "!api_tests/*" -t "!abi_tests/*" -t "!bootseq_tests/*" -t "!eosio_system_tests/*" -t "!multi_index_tests/*" -t "!ram_tests/*" -t "!providebw_tests/*"'
 result=$?
 
 docker-compose down

--- a/contracts/identity/identity.abi
+++ b/contracts/identity/identity.abi
@@ -1,5 +1,5 @@
 {
-  "version": "eosio::abi/1.0",
+  "version": "cyberway::abi/1.0",
   "types": [{
       "new_type_name": "account_name",
       "type": "name"
@@ -49,6 +49,7 @@
       "name": "certrow",
       "base": "",
       "fields": [
+        {"name":"id", "type":"uint64"},
         {"name":"property", "type":"property_name"},
         {"name":"trusted", "type":"uint64"},
         {"name":"certifier", "type":"account_name"},
@@ -64,10 +65,17 @@
         {"name":"creator", "type":"account_name"}
       ]
     },{
+      "name": "trustrow",
+      "base": "",
+      "fields": [
+        {"name":"account", "type":"account_name"}
+      ]
+    },{
       "name": "accountrow",
       "base": "",
       "fields": [
-        {"name":"identity", "type":"uint64"}
+        {"name":"id", "type":"account_name"},
+        {"name":"identity", "type":"uint64"},
       ]
     }
   ],
@@ -85,29 +93,47 @@
   "tables": [{
       "name": "certs",
       "type": "certrow",
-      "index_type": "i64i64i64",
-      "key_names" : [
-        "property",
-        "trusted",
-        "certifier"
-      ],
-      " key_types": [
-        "uint64",
-        "uint64",
-        "uint64"
+      "indexes": [{
+          "name": "primary",
+          "unique": "true",
+          "orders": [{"field": "id", "order": "asc"}]
+        },{
+          "name": "bytuple",
+          "unique": "true",
+          "orders": [
+            {"field": "property", "order": "asc"},
+            {"field": "trusted", "order": "asc"},
+            {"field": "certifier", "order": "asc"}
+          ]
+        }
       ]
     },{
       "name": "idents",
       "type": "identrow",
-      "index_type": "i64",
-      "key_names" : [ "identity" ],
-      "key_types": [ "uint64" ]
+      "indexes": [{
+          "name": "primary",
+          "unique": "true",
+          "orders": [{"field": "identity", "order": "asc"}]
+        }
+      ]
     },{
       "name": "trust",
-      "type": "account_name",
-      "index_type": "i64",
-      "key_names" : [ "account" ],
-      "key_types": [ "account_name" ]
+      "type": "trustrow",
+      "indexes": [{
+          "name": "primary",
+          "unique": "true",
+          "orders": [{"field": "account", "order": "asc"}]
+        }
+      ]
+    },{
+      "name": "account",
+      "type": "accountrow",
+      "indexes": [{
+         "name": "primary",
+         "unique": "true",
+         "orders": [{"field": "id", "order": "asc"}]
+        }
+      ]
     }
   ],
   "abi_extensions": []

--- a/contracts/identity/identity.cpp
+++ b/contracts/identity/identity.cpp
@@ -6,7 +6,6 @@
 namespace identity {
    using eosio::action_meta;
    using eosio::singleton;
-   using eosio::key256;
    using std::string;
    using std::vector;
 
@@ -121,7 +120,7 @@ namespace identity {
                auto idx = certs.template get_index<N(bytuple)>();
                if (value.confidence) {
                   eosio_assert(value.type.size() <= 32, "certrow::type should be not longer than 32 bytes");
-                  auto itr = idx.lower_bound( certrow::key(value.property, trusted, certifier) );
+                  auto itr = idx.lower_bound( std::make_tuple(value.property, trusted, certifier) );
 
                   if (itr != idx.end() && itr->property == value.property && itr->trusted == trusted && itr->certifier == certifier) {
                      idx.modify(itr, 0, [&](certrow& row) {
@@ -142,7 +141,7 @@ namespace identity {
                         });
                   }
 
-                  auto itr_old = idx.lower_bound( certrow::key(value.property, !trusted, certifier) );
+                  auto itr_old = idx.lower_bound( std::make_tuple(value.property, !trusted, certifier) );
                   if (itr_old != idx.end() && itr_old->property == value.property && itr_old->trusted == !trusted && itr_old->certifier == certifier) {
                      idx.erase(itr_old);
                   }
@@ -157,13 +156,13 @@ namespace identity {
                   }
                } else {
                   bool removed = false;
-                  auto itr = idx.lower_bound( certrow::key(value.property, trusted, certifier) );
+                  auto itr = idx.lower_bound( std::make_tuple(value.property, trusted, certifier) );
                   if (itr != idx.end() && itr->property == value.property && itr->trusted == trusted && itr->certifier == certifier) {
                      idx.erase(itr);
                   } else {
                      removed = true;
                   }
-                  itr = idx.lower_bound( certrow::key(value.property, !trusted, certifier) );
+                  itr = idx.lower_bound( std::make_tuple(value.property, !trusted, certifier) );
                   if (itr != idx.end() && itr->property == value.property && itr->trusted == !trusted && itr->certifier == certifier) {
                      idx.erase(itr);
                   } else {

--- a/contracts/identity/interface.cpp
+++ b/contracts/identity/interface.cpp
@@ -1,5 +1,7 @@
 #include "interface.hpp"
 
+#include <eosiolib/eosio.hpp>
+
 namespace identity {
 
 identity_name interface::get_claimed_identity( account_name acnt ) {
@@ -12,7 +14,7 @@ account_name interface::get_owner_for_identity( uint64_t receiver, identity_name
    //   check to see if the account has claimed it
    certs_table certs( _self, ident );
    auto idx = certs.template get_index<N(bytuple)>();
-   auto itr = idx.lower_bound(certrow::key(N(owner), 1, 0));
+   auto itr = idx.lower_bound(std::make_tuple(N(owner), 1ull));
    account_name owner = 0;
    while (itr != idx.end() && itr->property == N(owner) && itr->trusted) {
       if (sizeof(account_name) == itr->data.size()) {
@@ -46,7 +48,7 @@ account_name interface::get_owner_for_identity( uint64_t receiver, identity_name
    }
    // trusted certification not found
    // let's see if any untrusted certifications became trusted
-   itr = idx.lower_bound(certrow::key(N(owner), 0, 0));
+   itr = idx.lower_bound(N(owner));
    while (itr != idx.end() && itr->property == N(owner) && !itr->trusted) {
       if (sizeof(account_name) == itr->data.size()) {
          account_name account = *reinterpret_cast<const account_name*>(itr->data.data());

--- a/contracts/identity/test/identity_test.abi
+++ b/contracts/identity/test/identity_test.abi
@@ -1,5 +1,5 @@
 {
-  "version": "eosio::abi/1.0",
+  "version": "cyberway::abi/1.0",
   "types": [{
       "new_type_name": "account_name",
       "type": "name"
@@ -20,6 +20,13 @@
       "fields": [
         {"name":"account", "type":"account_name"}
       ]
+    },{
+      "name": "resultrow",
+      "base": "",
+      "fields": [
+        {"name":"id", "type":"uint64"},
+        {"name":"identity", "type":"uint64"},
+      ]
     }
   ],
   "actions": [{
@@ -30,6 +37,15 @@
       "type": "getidentity"
     }
   ],
-  "tables": [
+  "tables": [{
+      "name": "result",
+      "type": "resultrow",
+      "indexes": [{
+          "name": "primary",
+          "unique": "true",
+          "orders": [{"field": "id", "order": "asc"}]
+        }
+      ]
+    }
   ]
 }

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -416,8 +416,10 @@ namespace cyberway { namespace chaindb {
             if (itm) return itm->object();
 
             auto obj = driver_.object_by_pk(table, pk);
-            validate_object(table, obj, pk);
-            cache_.emplace(table, obj);
+            if (!obj.value.is_null()) {
+                validate_object(table, obj, pk);
+                cache_.emplace(table, obj);
+            }
             return obj;
         }
 

--- a/libraries/chain/chaindb/mongo_driver.cpp
+++ b/libraries/chain/chaindb/mongo_driver.cpp
@@ -285,7 +285,7 @@ namespace cyberway { namespace chaindb {
             if (!object_.value.is_null()) return object_;
 
             if (end_primary_key == get_pk_value()) {
-                object_.value = variant_object();
+                object_.value         = variant();
                 object_.service.pk    = pk;
                 object_.service.code  = index.code;
                 object_.service.scope = index.scope;
@@ -711,7 +711,7 @@ namespace cyberway { namespace chaindb {
             if (cursor.end() != itr) {
                 return build_object(table, *itr);
             } else {
-                obj.value = variant_object();
+                obj.value = variant();
                 return obj;
             }
 

--- a/libraries/chain/chaindb/mongo_driver_utils.cpp
+++ b/libraries/chain/chaindb/mongo_driver_utils.cpp
@@ -171,10 +171,10 @@ namespace cyberway { namespace chaindb {
         for (auto& key: pk_order.path) {
             auto itr = view.find(key);
             CYBERWAY_ASSERT(view.end() != itr, driver_primary_key_exception,
-                            "Can't find the part ${key} for the primary key ${pk} in the row '${row}' "
-                            "from the table ${table} for the scope '${scope}'",
-                            ("key", key)("pk", pk_order.field)("row", to_json(row))
-                                ("table", get_full_table_name(table))("scope", get_scope_name(table)));
+                "Can't find the part ${key} for the primary key ${pk} in the row '${row}' "
+                "from the table ${table} for the scope '${scope}'",
+                ("key", key)("pk", pk_order.field)("row", to_json(row))
+                ("table", get_full_table_name(table))("scope", get_scope_name(table)));
 
             --pos;
             if (0 == pos) {

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -92,12 +92,14 @@ namespace eosio { namespace testing {
 
          virtual ~base_tester() {};
 
-         void              init(bool push_genesis = true, db_read_mode read_mode = db_read_mode::SPECULATIVE);
-         void              init(controller::config config, const snapshot_reader_ptr& snapshot = nullptr);
+         static controller::config default_config(string chaindb_sys_name = string());
 
-         void              close();
-         void              open( const snapshot_reader_ptr& snapshot );
-         bool              is_same_chain( base_tester& other );
+         void init(controller::config config, bool push_genesis = true, db_read_mode read_mode = db_read_mode::SPECULATIVE);
+         void init(controller::config config, const snapshot_reader_ptr& snapshot = nullptr);
+
+         void close();
+         void open( const snapshot_reader_ptr& snapshot );
+         bool is_same_chain( base_tester& other );
 
          virtual signed_block_ptr produce_block( fc::microseconds skip_time = fc::milliseconds(config::block_interval_ms), uint32_t skip_flag = 0/*skip_missed_block_penalty*/ ) = 0;
          virtual signed_block_ptr produce_empty_block( fc::microseconds skip_time = fc::milliseconds(config::block_interval_ms), uint32_t skip_flag = 0/*skip_missed_block_penalty*/ ) = 0;
@@ -274,12 +276,8 @@ namespace eosio { namespace testing {
 
    class tester : public base_tester {
    public:
-      tester(bool push_genesis = true, db_read_mode read_mode = db_read_mode::SPECULATIVE ) {
-         init(push_genesis, read_mode);
-      }
-
-      tester(controller::config config) {
-         init(config);
+      tester(controller::config config = default_config(), bool push_genesis = true, db_read_mode read_mode = db_read_mode::SPECULATIVE) {
+         init(config, push_genesis, read_mode);
       }
 
       signed_block_ptr produce_block( fc::microseconds skip_time = fc::milliseconds(config::block_interval_ms), uint32_t skip_flag = 0/*skip_missed_block_penalty*/ )override {
@@ -312,57 +310,15 @@ namespace eosio { namespace testing {
       }
       controller::config vcfg;
 
-      static controller::config default_config() {
-         fc::temp_directory tempdir;
-         controller::config vcfg;
-         vcfg.blocks_dir      = tempdir.path() / std::string("v_").append(config::default_blocks_dir_name);
-         vcfg.state_dir  = tempdir.path() /  std::string("v_").append(config::default_state_dir_name);
-         vcfg.state_size = 1024*1024*8;
-         vcfg.state_guard_size = 0;
-         vcfg.reversible_cache_size = 1024*1024*8;
-         vcfg.reversible_guard_size = 0;
-         vcfg.contracts_console = false;
-
-         vcfg.genesis.initial_timestamp = fc::time_point::from_iso_string("2020-01-01T00:00:00.000");
-         vcfg.genesis.initial_key = get_public_key( config::system_account_name, "active" );
-
-         for(int i = 0; i < boost::unit_test::framework::master_test_suite().argc; ++i) {
-            if(boost::unit_test::framework::master_test_suite().argv[i] == std::string("--wavm"))
-               vcfg.wasm_runtime = chain::wasm_interface::vm_type::wavm;
-            else if(boost::unit_test::framework::master_test_suite().argv[i] == std::string("--wabt"))
-               vcfg.wasm_runtime = chain::wasm_interface::vm_type::wabt;
-         }
-         vcfg.chaindb_address = getenv("MONGO_URL") ?: "mongodb://127.0.0.1:27017";
-         return vcfg;
-      }
-
       validating_tester(const flat_set<account_name>& trusted_producers = flat_set<account_name>()) {
-         vcfg = default_config();
-
+         vcfg = default_config("_VALIDATE_");
          vcfg.trusted_producers = trusted_producers;
-         vcfg.chaindb_sys_name = "_VALIDATE_";
 
          validating_node = std::make_unique<controller>(vcfg);
          validating_node->add_indices();
          validating_node->startup( []() { return false; } );
 
-         init(true);
-      }
-
-      validating_tester(controller::config config) {
-         FC_ASSERT( config.blocks_dir.filename().generic_string() != "."
-                    && config.state_dir.filename().generic_string() != ".", "invalid path names in controller::config" );
-
-         vcfg = config;
-         vcfg.blocks_dir = vcfg.blocks_dir.parent_path() / std::string("v_").append( vcfg.blocks_dir.filename().generic_string() );
-         vcfg.state_dir  = vcfg.state_dir.parent_path() / std::string("v_").append( vcfg.state_dir.filename().generic_string() );
-         vcfg.chaindb_sys_name = "_VALIDATE_";
-
-         validating_node = std::make_unique<controller>(vcfg);
-         validating_node->add_indices();
-         validating_node->startup( []() { return false; } );
-
-         init(config);
+         init(default_config(), true);
       }
 
       signed_block_ptr produce_block( fc::microseconds skip_time = fc::milliseconds(config::block_interval_ms), uint32_t skip_flag = 0 /*skip_missed_block_penalty*/ )override {

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -77,41 +77,45 @@ namespace eosio { namespace testing {
      return control->head_block_id() == other.control->head_block_id();
    }
 
-   void base_tester::init(bool push_genesis, db_read_mode read_mode) {
-      fc::exception::enable_detailed_strace();
+   controller::config base_tester::default_config(string chaindb_sys_name) {
+     fc::exception::enable_detailed_strace();
 
-      cfg.blocks_dir      = tempdir.path() / config::default_blocks_dir_name;
-      cfg.state_dir  = tempdir.path() / config::default_state_dir_name;
-      cfg.state_size = 1024*1024*8;
-      cfg.state_guard_size = 0;
-      cfg.reversible_cache_size = 1024*1024*8;
-      cfg.reversible_guard_size = 0;
-      cfg.contracts_console = true;
+     fc::temp_directory tempdir;
+     controller::config result;
+     result.blocks_dir = tempdir.path() / string(chaindb_sys_name).append(config::default_blocks_dir_name);
+     result.state_dir  = tempdir.path() / string(chaindb_sys_name).append(config::default_state_dir_name);
+     result.state_size = 1024*1024*8;
+     result.state_guard_size = 0;
+     result.reversible_cache_size = 1024*1024*8;
+     result.reversible_guard_size = 0;
+     result.contracts_console = false;
+
+     result.genesis.initial_timestamp = fc::time_point::from_iso_string("2020-01-01T00:00:00.000");
+     result.genesis.initial_key = get_public_key( config::system_account_name, "active" );
+
+     for(int i = 0; i < boost::unit_test::framework::master_test_suite().argc; ++i) {
+       if(boost::unit_test::framework::master_test_suite().argv[i] == std::string("--wavm"))
+         result.wasm_runtime = chain::wasm_interface::vm_type::wavm;
+       else if(boost::unit_test::framework::master_test_suite().argv[i] == std::string("--wabt"))
+         result.wasm_runtime = chain::wasm_interface::vm_type::wabt;
+     }
+     result.chaindb_address  = getenv("MONGO_URL") ?: "mongodb://127.0.0.1:27017";
+     result.chaindb_sys_name = chaindb_sys_name;
+     return result;
+   }
+
+   void base_tester::init(controller::config config, bool push_genesis, db_read_mode read_mode) {
+      cfg = config;
       cfg.read_mode = read_mode;
-
-      cfg.genesis.initial_timestamp = fc::time_point::from_iso_string("2020-01-01T00:00:00.000");
-      cfg.genesis.initial_key = get_public_key( config::system_account_name, "active" );
-
-      for(int i = 0; i < boost::unit_test::framework::master_test_suite().argc; ++i) {
-         if(boost::unit_test::framework::master_test_suite().argv[i] == std::string("--wavm"))
-            cfg.wasm_runtime = chain::wasm_interface::vm_type::wavm;
-         else if(boost::unit_test::framework::master_test_suite().argv[i] == std::string("--wabt"))
-            cfg.wasm_runtime = chain::wasm_interface::vm_type::wabt;
-      }
-      cfg.chaindb_address = getenv("MONGO_URL") ?: "mongodb://127.0.0.1:27017";
 
       open(nullptr);
 
       if (push_genesis)
-         push_genesis_block();
+        push_genesis_block();
    }
 
-
    void base_tester::init(controller::config config, const snapshot_reader_ptr& snapshot) {
-      fc::exception::enable_detailed_strace();
-
       cfg = config;
-      cfg.chaindb_address = getenv("MONGO_URL") ?: "mongodb://127.0.0.1:27017";
       open(snapshot);
    }
 

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -88,7 +88,7 @@ namespace eosio { namespace testing {
      result.state_guard_size = 0;
      result.reversible_cache_size = 1024*1024*8;
      result.reversible_guard_size = 0;
-     result.contracts_console = false;
+     result.contracts_console = true;
 
      result.genesis.initial_timestamp = fc::time_point::from_iso_string("2020-01-01T00:00:00.000");
      result.genesis.initial_key = get_public_key( config::system_account_name, "active" );

--- a/unittests/payloadless_tests.cpp
+++ b/unittests/payloadless_tests.cpp
@@ -39,7 +39,7 @@ BOOST_FIXTURE_TEST_CASE( test_doit, payloadless_tester ) {
 
    auto trace = push_action(N(payloadless), N(doit), N(payloadless), mutable_variant_object());
    auto msg = trace->action_traces.front().console;
-   BOOST_CHECK_EQUAL(msg == "Im a payloadless action", true);
+   BOOST_CHECK_EQUAL(msg, "Im a payloadless action");
 }
 
 // test GH#3916 - contract api action with no parameters fails when called from cleos
@@ -73,7 +73,7 @@ BOOST_FIXTURE_TEST_CASE( test_abi_serializer, payloadless_tester ) {
    trx.sign( get_private_key( N(payloadless), "active" ), control->get_chain_id() );
    auto trace = push_transaction( trx );
    auto msg = trace->action_traces.front().console;
-   BOOST_CHECK_EQUAL(msg == "Im a payloadless action", true);
+   BOOST_CHECK_EQUAL(msg, "Im a payloadless action");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR enables the following unit tests:
- #350 using of identity contract for tests
- #349 testing of forks

Additional fixes for #353 (after #349) - enabling of console output in tester-class 