### PR TITLE
Fix tests after shuffle schedule of producers. #395

### DIFF
--- a/.buildkite/steps/deploy-unit_test.sh
+++ b/.buildkite/steps/deploy-unit_test.sh
@@ -15,7 +15,7 @@ docker-compose up -d mongo
 
 # Run unit-tests
 sleep 10s
-docker run --rm --network docker_cyberway-net -ti cyberway/cyberway:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/cyberway/bin/unit_test -l message -r detailed -t "!api_tests/*" -t "!abi_tests/*" -t "!bootseq_tests/*" -t "!eosio_system_tests/*" -t "!multi_index_tests/*" -t "!ram_tests/*" -t "!providebw_tests/*" -t "!forked_tests/*" -t "!producer_schedule_tests/*" -t "!block_tests/*"'
+docker run --rm --network docker_cyberway-net -ti cyberway/cyberway:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/cyberway/bin/unit_test -l message -r detailed -t "!api_tests/*" -t "!abi_tests/*" -t "!bootseq_tests/*" -t "!eosio_system_tests/*" -t "!multi_index_tests/*" -t "!ram_tests/*" -t "!providebw_tests/*"'
 result=$?
 
 docker-compose down

--- a/libraries/chain/block_header_state.cpp
+++ b/libraries/chain/block_header_state.cpp
@@ -127,7 +127,7 @@ namespace eosio { namespace chain {
       else {
           EOS_ASSERT( active_schedule.producers.size(), producer_schedule_exception, "SYSTEM: no active producers" );
           EOS_ASSERT( when > promoting_block, producer_schedule_exception, "SYSTEM: wrong promoting_block value" );
-          if ((when.slot - promoting_block.slot) % active_schedule.producers.size() == 0) {
+          if ((when.slot - promoting_block.slot) % (active_schedule.producers.size() * config::producer_repetitions) == 0) {
              shuffle(active_schedule.producers, when.slot);
           }
       }

--- a/libraries/chain/include/eosio/chain/random.hpp
+++ b/libraries/chain/include/eosio/chain/random.hpp
@@ -8,8 +8,10 @@ namespace eosio { namespace chain {
 
 template<typename T>
 void shuffle(std::vector<T>& items, uint32_t seed) {
-    auto hi = static_cast<uint64_t>(seed) << 32;
     auto s = items.size();
+    if (1 >= s) return;
+
+    auto hi = static_cast<uint64_t>(seed) << 32;
     for (uint32_t i = 0; i < s; ++i) {
         /// High performance random generator
         /// http://xorshift.di.unimi.it/

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -109,7 +109,8 @@ namespace eosio { namespace testing {
          virtual signed_block_ptr produce_block( fc::microseconds skip_time = fc::milliseconds(config::block_interval_ms), uint32_t skip_flag = 0/*skip_missed_block_penalty*/ ) = 0;
          virtual signed_block_ptr produce_empty_block( fc::microseconds skip_time = fc::milliseconds(config::block_interval_ms), uint32_t skip_flag = 0/*skip_missed_block_penalty*/ ) = 0;
          virtual signed_block_ptr finish_block() = 0;
-         void                 produce_blocks( uint32_t n = 1, bool empty = false );
+         signed_block_ptr     wait_irreversible_block( uint32_t, bool empty_blocks = false );
+         signed_block_ptr     produce_blocks( uint32_t n = 1, bool empty = false );
          void                 produce_blocks_until_end_of_round();
          void                 produce_blocks_for_n_rounds(const uint32_t num_of_rounds = 1);
          // Produce minimal number of blocks as possible to spend the given time without having any producer become inactive

--- a/tools/strace_decode.py
+++ b/tools/strace_decode.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+import sys
+import subprocess
+from pprint import pprint
+
+class LineInfo:
+    full = ''
+    num  = 0
+    addr = ''
+    exe  = ''
+
+
+class Addr2LineDecoder:
+    args   = []
+    result = {}
+    addr   = ''
+    source = ''
+
+    def __init__(self, exe):
+        self.args = ['/usr/bin/addr2line', '-Cfipe', exe, '-a']
+
+    def add_addr(self, addr):
+        self.args.append(addr)
+
+    def add_source(self):
+        if self.addr != '':
+            self.result[self.addr] = self.source.rstrip('\r\n')
+        self.addr    = ''
+        self.source  = ''
+
+    def decode_addrs(self):
+        proc = subprocess.Popen(self.args, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+        self.result = {}
+        self.addr   = ''
+        self.source = ''
+
+        for line in proc.stdout.readlines():
+            line = line.decode('ascii')
+            if line.startswith('0x'):
+                self.add_source()
+
+                pos = line.index(': ')
+                self.addr   = line[0: pos]
+                self.source = line[pos + 2: len(line)]
+            else:
+                self.source += line
+
+        self.add_source()
+
+
+class Addr2LineMap:
+    decoders = {}
+
+    def add_addr(self, exe, addr):
+        self.decoders.setdefault(exe, Addr2LineDecoder(exe)).add_addr(addr)
+
+    def decode_addrs(self):
+        for dec in self.decoders.values():
+            dec.decode_addrs()
+
+    def get_addr(self, exe, addr):
+        return self.decoders[exe].result[addr.lower()]
+
+
+strace = []
+addr2line = Addr2LineMap()
+
+for line in sys.stdin:
+    words = line.strip().split(' ')
+
+    info = LineInfo()
+    info.full = line.rstrip('\r\n')
+    if len(words) > 2 and words[0].endswith('#') and words[1].startswith('0x') and words[2] == 'in':
+        info.num  = int(words[0].strip('#'))
+        info.exe  = words[3]
+        info.addr = words[1]
+        addr2line.add_addr(info.exe, info.addr)
+
+    strace.append(info)
+
+addr2line.decode_addrs()
+print('')
+for info in strace:
+    if info.exe == '':
+        print(info.full)
+    else:
+        print('{:2}# {} in {}'.format(info.num, addr2line.get_addr(info.exe, info.addr), info.exe))

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -2,6 +2,7 @@
 #include <eosio/testing/tester.hpp>
 #include <eosio/chain/abi_serializer.hpp>
 #include <eosio/chain/fork_database.hpp>
+#include <eosio/chain/random.hpp>
 
 #include <eosio.token/eosio.token.wast.hpp>
 #include <eosio.token/eosio.token.abi.hpp>
@@ -360,18 +361,19 @@ BOOST_AUTO_TEST_CASE( read_modes ) try {
 
    tester head(tester::default_config("_HEAD_"), true, db_read_mode::HEAD);
    push_blocks(c, head);
-   BOOST_REQUIRE_EQUAL(head_block_num, head.control->fork_db_head_block_num());
-   BOOST_REQUIRE_EQUAL(head_block_num, head.control->head_block_num());
+   BOOST_CHECK_EQUAL(head_block_num, head.control->fork_db_head_block_num());
+   BOOST_CHECK_EQUAL(head_block_num, head.control->head_block_num());
 
    tester read_only(tester::default_config("_READ_ONLY_"), false, db_read_mode::READ_ONLY);
    push_blocks(c, read_only);
-   BOOST_REQUIRE_EQUAL(head_block_num, read_only.control->fork_db_head_block_num());
-   BOOST_REQUIRE_EQUAL(head_block_num, read_only.control->head_block_num());
+   BOOST_CHECK_EQUAL(head_block_num, read_only.control->fork_db_head_block_num());
+   BOOST_CHECK_EQUAL(head_block_num, read_only.control->head_block_num());
 
    tester irreversible(tester::default_config("_IRREVERSIBLE_"), true, db_read_mode::IRREVERSIBLE);
    push_blocks(c, irreversible);
-   BOOST_REQUIRE_EQUAL(head_block_num, irreversible.control->fork_db_head_block_num());
-   BOOST_REQUIRE_EQUAL(head_block_num - (config::producer_repetitions * 4 + 1), irreversible.control->head_block_num());
+   BOOST_CHECK_EQUAL(head_block_num, irreversible.control->fork_db_head_block_num());
+   // depends on shuffle
+   BOOST_CHECK_EQUAL(196, irreversible.control->head_block_num());
 
 } FC_LOG_AND_RETHROW()
 

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -268,60 +268,65 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, TESTER ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( producer_schedule_reduction, tester ) try {
-   create_accounts( {N(alice),N(bob),N(carol)} );
-   produce_block();
+   BOOST_TEST_MESSAGE("producer_schedule_reduction");
 
-   auto compare_schedules = [&]( const vector<producer_key>& a, const producer_schedule_type& b ) {
-      return std::equal( a.begin(), a.end(), b.producers.begin(), b.producers.end() );
-   };
+   create_accounts( {N(alice),N(bob),N(carol)} );
+   auto b = produce_blocks( config::producer_repetitions );
 
    auto res = set_producers( {N(alice),N(bob),N(carol)} );
    vector<producer_key> sch1 = {
                                  {N(alice), get_public_key(N(alice), "active")},
                                  {N(bob),   get_public_key(N(bob),   "active")},
-                                 {N(carol),   get_public_key(N(carol),   "active")}
+                                 {N(carol), get_public_key(N(carol), "active")}
                                };
-   wlog("set producer schedule to [alice,bob,carol]");
-   BOOST_REQUIRE_EQUAL( true, control->proposed_producers().valid() );
+   // One BP shift LIB on each series
+
+   BOOST_TEST_MESSAGE("-- set producer schedule to [alice,bob,carol]");
+   BOOST_CHECK_EQUAL( true, control->proposed_producers().valid() );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *control->proposed_producers() ) );
    BOOST_CHECK_EQUAL( control->pending_producers().version, 0 );
-   produce_block(); // Starts new block which promotes the proposed schedule to pending
+   // Starts new block which promotes the proposed schedule to pending
+   b = produce_blocks( config::producer_repetitions ); // One BP shift LIB
    BOOST_CHECK_EQUAL( control->pending_producers().version, 1 );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, control->pending_producers() ) );
    BOOST_CHECK_EQUAL( control->active_producers().version, 0 );
-   produce_block();
-   produce_block(); // Starts new block which promotes the pending schedule to active
+   // Starts new block which promotes the pending schedule to active
+   b = produce_blocks( config::producer_repetitions ); // One BP shift LIB
    BOOST_CHECK_EQUAL( control->active_producers().version, 1 );
+   b = produce_blocks( config::producer_repetitions ); // One BP shift LIB
+   BOOST_CHECK_EQUAL( control->pending_block_state()->promoting_block.slot, b->timestamp.slot );
+   shuffle( sch1, b->timestamp.slot );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, control->active_producers() ) );
-   produce_blocks(6 * config::producer_repetitions - control->head_block_num() % config::producer_repetitions);
+   b = produce_blocks( config::producer_repetitions * sch1.size() * 3 );
 
    res = set_producers( {N(alice),N(bob)} );
    vector<producer_key> sch2 = {
                                  {N(alice), get_public_key(N(alice), "active")},
                                  {N(bob),   get_public_key(N(bob),   "active")}
                                };
-   wlog("set producer schedule to [alice,bob]");
+   BOOST_TEST_MESSAGE("-- set producer schedule to [alice,bob]");
    BOOST_REQUIRE_EQUAL( true, control->proposed_producers().valid() );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch2, *control->proposed_producers() ) );
 
-   produce_blocks(4 * config::producer_repetitions);
-   BOOST_REQUIRE_EQUAL( control->head_block_producer(), N(bob) );
-   BOOST_REQUIRE_EQUAL( control->pending_block_state()->header.producer, N(carol) );
+   b = produce_block();
+   BOOST_CHECK_EQUAL( control->pending_producers().version, 1 );
+   b = wait_irreversible_block( b->block_num() );
    BOOST_CHECK_EQUAL( control->pending_producers().version, 2 );
+   BOOST_CHECK_EQUAL( true, compare_schedules( sch2, control->pending_producers() ) );
 
-   produce_blocks(4 * config::producer_repetitions - 1);
    BOOST_CHECK_EQUAL( control->active_producers().version, 1 );
-   produce_blocks(1);
-
-   BOOST_REQUIRE_EQUAL( control->head_block_producer(), N(carol) );
-   BOOST_REQUIRE_EQUAL( control->pending_block_state()->header.producer, N(alice) );
+   b = produce_block();
+   b = wait_irreversible_block( b->block_num() );
    BOOST_CHECK_EQUAL( control->active_producers().version, 2 );
+   BOOST_CHECK_EQUAL( control->pending_block_state()->promoting_block.slot, b->timestamp.slot );
+   shuffle( sch2, b->timestamp.slot );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch2, control->active_producers() ) );
+   b = produce_block( );
 
-   produce_blocks(2);
-   BOOST_CHECK_EQUAL( control->head_block_producer(), N(bob) );
+   BOOST_CHECK_EQUAL( control->head_block_producer(), get_expected_producer( sch2, b->timestamp.slot ) );
 
    BOOST_REQUIRE_EQUAL( validate(), true );
+
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( empty_producer_schedule_has_no_effect, tester ) try {

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -221,19 +221,24 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, TESTER ) try {
    BOOST_CHECK_EQUAL( true, control->proposed_producers().valid() );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *control->proposed_producers() ) );
    BOOST_CHECK_EQUAL( control->pending_producers().version, 0 );
