### PR TITLE
Make chain_id depending on generic genesis hash #445

### DIFF
--- a/libraries/chain/genesis/genesis_import.cpp
+++ b/libraries/chain/genesis/genesis_import.cpp
@@ -34,11 +34,8 @@ struct genesis_import::impl final {
     }
 
     void import_state() {
-        // TODO: checksum
-        EOS_ASSERT(fc::is_regular_file(_state_file), extract_genesis_exception,
-            "Genesis state file '${f}' does not exist.", ("f", _state_file.generic_string()));
+        // file existance already checked when calculated hash
         std::cout << "Reading state from " << _state_file << "..." << std::endl;
-
         bfs::ifstream in(_state_file);
         genesis_header h{"", 0, 0};
         in.read((char*)&h, sizeof(h));

--- a/libraries/chain/include/eosio/chain/genesis_state.hpp
+++ b/libraries/chain/include/eosio/chain/genesis_state.hpp
@@ -44,6 +44,7 @@ struct genesis_state {
 
    time_point                               initial_timestamp;
    public_key_type                          initial_key;
+   fc::sha256                               genesis_hash;      // hash of generic genesis file
 
    /**
     * Get the chain_id corresponding to this genesis state.
@@ -65,4 +66,4 @@ struct genesis_state {
 
 
 FC_REFLECT(eosio::chain::genesis_state,
-           (initial_timestamp)(initial_key)(initial_configuration))
+           (initial_timestamp)(initial_key)(genesis_hash)(initial_configuration))

--- a/libraries/chain/include/eosio/chain/genesis_state.hpp
+++ b/libraries/chain/include/eosio/chain/genesis_state.hpp
@@ -44,7 +44,9 @@ struct genesis_state {
 
    time_point                               initial_timestamp;
    public_key_type                          initial_key;
-   fc::sha256                               genesis_hash;      // hash of generic genesis file
+   fc::sha256                               genesis_data_hash;      // hash of generic genesis file
+   // TODO: event_engine_data_hash #453
+
 
    /**
     * Get the chain_id corresponding to this genesis state.
@@ -66,4 +68,4 @@ struct genesis_state {
 
 
 FC_REFLECT(eosio::chain::genesis_state,
-           (initial_timestamp)(initial_key)(genesis_hash)(initial_configuration))
+           (initial_timestamp)(initial_key)(genesis_data_hash)(initial_configuration))


### PR DESCRIPTION
The following checked:
1. if file targeted with `--genesis-json` option contains non-empty `genesis_data_hash` field, then `--genesis-data` option required
2. if `--genesis-data` option set, then `--genesis-json` required and it's `genesis_data_hash` field should not be empty
3. if 1. or 2., then calculated SHA256 hash of genesis data file should be equal to value provided in `genesis_data_hash` field of genesis.json
4. if `genesis_data_hash` value is empty, then `--genesis-data` must not be set