### PR TITLE
Add missing index in golos.vesting table when genesis read #417

### DIFF
--- a/libraries/chain/genesis/genesis_accounts.cpp
+++ b/libraries/chain/genesis/genesis_accounts.cpp
@@ -43,7 +43,8 @@ abi_def golos_vesting_contract_abi(abi_def abi = abi_def()) {
     }});
     abi.tables.emplace_back(table_def{"delegation", "delegation", {
         {"primary", true, {{"id", "asc"}}},
-        {"delegator",  true, {{"delegator", "asc"}, {"delegatee", "asc"}}}
+        {"delegator",  true, {{"delegator", "asc"}, {"delegatee", "asc"}}},
+        {"delegatee",  false, {{"delegatee", "asc"}}}
     }});
     abi.tables.emplace_back(table_def{"rdelegation", "return_delegation", {
         {"primary", true, {{"id", "asc"}}},


### PR DESCRIPTION
Fixes #417
Cyberway can't create indexes on tables with data records. So when create genesis it's need to create all indexes in created tables.