+
    // Starts new block which promotes the proposed schedule to pending
    b = produce_blocks( config::producer_repetitions ); // One BP shift LIB
    BOOST_CHECK_EQUAL( control->pending_producers().version, 1 );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, control->pending_producers() ) );
    BOOST_CHECK_EQUAL( control->active_producers().version, 0 );
+
    // Starts new block which promotes the pending schedule to active
    b = produce_blocks( config::producer_repetitions ); // One BP shift LIB
    BOOST_CHECK_EQUAL( control->active_producers().version, 1 );
+
    b = produce_blocks( config::producer_repetitions );
    BOOST_CHECK_EQUAL( control->pending_block_state()->promoting_block.slot, b->timestamp.slot );
    shuffle( sch1, b->timestamp.slot );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, control->active_producers() ) );
-   b = produce_blocks( config::producer_repetitions * sch1.size() * 3 );
+
+   // Produce many blocks with active producers
+   b = produce_blocks( config::producer_repetitions * sch1.size() * 10 );
 
    // Now, we have more than 1 BP and random schedule, LIB shifts on changing of BPs
 
@@ -253,15 +258,16 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, TESTER ) try {
    b = wait_irreversible_block( b->block_num() );
    BOOST_CHECK_EQUAL( control->pending_producers().version, 2 );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch2, control->pending_producers() ) );
