### PR TITLE
Asset and symbol as string in API answers

### DIFF
--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -97,10 +97,9 @@ namespace eosio { namespace chain {
       built_in_types.emplace("public_key",                pack_unpack<public_key_type>());
       built_in_types.emplace("signature",                 pack_unpack<signature_type>());
 
-      built_in_types.emplace("symbol",                    pack_unpack<symbol>());
+      built_in_types.emplace("symbol",                    pack_unpack<symbol_info>());
       built_in_types.emplace("symbol_code",               pack_unpack<symbol_code>());
-      built_in_types.emplace("asset",                     pack_unpack<asset>());
-      built_in_types.emplace("extended_asset",            pack_unpack<extended_asset>());
+      built_in_types.emplace("asset",                     pack_unpack<asset_info>());
    }
 
    void abi_serializer::disable_check_field_name() {


### PR DESCRIPTION
Resolve #457 

For internal structures (chaindb as an example) the `asset` is stored in a `variant` as `asset_info` structure.
For external communications (API an example) the `asset` is encoded as string.

The same is done for the `symbol_code`.

An additional change - `extended_asset` is removed. 
It contains the field `contract`, and declared as a builtin type.
But it doesn't used in any system contract, and can be declared in a contract as an internal structure.

The same is done for the `extended_symbol`.

IMHO, the `asset` is not required for chain structure. It can be removed too.