-
    BOOST_CHECK_EQUAL( control->active_producers().version, 1 );
+
    b = produce_block();
    b = wait_irreversible_block( b->block_num() );
    BOOST_CHECK_EQUAL( control->active_producers().version, 2 );
+   BOOST_CHECK_EQUAL( control->pending_block_state()->promoting_block.slot, b->timestamp.slot );
    shuffle( sch2, b->timestamp.slot );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch2, control->active_producers() ) );
-   b = produce_block( );
 
+   b = produce_block();
    BOOST_CHECK_EQUAL( control->head_block_producer(), get_expected_producer( sch2, b->timestamp.slot ) );
 
    BOOST_REQUIRE_EQUAL( validate(), true );
@@ -285,11 +291,13 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_reduction, tester ) try {
    BOOST_CHECK_EQUAL( true, control->proposed_producers().valid() );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *control->proposed_producers() ) );
    BOOST_CHECK_EQUAL( control->pending_producers().version, 0 );
+
    // Starts new block which promotes the proposed schedule to pending
    b = produce_blocks( config::producer_repetitions ); // One BP shift LIB
    BOOST_CHECK_EQUAL( control->pending_producers().version, 1 );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, control->pending_producers() ) );
    BOOST_CHECK_EQUAL( control->active_producers().version, 0 );
+
    // Starts new block which promotes the pending schedule to active
    b = produce_blocks( config::producer_repetitions ); // One BP shift LIB
    BOOST_CHECK_EQUAL( control->active_producers().version, 1 );
@@ -297,7 +305,9 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_reduction, tester ) try {
    BOOST_CHECK_EQUAL( control->pending_block_state()->promoting_block.slot, b->timestamp.slot );
    shuffle( sch1, b->timestamp.slot );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, control->active_producers() ) );
-   b = produce_blocks( config::producer_repetitions * sch1.size() * 3 );
+
+   // Producer many blocks with active producers
+   b = produce_blocks( config::producer_repetitions * sch1.size() * 10 );
 
    res = set_producers( {N(alice),N(bob)} );
    vector<producer_key> sch2 = {
@@ -313,16 +323,16 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_reduction, tester ) try {
    b = wait_irreversible_block( b->block_num() );
    BOOST_CHECK_EQUAL( control->pending_producers().version, 2 );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch2, control->pending_producers() ) );
-
    BOOST_CHECK_EQUAL( control->active_producers().version, 1 );
+
    b = produce_block();
    b = wait_irreversible_block( b->block_num() );
    BOOST_CHECK_EQUAL( control->active_producers().version, 2 );
    BOOST_CHECK_EQUAL( control->pending_block_state()->promoting_block.slot, b->timestamp.slot );
    shuffle( sch2, b->timestamp.slot );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch2, control->active_producers() ) );
-   b = produce_block( );
 
+   b = produce_block( );
    BOOST_CHECK_EQUAL( control->head_block_producer(), get_expected_producer( sch2, b->timestamp.slot ) );
 
    BOOST_REQUIRE_EQUAL( validate(), true );
@@ -348,25 +358,31 @@ BOOST_FIXTURE_TEST_CASE( empty_producer_schedule_has_no_effect, tester ) try {
    BOOST_CHECK_EQUAL( true, control->proposed_producers().valid() );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *control->proposed_producers() ) );
    BOOST_CHECK_EQUAL( control->pending_producers().version, 0 );
+
    // Starts new block which promotes the proposed schedule to pending
    b = produce_blocks( config::producer_repetitions ); // One BP shift LIB
    BOOST_CHECK_EQUAL( control->pending_producers().version, 1 );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, control->pending_producers() ) );
    BOOST_CHECK_EQUAL( control->active_producers().version, 0 );
+
    // Starts new block which promotes the pending schedule to active
    b = produce_blocks( config::producer_repetitions ); // One BP shift LIB
    BOOST_CHECK_EQUAL( control->active_producers().version, 1 );
+
    b = produce_blocks( config::producer_repetitions );
    BOOST_CHECK_EQUAL( control->pending_block_state()->promoting_block.slot, b->timestamp.slot );
    shuffle( sch1, b->timestamp.slot );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, control->active_producers() ) );
-   b = produce_blocks( config::producer_repetitions * sch1.size() * 3 );
+
+   // Producer many blocks with active producers
+   b = produce_blocks( config::producer_repetitions * sch1.size() * 10 );
 
    res = set_producers( {} );
    BOOST_TEST_MESSAGE("-- set producer schedule to []");
    BOOST_CHECK_EQUAL( true, control->proposed_producers().valid() );
    BOOST_CHECK_EQUAL( control->proposed_producers()->producers.size(), 0 );
    BOOST_CHECK_EQUAL( control->proposed_producers()->version, 2 );
+
    b = produce_block();
    BOOST_CHECK_EQUAL( control->pending_producers().version, 1 );
    b = wait_irreversible_block( b->block_num() );
@@ -395,6 +411,7 @@ BOOST_FIXTURE_TEST_CASE( empty_producer_schedule_has_no_effect, tester ) try {
    BOOST_CHECK_EQUAL( control->active_producers().version, 1 );
    BOOST_CHECK_EQUAL( control->pending_producers().version, 2 );
    BOOST_CHECK_EQUAL( 0, control->pending_producers().producers.size() );
+
    b = wait_irreversible_block( b->block_num() );
    BOOST_CHECK_EQUAL( control->active_producers().version, 1 );
    BOOST_CHECK_EQUAL( control->pending_producers().version, 2 );
@@ -406,6 +423,9 @@ BOOST_FIXTURE_TEST_CASE( empty_producer_schedule_has_no_effect, tester ) try {
    BOOST_CHECK_EQUAL( control->pending_block_state()->promoting_block.slot, b->timestamp.slot );
    shuffle( sch2, b->timestamp.slot );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch2, control->active_producers() ) );
+
+   b = produce_block( );
+   BOOST_CHECK_EQUAL( control->head_block_producer(), get_expected_producer( sch2, b->timestamp.slot ) );
 
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW()


### PR DESCRIPTION
Resolve #395 

After integrating of random to schedule of producers, several unit tests were broken.
This PR adapts blocks, forking and producers unit tests to random schedule of producers.