### PR TITLE
Refactor cache layer for chaindb

### DIFF
--- a/CMakeModules/ChaindbMongo.cmake
+++ b/CMakeModules/ChaindbMongo.cmake
@@ -35,7 +35,7 @@ if (BUILD_CYBERWAY_CHAINDB_MONGO)
         set(CHAINDB_DEFS ${CHAINDB_DEFS} CYBERWAY_CHAINDB=1 ${LIBMONGOCXX_STATIC_DEFINITIONS} ${LIBBSONCXX_STATIC_DEFINITIONS})
         set(CHAINDB_INCS ${CHAINDB_INCS} ${BSON_INCLUDE_DIRS} ${LIBMONGOCXX_STATIC_INCLUDE_DIRS} ${LIBBSONCXX_STATIC_INCLUDE_DIRS})
         set(CHAINDB_LIBS ${CHAINDB_LIBS} ${CHAINDB_LIBMONGOCXX} ${CHAINDB_LIBBSONCXX} ${BSON_LIBRARIES})
-        set(CHAINDB_SRCS ${CHAINDB_SRCS} chaindb/mongo_driver.cpp chaindb/mongo_driver_utils.cpp chaindb/mongo_big_int_converter.cpp)
+        set(CHAINDB_SRCS ${CHAINDB_SRCS} chaindb/mongo_driver.cpp chaindb/mongo_driver_utils.cpp chaindb/mongo_bigint_converter.cpp)
 
     else()
         message("Could NOT find MongoDB. chaindb with MongoDB support will not be included.")

--- a/contracts/eosiolib/chaindb.h
+++ b/contracts/eosiolib/chaindb.h
@@ -17,12 +17,13 @@ typedef uint64_t primary_key_t;
 static constexpr primary_key_t end_primary_key = static_cast<primary_key_t>(-1);
 static constexpr primary_key_t unset_primary_key = static_cast<primary_key_t>(-2);
 
-cursor_t chaindb_opt_find_by_pk(account_name_t code, scope_t scope, table_name_t table, primary_key_t pk);
-
-cursor_t chaindb_lower_bound(account_name_t code, scope_t scope, table_name_t, index_name_t, void* key, size_t);
-cursor_t chaindb_upper_bound(account_name_t code, scope_t scope, table_name_t, index_name_t, void* key, size_t);
-cursor_t chaindb_find(account_name_t code, scope_t scope, table_name_t, index_name_t, primary_key_t, void* key, size_t);
+cursor_t chaindb_begin(account_name_t code, scope_t scope, table_name_t, index_name_t);
 cursor_t chaindb_end(account_name_t code, scope_t scope, table_name_t, index_name_t);
+cursor_t chaindb_lower_bound(account_name_t code, scope_t scope, table_name_t, index_name_t, void* key, size_t);
+cursor_t chaindb_lower_bound_pk(account_name_t code, scope_t scope, table_name_t, primary_key_t);
+cursor_t chaindb_upper_bound(account_name_t code, scope_t scope, table_name_t, index_name_t, void* key, size_t);
+cursor_t chaindb_upper_bound_pk(account_name_t code, scope_t scope, table_name_t, primary_key_t);
+cursor_t chaindb_locate_to(account_name_t code, scope_t scope, table_name_t, index_name_t, primary_key_t, void* key, size_t);
 cursor_t chaindb_clone(account_name_t code, cursor_t);
 
 void chaindb_close(account_name_t code, cursor_t);
@@ -36,8 +37,8 @@ primary_key_t chaindb_data(account_name_t code, cursor_t, void* data, const size
 
 primary_key_t chaindb_available_primary_key(account_name_t code, scope_t scope, table_name_t table);
 
-primary_key_t chaindb_insert(account_name_t code, scope_t scope, table_name_t, account_name_t payer, primary_key_t, void* data, size_t);
-primary_key_t chaindb_update(account_name_t code, scope_t scope, table_name_t, account_name_t payer, primary_key_t, void* data, size_t);
+primary_key_t chaindb_insert(account_name_t code, scope_t scope, account_name_t payer, table_name_t, primary_key_t, void* data, size_t);
+primary_key_t chaindb_update(account_name_t code, scope_t scope, account_name_t payer, table_name_t, primary_key_t, void* data, size_t);
 primary_key_t chaindb_delete(account_name_t code, scope_t scope, table_name_t, primary_key_t);
 
 #ifdef __cplusplus

--- a/contracts/proxy/proxy.cpp
+++ b/contracts/proxy/proxy.cpp
@@ -12,9 +12,9 @@ namespace proxy {
    namespace configs {
 
       bool get(config &out, const account_name &self) {
-         auto it = chaindb_opt_find_by_pk(self, self, N(configs), out.key);
+         auto it = chaindb_lower_bound_pk(self, self, N(configs), out.key);
          auto pk = chaindb_current(self, it);
-         if (pk != end_primary_key) {
+         if (pk == out.key) {
             auto size = chaindb_datasize(self, it);
             eosio_assert(size == sizeof(config), "Wrong record size");
             chaindb_data(self, it, (void*)&out, sizeof(config));
@@ -25,9 +25,9 @@ namespace proxy {
       }
 
       void store(const config &in, const account_name &self) {
-         auto it = chaindb_opt_find_by_pk(self, self, N(configs), in.key);
+         auto it = chaindb_lower_bound_pk(self, self, N(configs), in.key);
          auto pk = chaindb_current(self, it);
-         if (pk != end_primary_key) {
+         if (pk == in.key) {
             chaindb_update(self, self, N(configs), self, in.key, (void *)&in, sizeof(config));
          } else {
             chaindb_insert(self, self, N(configs), self, in.key, (void *)&in, sizeof(config));

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -62,7 +62,7 @@ void apply_context::exec_one( action_trace& trace )
             try {
                cyberway::chaindb::chaindb_guard guard(chaindb, receiver);
                control.get_wasm_interface().apply( a.code_version, a.code, *this );
-               chaindb.apply_all_changes();
+               chaindb.apply_code_changes(a.name);
             } catch( const wasm_exit& ) {}
          }
       } FC_RETHROW_EXCEPTIONS(warn, "pending console output: ${console}", ("console", _pending_console_output.str()))

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -162,9 +162,10 @@ namespace cyberway { namespace chaindb {
 
         void build_cache_indicies(cache_object& cache, cache_indicies& indicies) {
             auto& object  = cache.object();
-            auto& service = cache.service();
+            if (object.is_null()) return;
 
-            auto ctr = abi_map_.find(service.code);
+            auto& service = cache.service();
+            auto  ctr = abi_map_.find(service.code);
             if (abi_map_.end() == ctr) return;
 
             auto& abi = ctr->second;
@@ -178,8 +179,10 @@ namespace cyberway { namespace chaindb {
             for (auto& i: ttr->indexes) if (i.unique && i.name != names::primary_index) {
                 info.index = &i;
 
+                auto bytes = abi.to_bytes(info, object.value); // size of this object is 1 Mb
+                if (bytes.empty()) continue;
+
                 using data_t = cache_index_value::data_t;
-                auto  bytes =  abi.to_bytes(info, object.value);   // 1 Mb
                 auto  data  =  data_t(bytes.begin(), bytes.end()); // minize memory usage
                 indicies.emplace_back(i.name, std::move(data), cache);
                 CYBERWAY_ASSERT(cache_index_tree_.end() == cache_index_tree_.find(indicies.back()),

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -1,159 +1,268 @@
 #include <cyberway/chaindb/cache_map.hpp>
 #include <cyberway/chaindb/controller.hpp>
-#include <cyberway/chaindb/table_object.hpp>
 
 namespace cyberway { namespace chaindb {
 
-    struct table_cache_object final: public table_object::object {
-        table_cache_object(const table_info& src, const cache_converter_interface& converter)
-        : object(src),
-          converter_(converter) {
+    struct cache_item_compare {
+        bool operator()(const service_state& l, const service_state& r) const {
+            if (l.pk    < r.pk   ) return true;
+            if (l.pk    > r.pk   ) return false;
+
+            if (l.table < r.table) return true;
+            if (l.table > r.table) return false;
+
+            if (l.code  < r.code ) return true;
+            if (l.code  > r.code ) return false;
+
+            return l.scope < r.scope;
         }
 
-        using map_type = fc::flat_map<primary_key_t, cache_item_ptr>;
+        bool operator()(const cache_item& l, const cache_item& r) const {
+            return (*this)(l.object().service, r.object().service);
+        }
 
-        map_type map;
+        bool operator()(const cache_item& l, const service_state& r) const {
+            return (*this)(l.object().service, r);
+        }
+
+        bool operator()(const service_state& l, const cache_item& r) const {
+            return (*this)(l, r.object().service);
+        }
+    }; // struct cache_compare
+
+    bool operator<(const cache_item& l, const cache_item& r) {
+        return cache_item_compare()(l, r);
+    }
+
+    struct cache_service_key final {
+        account_name code;
+        table_name table;
+
+        cache_service_key(const object_value& obj)
+        : code(obj.service.code), table(obj.service.table) {
+        }
+
+        cache_service_key(const table_info& tab)
+        : code(tab.code), table(tab.table->name) {
+        }
+
+        cache_service_key(cache_service_key&&) = default;
+        cache_service_key(const cache_service_key&) = default;
+
+        friend bool operator<(const cache_service_key& l, const cache_service_key& r) {
+            if (l.code < r.code) return true;
+            if (l.code > r.code) return false;
+            return l.table < r.table;
+        }
+    }; // cache_service_key
+
+    struct cache_service_info final {
+        int cache_item_cnt = 0;
         primary_key_t next_pk = unset_primary_key;
+        const cache_converter_interface* converter = nullptr; // exist only for interchain tables
+
+        bool empty() const {
+            assert(cache_item_cnt >= 0);
+            return (converter == nullptr /* info for contacts tables */) && (cache_item_cnt == 0);
+        }
+    }; // struct cache_service_info
+
+    struct table_cache_map final {
+        ~table_cache_map() {
+            clear();
+        }
+
+        cache_item* find(const service_state& key) {
+            auto itr = cache_tree_.find(key, cache_item_compare());
+            if (cache_tree_.end() != itr) {
+                return &(*itr);
+            }
+
+            return nullptr;
+        }
 
         cache_item_ptr emplace(object_value obj) {
-            auto pk = obj.pk();
-            auto itr = map.find(pk);
+            auto& cache_service = get_cache_service(obj);
+            auto  cache_ptr     = cache_item_ptr(find(obj.service));
 
-            if (map.end() == itr) {
-                cache_item_ptr itm = new cache_item(std::move(obj));
-                itr = map.emplace(pk, std::move(itm)).first;
+            if (!cache_ptr) {
+                cache_ptr = cache_item_ptr(new cache_item(*this, std::move(obj)));
+
+                // self incrementing of ref counter allows to use object w/o an additional storage
+                //   self decrementing happens in remove()
+                intrusive_ptr_add_ref(cache_ptr.get());
+
+
+                cache_tree_.insert(*cache_ptr.get());
+                cache_service.cache_item_cnt++;
             } else {
-                itr->second->set_object(std::move(obj));
+                // updating of an exist cache item
+                cache_ptr->set_object(std::move(obj));
+
+                auto lru_itr = lru_list_.iterator_to(*cache_ptr.get());
+                lru_list_.erase(lru_itr);
             }
-            if (!itr->second->object().is_null()) {
-                itr->second->data = converter_.convert_variant(*itr->second, itr->second->object());
+
+            lru_list_.push_back(*cache_ptr.get());
+
+            // emplace happens in three cases:
+            //   1. create object for interchain tables ->  object().is_null()
+            //   2. loading object from chaindb         -> !object().is_null()
+            //   3. restore from undo state             -> !object().is_null()
+            if (cache_service.converter && !cache_ptr->object().is_null()) {
+                cache_ptr->data = cache_service.converter->convert_variant(*cache_ptr.get(), cache_ptr->object());
             }
-            return itr->second;
+
+            // TODO: cache size should be configurable
+            if (lru_list_.size() > 100'000) {
+                auto& cache_itm = lru_list_.front();
+                cache_itm.mark_deleted();
+            }
+
+            return cache_ptr;
         }
 
-    private:
-        const cache_converter_interface& converter_;
-    }; // struct table_cache_object
+        void remove(cache_item& itm) {
+            // self decrementing of ref counter, see emplace()
+            auto cache_ptr   = cache_item_ptr(&itm, false);
+            auto tree_itr    = cache_tree_.iterator_to(itm);
+            auto list_itr    = lru_list_.iterator_to(itm);
+            auto service_itr = service_tree_.find(itm.object());
 
-    using table_cache_object_index = table_object::index<table_cache_object>;
+            cache_tree_.erase(tree_itr);
+            lru_list_.erase(list_itr);
 
-    struct cache_map::cache_map_impl_ final {
-        cache_map_impl_() = default;
-        ~cache_map_impl_() = default;
+            if (service_tree_.end() == service_itr) {
+                return;
+            }
 
-        table_cache_object* find(const table_info& table) {
-            auto itr = table_object::find(index_, table);
-            if (index_.end() != itr) return &const_cast<table_cache_object&>(*itr);
-
-            return nullptr;
+            service_itr->second.cache_item_cnt--;
+            if (service_itr->second.empty()) {
+                service_tree_.erase(service_itr);
+            }
         }
 
-        table_cache_object* find_without_scope(const table_info& table) {
-            auto itr = table_object::find_without_scope(index_, table);
-            if (index_.end() != itr) return &const_cast<table_cache_object&>(*itr);
-
-            return nullptr;
+        void remove(const service_state& key) {
+            auto ptr = find(key);
+            if (ptr) {
+                ptr->mark_deleted();
+            }
         }
 
-        void set_converter(const table_info& table, const cache_converter_interface& converter) {
-            auto cache = find(table);
-            if (cache) return;
-
-            table_object::emplace(index_, table, converter);
+        void set_revision(const service_state& key, const revision_t rev) {
+            auto ptr = find(key);
+            if (ptr) {
+                ptr->set_revision(rev);
+            }
         }
 
-        void erase(table_cache_object& cache) {
-            index_.erase(index_.iterator_to(cache));
+        primary_key_t get_next_pk(const table_info& table) {
+            auto ptr = find_cache_service(table);
+            if (ptr && unset_primary_key != ptr->next_pk) {
+                return ptr->next_pk++;
+            }
+            return unset_primary_key;
+        }
+
+        void set_next_pk(const table_info& table, const primary_key_t pk) {
+            auto ptr = find_cache_service(table);
+            if (ptr) {
+                ptr->next_pk = pk;
+            }
+        }
+
+        void set_cache_converter(const table_info& table, const cache_converter_interface& converter) {
+            get_cache_service(table).converter = &converter;
         }
 
         void clear() {
-            for (auto& table: index_) {
-                const_cast<table_cache_object&>(table).map.clear();
-                const_cast<table_cache_object&>(table).next_pk = unset_primary_key;
+            cache_tree_.clear();
+            while (!lru_list_.empty()) {
+                // self decrementing of ref counter, see emplace()
+                auto cache_ptr = cache_item_ptr(&lru_list_.front(), false);
+                lru_list_.pop_front();
+            }
+
+            for (auto itr = service_tree_.begin(), etr = service_tree_.end(); etr != itr; ) {
+                itr->second.cache_item_cnt = 0;
+                if (itr->second.empty()) {
+                    itr = service_tree_.erase(itr);
+                } else {
+                    ++itr;
+                }
             }
         }
 
     private:
-        table_cache_object_index index_;
-    }; // struct cache_map::cache_map_impl_
+        using cache_tree_type   = boost::intrusive::set<cache_item>;
+        using lru_list_type     = boost::intrusive::list<cache_item, boost::intrusive::constant_time_size<true>>;
+        using service_tree_type = std::map<cache_service_key, cache_service_info>;
+
+        cache_tree_type   cache_tree_;
+        lru_list_type     lru_list_;
+        service_tree_type service_tree_;
+
+        template <typename Table>
+        cache_service_info& get_cache_service(const Table& table) {
+            return service_tree_.emplace(cache_service_key(table), cache_service_info()).first->second;
+        }
+
+        template <typename Table>
+        cache_service_info* find_cache_service(const Table& table) {
+            auto itr = service_tree_.find({table});
+            if (service_tree_.end() != itr) {
+                return &itr->second;
+            }
+            return nullptr;
+        }
+    }; // struct table_cache_map
+
+    void cache_item::mark_deleted() {
+        assert(table_cache_map_);
+        auto& map = *table_cache_map_;
+        table_cache_map_ = nullptr;
+        map.remove(*this);
+    }
 
     cache_map::cache_map()
-    : impl_(new cache_map_impl_()) {
+    : impl_(new table_cache_map()) {
     }
 
     cache_map::~cache_map() = default;
 
     void cache_map::set_cache_converter(const table_info& table, const cache_converter_interface& converter) const  {
-        impl_->set_converter(table, converter);
+        impl_->set_cache_converter(table, converter);
     }
 
     cache_item_ptr cache_map::create(const table_info& table) const {
-        cache_item_ptr item;
-        auto cache_pk = impl_->find_without_scope(table);
-        if (BOOST_LIKELY(cache_pk && cache_pk->next_pk != unset_primary_key)) {
-            const auto pk = cache_pk->next_pk++;
-            auto cache_value = impl_->find(table);
-            if (cache_value) {
-                return cache_value->emplace({{table, pk}, {}});
-            }
+        auto pk = impl_->get_next_pk(table);
+        if (BOOST_UNLIKELY(unset_primary_key == pk)) {
+            return {};
         }
-        return cache_item_ptr();
+        return impl_->emplace({{table, pk}, {}});
     }
 
     void cache_map::set_next_pk(const table_info& table, const primary_key_t pk) const {
-        auto cache = impl_->find_without_scope(table);
-        if (!cache) return;
-
-        cache->next_pk = pk;
-
-        // TODO: is it possible case?
-//        auto itr = cache->map.lower_bound(pk);
-//        for (auto etr = cache->map.end(); itr != etr; ) {
-//            cache->map.erase(itr++);
-//        }
+        impl_->set_next_pk(table, pk);
     }
 
     cache_item_ptr cache_map::find(const table_info& table, const primary_key_t pk) const {
-        cache_item_ptr item;
-        auto cache = impl_->find(table);
-        if (!cache) return item;
-
-        auto itr = cache->map.find(pk);
-        if (cache->map.end() != itr) {
-            if (itr->second->is_deleted()) {
-                cache->map.erase(itr);
-            } else {
-                return itr->second;
-            }
-        }
-
-        return item;
+        return cache_item_ptr(impl_->find({table, pk}));
     }
 
     cache_item_ptr cache_map::emplace(const table_info& table, object_value obj) const {
-        if (obj.pk() == unset_primary_key) return cache_item_ptr();
-
-        auto cache = impl_->find(table);
-        if (!cache) return cache_item_ptr();
-
-        return cache->emplace(std::move(obj));
+        assert(obj.pk() != unset_primary_key && !obj.is_null());
+        return impl_->emplace(std::move(obj));
     }
 
     void cache_map::remove(const table_info& table, const primary_key_t pk) const {
-        if (pk == unset_primary_key) return;
+        assert(pk != unset_primary_key);
+        impl_->remove({table, pk});
+    }
 
-        auto cache = impl_->find(table);
-        if (!cache) return;
-
-        auto itr = cache->map.find(pk);
-        if (itr != cache->map.end()) {
-            itr->second->mark_deleted();
-            cache->map.erase(itr);
-        }
-
-        if (cache->map.empty() && cache->code() != account_name()) {
-            impl_->erase(*cache);
-        }
+    void cache_map::set_revision(const object_value& obj, const revision_t rev) const {
+        assert(obj.pk() != unset_primary_key && impossible_revision != rev);
+        impl_->set_revision(obj.service, rev);
     }
 
     void cache_map::clear() {

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -20,7 +20,7 @@ namespace cyberway { namespace chaindb {
             auto itr = map.find(pk);
 
             if (map.end() == itr) {
-                auto itm = std::make_shared<cache_item>(std::move((obj)));
+                cache_item_ptr itm = new cache_item(std::move(obj));
                 itr = map.emplace(pk, std::move(itm)).first;
             } else {
                 itr->second->set_object(std::move(obj));

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -355,6 +355,7 @@ namespace cyberway { namespace chaindb {
         assert(table_cache_map_);
 
         object_ = std::move(obj);
+        blob_.clear();
 
         if (!is_system_code(object_.service.code) || indicies_.empty()) {
             table_cache_map_->remove_cache_indicies(std::move(indicies_));

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -342,6 +342,11 @@ namespace cyberway { namespace chaindb {
 
     //--------------
 
+    cache_object::cache_object(table_cache_map& map, object_value obj)
+    : table_cache_map_(&map), object_(std::move(obj)) {
+        table_cache_map_->build_cache_indicies(*this, indicies_);
+    }
+
     void cache_object::set_object(object_value obj) {
         assert(is_valid_table(obj.service));
         assert(table_cache_map_);

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -353,8 +353,10 @@ namespace cyberway { namespace chaindb {
 
         object_ = std::move(obj);
 
-        table_cache_map_->remove_cache_indicies(std::move(indicies_));
-        table_cache_map_->build_cache_indicies(*this, indicies_);
+        if (!is_system_code(object_.service.code) || indicies_.empty()) {
+            table_cache_map_->remove_cache_indicies(std::move(indicies_));
+            table_cache_map_->build_cache_indicies(*this, indicies_);
+        }
     }
 
     void cache_object::mark_deleted() {

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -178,36 +178,42 @@ namespace cyberway { namespace chaindb {
         }
 
         const cursor_info& lower_bound(const index_request& request, const char* key, const size_t size) const {
-            auto index = get_index(request);
-            auto value = index.abi->to_object(index, key, size);
-            return driver_.lower_bound(std::move(index), std::move(value));
+            auto  index = get_index(request);
+            auto  value = index.abi->to_object(index, key, size);
+            auto& cursor = driver_.lower_bound(std::move(index), std::move(value));
+            return driver_.current(cursor);
         }
 
         const cursor_info& upper_bound(const index_request& request, const char* key, const size_t size) const {
-            auto index = get_index(request);
-            auto value = index.abi->to_object(index, key, size);
-            return driver_.upper_bound(std::move(index), std::move(value));
+            auto  index = get_index(request);
+            auto  value = index.abi->to_object(index, key, size);
+            auto& cursor = driver_.upper_bound(std::move(index), std::move(value));
+            return driver_.current(cursor);
         }
 
         const cursor_info& lower_bound(const index_request& request, const fc::variant& orders) const {
-            auto index = get_index(request);
-            return driver_.lower_bound(std::move(index), orders);
+            auto  index = get_index(request);
+            auto& cursor = driver_.lower_bound(std::move(index), orders);
+            return driver_.current(cursor);
         }
 
         const cursor_info& upper_bound(const index_request& request, const fc::variant& orders) const {
-            auto index = get_index(request);
-            return driver_.upper_bound(std::move(index), orders);
+            auto  index = get_index(request);
+            auto& cursor = driver_.upper_bound(std::move(index), orders);
+            return driver_.current(cursor);
         }
 
-        const cursor_info& find(const index_request& request, primary_key_t pk, const char* key, size_t size) const {
-            auto index = get_index(request);
-            auto value = index.abi->to_object(index, key, size);
-            return driver_.find(std::move(index), pk, std::move(value));
+        const cursor_info& locate_to(const index_request& request, const char* key, size_t size, primary_key_t pk) const {
+            auto  index = get_index(request);
+            auto  value = index.abi->to_object(index, key, size);
+            auto& cursor = driver_.locate_to(std::move(index), std::move(value), pk);
+            return driver_.current(cursor);
         }
 
         const cursor_info& begin(const index_request& request) const {
-            auto index = get_index(request);
-            return driver_.begin(std::move(index));
+            auto  index = get_index(request);
+            auto& cursor = driver_.begin(std::move(index));
+            return driver_.current(cursor);
         }
 
         const cursor_info& end(const index_request& request) const {
@@ -362,7 +368,7 @@ namespace cyberway { namespace chaindb {
             index_info index(table);
             index.index = &get_pk_index(table);
             auto pk_key_value = _detail::get_pk_value(table, pk);
-            return driver_.opt_find_by_pk(index, pk, std::move(pk_key_value));
+            return driver_.current(driver_.lower_bound(index, std::move(pk_key_value)));
         }
 
         table_info get_table(const cache_item& itm) const {
@@ -694,9 +700,8 @@ namespace cyberway { namespace chaindb {
         return {info.id, info.pk};
     }
 
-
-    find_info chaindb_controller::find(const index_request& request, primary_key_t pk, const char* key, size_t size) {
-        const auto& info = impl_->find(request, pk, key, size);
+    find_info chaindb_controller::locate_to(const index_request& request, const char* key, size_t size, primary_key_t pk) {
+        const auto& info = impl_->locate_to(request, key, size, pk);
         return {info.id, info.pk};
     }
 

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -182,15 +182,17 @@ namespace cyberway { namespace chaindb {
         const cursor_info& lower_bound(const index_request& request, const char* key, const size_t size) const {
             auto  index  = get_index(request);
             auto  value  = index.abi->to_object(index, key, size);
-            auto  cache  = cache_.find(index, key, size);
             auto& cursor = driver_.lower_bound(std::move(index), std::move(value));
 
-            if (cache) {
-                cursor.pk = cache->pk();
-            } else {
-                driver_.current(cursor);
+            if (index.index->unique) {
+                auto cache = cache_.find(index, key, size);
+                if (cache) {
+                    cursor.pk = cache->pk();
+                    return cursor;
+                }
             }
-            return cursor;
+
+            return driver_.current(cursor);
         }
 
         const cursor_info& lower_bound(const index_request& request, const primary_key_t pk) const {

--- a/libraries/chain/chaindb/mongo_bigint_converter.cpp
+++ b/libraries/chain/chaindb/mongo_bigint_converter.cpp
@@ -6,7 +6,7 @@
 #include <fc/crypto/hex.hpp>
 
 #include <cyberway/chaindb/mongo_driver_utils.hpp>
-#include <cyberway/chaindb/mongo_big_int_converter.hpp>
+#include <cyberway/chaindb/mongo_bigint_converter.hpp>
 
 namespace cyberway { namespace chaindb {
 
@@ -15,10 +15,10 @@ namespace cyberway { namespace chaindb {
         constexpr size_t NUMBER_128_BLOB_SIZE   = sizeof(__int128) + 1;
     }
 
-    const std::string mongo_big_int_converter::BINARY_FIELD = "binary";
-    const std::string mongo_big_int_converter::STRING_FIELD = "string";
+    const std::string mongo_bigint_converter::BINARY_FIELD = "binary";
+    const std::string mongo_bigint_converter::STRING_FIELD = "string";
 
-    mongo_big_int_converter::mongo_big_int_converter(const bsoncxx::document::view& document) {
+    mongo_bigint_converter::mongo_bigint_converter(const bsoncxx::document::view& document) {
         type_ = type::invalid;
 
         auto binary_itr = document.begin();
@@ -34,7 +34,7 @@ namespace cyberway { namespace chaindb {
         parse_binary(cyberway::chaindb::build_blob_content(binary_itr->get_binary()));
     }
 
-    void mongo_big_int_converter::parse_binary(const std::vector<char> &bytes) {
+    void mongo_bigint_converter::parse_binary(const std::vector<char> &bytes) {
         if (bytes.size() != NUMBER_128_BLOB_SIZE) return;
 
         auto it = bytes.begin();
@@ -57,17 +57,17 @@ namespace cyberway { namespace chaindb {
         }
     }
 
-    mongo_big_int_converter::mongo_big_int_converter(const __int128 &int128_val) :
+    mongo_bigint_converter::mongo_bigint_converter(const __int128 &int128_val) :
         type_(type::int128) {
         value_.int128_val = int128_val;
     }
 
-    mongo_big_int_converter::mongo_big_int_converter(const unsigned __int128 &uint128_val) :
+    mongo_bigint_converter::mongo_bigint_converter(const unsigned __int128 &uint128_val) :
         type_(type::uint128) {
         value_.uint128_val = uint128_val;
     }
 
-    fc::variant mongo_big_int_converter::get_raw_value() const {
+    fc::variant mongo_bigint_converter::get_raw_value() const {
         switch (type_) {
             case type::int128: return fc::variant(value_.int128_val);
             case type::uint128: return fc::variant(value_.uint128_val);
@@ -75,11 +75,11 @@ namespace cyberway { namespace chaindb {
         }
     }
 
-    bool mongo_big_int_converter::is_valid_value() const {
+    bool mongo_bigint_converter::is_valid_value() const {
         return type_ != type::invalid;
     }
 
-    std::vector<char> mongo_big_int_converter::get_blob_value() const {
+    std::vector<char> mongo_bigint_converter::get_blob_value() const {
         switch (type_) {
             case type::int128:
                 return get_int128_blob();
@@ -91,7 +91,7 @@ namespace cyberway { namespace chaindb {
         return {};
     }
 
-    std::string mongo_big_int_converter::get_string_value() const {
+    std::string mongo_bigint_converter::get_string_value() const {
         switch (type_) {
             case type::int128:
                 return boost::lexical_cast<std::string>(value_.int128_val);
@@ -103,7 +103,7 @@ namespace cyberway { namespace chaindb {
         return std::string();
     }
 
-    std::vector<char> mongo_big_int_converter::get_int128_blob() const {
+    std::vector<char> mongo_bigint_converter::get_int128_blob() const {
         std::vector<char> blob(NUMBER_128_BLOB_SIZE);
 
         auto itr = blob.begin();
@@ -115,7 +115,7 @@ namespace cyberway { namespace chaindb {
         return blob;
     }
 
-    std::vector<char> mongo_big_int_converter::get_uint128_blob() const {
+    std::vector<char> mongo_bigint_converter::get_uint128_blob() const {
         std::vector<char> blob(NUMBER_128_BLOB_SIZE);
         auto itr = blob.begin();
 
@@ -124,7 +124,7 @@ namespace cyberway { namespace chaindb {
         return blob;
     }
 
-    void mongo_big_int_converter::fill_blob(std::vector<char>::iterator &it, const unsigned __int128& val) const {
+    void mongo_bigint_converter::fill_blob(std::vector<char>::iterator &it, const unsigned __int128& val) const {
         for (size_t i = CHAR_BIT; i <= NUMBER_128_BITS; i += CHAR_BIT, ++it) {
             const char byte = static_cast<char>(val >> (NUMBER_128_BITS - i));
             *it = byte;

--- a/libraries/chain/chaindb/mongo_driver.cpp
+++ b/libraries/chain/chaindb/mongo_driver.cpp
@@ -665,13 +665,13 @@ namespace cyberway { namespace chaindb {
 
             obj.service.pk = pk;
             build_find_pk_document(pk_doc, table, obj);
-            auto cursor = get_db_table(table).find(pk_doc.view(), options::find().limit(1));
+            auto doc = get_db_table(table).find_one(pk_doc.view());
 
-            auto itr = cursor.begin();
-            if (cursor.end() != itr) {
-                return build_object(table, *itr);
+            if (!!doc) {
+                return build_object(table, doc->view());
             } else {
-                obj.value = variant();
+                obj.clear();
+                obj.service.pk    = end_primary_key;
                 obj.service.code  = table.code;
                 obj.service.scope = table.scope;
                 obj.service.table = table.table->name;

--- a/libraries/chain/chaindb/mongo_driver.cpp
+++ b/libraries/chain/chaindb/mongo_driver.cpp
@@ -913,67 +913,67 @@ namespace cyberway { namespace chaindb {
         impl_->apply_all_changes();
     }
 
-    const cursor_info& mongodb_driver::lower_bound(index_info index, variant key) {
+    cursor_info& mongodb_driver::lower_bound(index_info index, variant key) {
         auto& cursor = impl_->create_cursor(std::move(index));
         cursor.open(direction::Forward, std::move(key), unset_primary_key);
         return cursor;
     }
 
-    const cursor_info& mongodb_driver::upper_bound(index_info index, variant key) {
+    cursor_info& mongodb_driver::upper_bound(index_info index, variant key) {
         auto& cursor = impl_->create_cursor(std::move(index));
         cursor.open(direction::Backward, std::move(key), unset_primary_key).next();
         return cursor;
     }
 
-    const cursor_info& mongodb_driver::locate_to(index_info index, variant key, primary_key_t pk) {
+    cursor_info& mongodb_driver::locate_to(index_info index, variant key, primary_key_t pk) {
         auto& cursor = impl_->create_cursor(std::move(index));
         cursor.open(direction::Forward, std::move(key), pk);
         return cursor;
     }
 
-    const cursor_info& mongodb_driver::begin(index_info index) {
+    cursor_info& mongodb_driver::begin(index_info index) {
         auto& cursor = impl_->create_cursor(std::move(index));
         cursor.open(direction::Forward, {}, unset_primary_key);
         return cursor;
     }
 
-    const cursor_info& mongodb_driver::end(index_info index) {
+    cursor_info& mongodb_driver::end(index_info index) {
         auto& cursor = impl_->create_cursor(std::move(index));
         cursor.open(direction::Backward, {}, end_primary_key);
         return cursor;
     }
 
-    const cursor_info& mongodb_driver::current(const cursor_info& info) {
+    cursor_info& mongodb_driver::current(const cursor_info& info) {
         auto& cursor = impl_->get_applied_cursor(info);
         cursor.current();
         return cursor;
     }
 
-    const cursor_info& mongodb_driver::current(const cursor_request& request) {
+    cursor_info& mongodb_driver::current(const cursor_request& request) {
         auto& cursor = impl_->get_applied_cursor(request);
         cursor.current();
         return cursor;
     }
 
-    const cursor_info& mongodb_driver::next(const cursor_request& request) {
+    cursor_info& mongodb_driver::next(const cursor_request& request) {
         auto& cursor = impl_->get_applied_cursor(request);
         cursor.next();
         return cursor;
     }
 
-    const cursor_info& mongodb_driver::next(const cursor_info& info) {
+    cursor_info& mongodb_driver::next(const cursor_info& info) {
         auto& cursor = impl_->get_applied_cursor(info);
         cursor.next();
         return cursor;
     }
 
-    const cursor_info& mongodb_driver::prev(const cursor_request& request) {
+    cursor_info& mongodb_driver::prev(const cursor_request& request) {
         auto& cursor = impl_->get_applied_cursor(request);
         cursor.prev();
         return cursor;
     }
 
-    const cursor_info& mongodb_driver::prev(const cursor_info& info) {
+    cursor_info& mongodb_driver::prev(const cursor_info& info) {
         auto& cursor = impl_->get_applied_cursor(info);
         cursor.prev();
         return cursor;

--- a/libraries/chain/chaindb/mongo_driver.cpp
+++ b/libraries/chain/chaindb/mongo_driver.cpp
@@ -1,6 +1,6 @@
 #include <limits>
 
-#include <cyberway/chaindb/mongo_big_int_converter.hpp>
+#include <cyberway/chaindb/mongo_bigint_converter.hpp>
 #include <cyberway/chaindb/mongo_driver.hpp>
 #include <cyberway/chaindb/exception.hpp>
 #include <cyberway/chaindb/names.hpp>
@@ -41,24 +41,16 @@ namespace cyberway { namespace chaindb {
     using document_view = bsoncxx::document::view;
 
     enum class direction: int {
-        Forward = 1,
+        Forward  =  1,
         Backward = -1
     }; // enum direction
 
-    struct cmp_info {
-        const direction order;
-        const char* from_forward;
-        const char* from_backward;
-        const char* to_forward;
-        const char* to_backward;
-    }; // struct cmp_info
-
     enum class mongo_code: int {
-        Unknown = -1,
-        EmptyBulk = 22,
+        Unknown        = -1,
+        EmptyBulk      = 22,
         DuplicateValue = 11000,
-        NoServer = 13053
-    };
+        NoServer       = 13053
+    }; // enum mongo_code
 
     namespace { namespace _detail {
         static const string pk_index_postfix = "_pk";
@@ -80,44 +72,26 @@ namespace cyberway { namespace chaindb {
             }
         }
 
-        const cmp_info& start_from() {
-            static cmp_info value = {
-                direction::Forward,
-                "$gte", "$lte",
-                "$gt",  "$lt" };
-            return value;
-        }
-
-        const cmp_info& start_after() {
-            static cmp_info value = {
-                direction::Forward,
-                "$gt", "$lt",
-                nullptr, nullptr };
-            return value;
-        }
-
-        const cmp_info& reverse_start_from() {
-            static cmp_info value = {
-                direction::Backward,
-                "$lte", "$gte",
-                "$lt",  "$gt" };
-            return value;
-        }
-
         bool is_asc_order(const string& name) {
             return name.size() == names::asc_order.size();
         }
 
-        variant get_order_value(const variant_object& row, const index_info& index, const order_def& order) { try {
+        field_name get_order_field(const order_def& order) {
+            field_name field = order.field;
+            if (order.type == "uint128" || order.type == "int128") {
+                field.append(1, '.').append(mongo_bigint_converter::BINARY_FIELD);
+            }
+            return field;
+        }
+
+        variant get_order_value(const variant_object& row, const index_info& index, const order_def& order) try {
             auto* object = &row;
             auto pos = order.path.size();
             for (auto& key: order.path) {
                 auto itr = object->find(key);
                 CYBERWAY_ASSERT(object->end() != itr, driver_absent_field_exception,
-                    "Can't find the part ${key} for the field ${field} in the row ${row} "
-                    "from the table ${table} for the scope '${scope} ",
-                    ("key", key)("field", order.field)
-                    ("table", get_full_table_name(index))("scope", get_scope_name(index))("row", row));
+                    "Can't find the part ${key} for the field ${field} in the row ${row} from the table ${table}",
+                    ("key", key)("field", order.field)("table", get_full_table_name(index))("row", row));
 
                 --pos;
                 if (0 == pos) {
@@ -127,18 +101,15 @@ namespace cyberway { namespace chaindb {
                 }
             }
             CYBERWAY_ASSERT(false, driver_absent_field_exception,
-                "Wrong logic on parsing of the field ${field} in the row ${row} "
-                "from the table ${table} for the scope '${scope}'",
+                "Wrong logic on parsing of the field ${field} in the row ${row} from the table ${table}",
                 ("table", get_full_table_name(index))("field", order.field)("row", row));
         } catch (const driver_absent_field_exception&) {
             throw;
         } catch (...) {
             CYBERWAY_ASSERT(false, driver_absent_field_exception,
-                "External database can't read the field ${field} in the row ${row} "
-                "from the table ${table} for the scope '${scope}'",
-                ("field", order.field)
-                ("table", get_full_table_name(index))("scope", get_scope_name(index))("row", row));
-        } }
+                "External database can't read the field ${field} in the row ${row} from the table ${table}",
+                ("field", order.field)("table", get_full_table_name(index))("row", row));
+        }
 
         template <typename Lambda>
         void auto_reconnect(Lambda&& lambda) {
@@ -146,7 +117,7 @@ namespace cyberway { namespace chaindb {
             constexpr int max_iters = 12;
             constexpr int sleep_seconds = 5;
 
-            for (int i = 0; i < max_iters; ++i) { try {
+            for (int i = 0; i < max_iters; ++i) try {
                 if (i > 0) {
                     wlog("Fail to connect to MongoDB server, wait ${sec} seconds...", ("sec", sleep_seconds));
                     sleep(sleep_seconds);
@@ -160,7 +131,7 @@ namespace cyberway { namespace chaindb {
                 }
 
                 throw;
-            } }
+            }
 
             CYBERWAY_ASSERT(false, driver_open_exception, "Fail to connect to MongoDB server");
         }
@@ -182,98 +153,58 @@ namespace cyberway { namespace chaindb {
         mongodb_cursor_info clone(cursor_t id) {
             mongodb_cursor_info dst(id, index, db_table_);
 
-            if (find_cmp_->order == direction::Forward) {
-                dst.find_cmp_ = &_detail::start_from();
-            } else {
-                dst.find_cmp_ = &_detail::reverse_start_from();
-            }
-
             if (source_) {
                 // it is faster to get object from exist cursor then to open a new cursor, locate, and get object
-                dst.object_ = get_object_value();
-                dst.find_key_ = dst.object_.value;
-                dst.find_pk_ = get_pk_value();
+                dst.object_    = get_object_value();
+                dst.find_key_  = dst.object_.value;
+                dst.find_pk_   = get_pk_value();
+                // don't copy direction, because direction::Backward starts from previous, not from currently
+                dst.direction_ = direction::Forward;
             } else {
-                dst.find_key_ = find_key_;
-                dst.find_pk_ = find_pk_;
-                dst.object_ = object_;
+                dst.find_key_  = find_key_;
+                dst.find_pk_   = find_pk_;
+                dst.object_    = object_;
+                dst.direction_ = direction_;
             }
-            dst.pk = pk;
+
+            dst.pk   = pk;
             dst.blob = blob;
 
             return dst;
         }
 
-        mongodb_cursor_info& open(const cmp_info& find_cmp, variant key, const primary_key_t locate_pk = unset_primary_key) {
-            reset();
+        // open() allows to reuse the same cursor for different cases
+        mongodb_cursor_info& open(const direction dir, variant key, const primary_key_t locate_pk) {
+            reset_object();
+            source_.reset();
 
-            find_cmp_ = &find_cmp;
-            find_key_ = std::move(key);
-            find_pk_ = locate_pk;
+            pk         = locate_pk;
+            direction_ = dir;
 
-            return *this;
-        }
-
-        mongodb_cursor_info& open_by_pk(variant key, const primary_key_t locate_pk) {
-            reset();
-            pk = locate_pk;
-
-            find_cmp_ = &_detail::start_from();
-            find_key_ = std::move(key);
-            find_pk_ = unset_primary_key;
-
-            return *this;
-        }
-
-        mongodb_cursor_info& open_begin() {
-            reset();
-
-            find_cmp_ = &_detail::start_from();
-            find_key_.clear();
-            find_pk_ = unset_primary_key;
-
-            return *this;
-        }
-
-        mongodb_cursor_info& open_end() {
-            reset();
-            pk = end_primary_key;
-
-            find_cmp_ = &_detail::reverse_start_from();
-            find_key_.clear();
-            find_pk_ = unset_primary_key;
-
-            return *this;
-        }
-
-        mongodb_cursor_info& open_end_() {
-            reset();
-            pk = end_primary_key;
-
-            find_cmp_ = &_detail::reverse_start_from();
-            find_key_.clear();
-            find_pk_ = unset_primary_key;
+            find_pk_   = locate_pk;
+            find_key_  = std::move(key);
 
             return *this;
         }
 
         void next() {
-            if (find_cmp_->order == direction::Backward) {
-                change_direction(_detail::start_from());
+            if (direction::Backward == direction_) {
+                // we at the last record of a range - we should get its key for correct locating
+                lazy_open();
+                change_direction(direction::Forward);
             }
             lazy_next();
         }
 
         void prev() {
-            if (end_primary_key == pk) {
-                open_end_();
-                pk = unset_primary_key;
+            if (direction::Forward == direction_) {
+                change_direction(direction::Backward);
                 lazy_open();
-                return;
-            } else if (find_cmp_->order == direction::Forward) {
-                change_direction(_detail::reverse_start_from());
+            } else if (end_primary_key == pk) {
+                lazy_open();
+            } else {
+                lazy_next();
             }
-            lazy_next();
         }
 
         void current() {
@@ -285,7 +216,7 @@ namespace cyberway { namespace chaindb {
             if (!object_.value.is_null()) return object_;
 
             if (end_primary_key == get_pk_value()) {
-                object_.value         = variant();
+                object_.clear();
                 object_.service.pk    = pk;
                 object_.service.code  = index.code;
                 object_.service.scope = index.scope;
@@ -293,72 +224,111 @@ namespace cyberway { namespace chaindb {
             } else {
                 auto& view = *source_->begin();
                 object_ = build_object(index, view);
-                pk = object_.service.pk;
+                pk      = object_.service.pk;
             }
 
             return object_;
         }
 
-    private:
-        collection db_table_;
+        bool is_openned() const {
+            return !!source_;
+        }
 
-        const cmp_info* find_cmp_ = &_detail::start_from();
-        variant find_key_;
-        primary_key_t find_pk_ = unset_primary_key;
+    private:
+        collection    db_table_;
+
+        direction     direction_ = direction::Forward;
+        primary_key_t find_pk_   = unset_primary_key;
+        variant       find_key_;
 
         std::unique_ptr<mongocxx::cursor> source_;
-        object_value object_;
+        object_value  object_;
 
-        void change_direction(const cmp_info& find_cmp) {
-            find_cmp_ = &find_cmp;
+        void change_direction(const direction dir) {
+            direction_ = dir;
             if (source_) {
                 find_key_ = get_object_value().value;
-                find_pk_ = get_pk_value();
+                find_pk_  = get_pk_value();
             }
-
-            reset();
+            source_.reset();
         }
 
         void reset_object() {
             pk = unset_primary_key;
-            if (!blob.empty()) blob.clear();
+
+            if (!blob.empty())      blob.clear();
             if (!object_.is_null()) object_.clear();
         }
 
-        void reset() {
-            reset_object();
-            source_.reset();
+        document create_find_document() const {
+            document find;
+            find.append(kvp(names::scope_path, get_scope_name(index)));
+            return find;
         }
 
-        document create_find_document(const char* forward, const char* backward) const {
-            document find;
+        primary_key_t get_primary_pk_bound() const {
+            if (find_pk_ > end_primary_key) {
+                return find_pk_;
+            }
 
-            find.append(kvp(names::scope_path, get_scope_name(index)));
-            if (!find_key_.is_object()) return find;
+            switch (index.pk_order->type.front()) {
+                case 'i': // int64
+                    if (direction::Forward == direction_) {
+                        return std::numeric_limits<int64_t>::min();
+                    } else {
+                        return std::numeric_limits<int64_t>::max();
+                    }
+                case 'u': // uint64
+                case 'n': // name
+                case 's': // symbol_code
+                    if (direction::Forward == direction_) {
+                        return std::numeric_limits<uint64_t>::min();
+                    } else {
+                        return std::numeric_limits<uint64_t>::max();
+                    }
+                default:
+                    CYBERWAY_ASSERT(false, driver_primary_key_exception,
+                        "Invalid type ${type} for the primary key ${pk} in the table ${table}",
+                        ("type", index.pk_order->type)("pk", pk)("table", get_full_table_name(index)));
+            }
+        }
 
+        document create_bound_document() {
+            document bound;
+
+            if (!find_key_.is_object()) return bound;
             auto& find_object = find_key_.get_object();
-            if (!find_object.size()) return find;
+            if (!find_object.size()) return bound;
+
+            bound.append(kvp(names::scope_path, get_scope_name(index)));
 
             auto& orders = index.index->orders;
             for (auto& o: orders) {
-                auto cmp = _detail::is_asc_order(o.order) ? forward : backward;
+                auto field = _detail::get_order_field(o);
                 auto value = _detail::get_order_value(find_object, index, o);
-                find.append(kvp(o.field, [&](sub_document doc){build_document(doc, cmp, value);}));
+                build_document(bound, field, value);
             }
 
-            return find;
+            if (!index.index->unique) {
+                append_pk_value(bound, index, get_primary_pk_bound());
+            }
+
+            return bound;
         }
 
         document create_sort_document() const {
             document sort;
-            auto order = static_cast<int>(find_cmp_->order);
+            auto order = static_cast<int>(direction_);
+
+            sort.append(kvp(names::scope_path, order));
 
             auto& orders = index.index->orders;
             for (auto& o: orders) {
+                auto field = _detail::get_order_field(o);
                 if (_detail::is_asc_order(o.order)) {
-                    sort.append(kvp(o.field, order));
+                    sort.append(kvp(field, order));
                 } else {
-                    sort.append(kvp(o.field, -order));
+                    sort.append(kvp(field, -order));
                 }
             }
 
@@ -371,62 +341,44 @@ namespace cyberway { namespace chaindb {
 
         void lazy_open() {
             if (source_) return;
-            if (end_primary_key == pk) return;
 
-            reset();
+            reset_object();
 
-            auto find = create_find_document(find_cmp_->from_forward, find_cmp_->from_backward);
-            auto sort = create_sort_document();
+            auto find  = create_find_document();
+            auto bound = create_bound_document();
+            auto sort  = create_sort_document();
 
-            const auto find_pk = find_pk_;
             find_pk_ = unset_primary_key;
 
+            auto opts = options::find()
+                .hint(mongocxx::hint(db_name_to_string(index.index->name)))
+                .sort(sort.view());
+
+            if (direction_ == direction::Forward) {
+                opts.min(bound.view());
+            } else {
+                opts.max(bound.view());
+            }
+
             _detail::auto_reconnect([&]() {
-                source_ = std::make_unique<mongocxx::cursor>(db_table_.find(find.view(), options::find().sort(sort.view())));
-
+                source_ = std::make_unique<mongocxx::cursor>(db_table_.find(find.view(), opts));
                 init_pk_value();
-                if (unset_primary_key == find_pk || find_pk == pk || end_primary_key == pk) return;
-                if (index.index->unique || !find_cmp_->to_forward) return;
-
-                // locate cursor to primary key
-
-                auto to_find = create_find_document(find_cmp_->to_forward, find_cmp_->to_backward);
-                auto to_cursor = db_table_.find(to_find.view(), options::find().sort(sort.view()).limit(1));
-
-                auto to_pk = unset_primary_key;
-                auto to_itr = to_cursor.begin();
-                if (to_itr != to_cursor.end()) to_pk = chaindb::get_pk_value(index, *to_itr);
-
-                // TODO: limitation by deadline
-                static constexpr int max_iters = 10000;
-                auto itr = source_->begin();
-                auto etr = source_->end();
-                for (int i = 0; i < max_iters && itr != etr; ++i, ++itr) {
-                    pk = chaindb::get_pk_value(index, *to_itr);
-                    // range is end, but pk not found
-                    if (to_pk == pk) break;
-                    // ok, key is found
-                    if (find_pk == pk) return;
-                }
-
-                open_end();
             });
         }
 
         void lazy_next() {
-            reset_object();
             lazy_open();
-            if (!source_) return;
 
             auto itr = source_->begin();
-            if (source_->end() != itr) {
-                ++itr;
+            if (source_->end() == itr) {
+                return;
             }
-            CYBERWAY_ASSERT(find_cmp_->order != direction::Backward || itr != source_->end(),
-                driver_out_of_range_exception,
-                "External database tries to locate row in the index ${index} for the scope '${scope}' in out of range",
-                ("index", get_full_index_name(index))("scope", get_scope_name(index)));
-            init_pk_value();
+
+            ++itr;
+            if (source_->end() != itr || direction::Forward == direction_) {
+                reset_object();
+                init_pk_value();
+            }
         }
 
         primary_key_t get_pk_value() {
@@ -481,13 +433,21 @@ namespace cyberway { namespace chaindb {
 
         ~mongodb_impl_() = default;
 
-        cursor_location get_applied_cursor(const cursor_request& request) {
-            auto loc = get_cursor(request);
-            auto& cursor = loc.cursor();
-            if (cursor.pk == unset_primary_key) {
+        mongodb_cursor_info& get_applied_cursor(cursor_info& info) {
+            auto& cursor = static_cast<mongodb_cursor_info&>(info);
+            if (!cursor.is_openned()) {
                 apply_table_changes(cursor.index);
             }
-            return loc;
+            return cursor;
+        }
+
+        mongodb_cursor_info& get_applied_cursor(const cursor_info& info) {
+            return get_applied_cursor(const_cast<cursor_info&>(info));
+        }
+
+        mongodb_cursor_info& get_applied_cursor(const cursor_request& request) {
+            auto loc = get_cursor(request);
+            return get_applied_cursor(loc.cursor());
         }
 
         void apply_code_changes(const account_name& code) {
@@ -512,24 +472,14 @@ namespace cyberway { namespace chaindb {
             auto itr = code_cursor_map_.find(code);
             if (code_cursor_map_.end() == itr) return;
 
-//            CYBERWAY_ASSERT(!itr->second.has_changes(), driver_has_unapplied_changes_exception,
-//                "Chaindb has unapplied changes for the db ${db}", ("db", get_code_name(code)));
             code_cursor_map_.erase(itr);
-        }
-
-        mongodb_cursor_info& clone_cursor(const cursor_request& request) {
-            auto loc = get_cursor(request);
-            auto next_id = get_next_cursor_id(loc.code_itr_);
-
-            auto cloned_cursor = loc.cursor().clone(next_id);
-            return add_cursor(loc.code_itr_, request.code, std::move(cloned_cursor));
         }
 
         std::vector<index_def> get_db_indexes(collection& db_table) const {
             std::vector<index_def> result;
             auto indexes = db_table.list_indexes();
 
-            result.reserve(abi_info::max_index_cnt * 2);
+            result.reserve(abi_info::max_index_cnt() * 2);
             for (auto& info: indexes) {
                 index_def index;
 
@@ -562,10 +512,10 @@ namespace cyberway { namespace chaindb {
                         order.field = key.to_string();
 
                         // <FIELD_NAME>.binary - we should remove ".binary"
-                        if (order.field.size() > mongo_big_int_converter::BINARY_FIELD.size() &&
-                            key.ends_with(mongo_big_int_converter::BINARY_FIELD)
+                        if (order.field.size() > mongo_bigint_converter::BINARY_FIELD.size() &&
+                            key.ends_with(mongo_bigint_converter::BINARY_FIELD)
                         ) {
-                            order.field.erase(order.field.size() - 1 - mongo_big_int_converter::BINARY_FIELD.size());
+                            order.field.erase(order.field.size() - 1 - mongo_bigint_converter::BINARY_FIELD.size());
                         }
 
                         order.order = field.get_int32().value == 1 ? names::asc_order : names::desc_order;
@@ -584,7 +534,7 @@ namespace cyberway { namespace chaindb {
             static constexpr std::chrono::milliseconds max_time(10);
             std::vector<table_def> tables;
 
-            tables.reserve(abi_info::max_table_cnt * 2);
+            tables.reserve(abi_info::max_table_cnt() * 2);
             _detail::auto_reconnect([&]() {
                 tables.clear();
                 auto db = mongo_conn_.database(get_code_name(sys_code_name_, code));
@@ -629,11 +579,7 @@ namespace cyberway { namespace chaindb {
 
             idx_doc.append(kvp(names::scope_path, 1));
             for (auto& order: index.orders) {
-                auto field = order.field;
-                // ui128 || i128
-                if (order.type.back() == '8' && (order.type.front() == 'i' || order.type.front() == 'u')) {
-                    field.append(".").append(mongo_big_int_converter::BINARY_FIELD);
-                }
+                auto field = _detail::get_order_field(order);
                 if (_detail::is_asc_order(order.order)) {
                     idx_doc.append(kvp(field, 1));
                 } else {
@@ -660,14 +606,23 @@ namespace cyberway { namespace chaindb {
             }
         }
 
-        mongodb_cursor_info& create_cursor(index_info index) {
+        template <typename... Args>
+        mongodb_cursor_info& create_cursor(index_info index, Args&&... args) {
             auto code = index.code;
             auto itr = code_cursor_map_.find(code);
             auto id = get_next_cursor_id(itr);
             auto db_table = get_db_table(index);
-            mongodb_cursor_info new_cursor(id, std::move(index), std::move(db_table));
-            apply_table_changes(index);
+            mongodb_cursor_info new_cursor(id, std::move(index), std::move(db_table), std::forward<Args>(args)...);
+            // apply_table_changes(index);
             return add_cursor(std::move(itr), code, std::move(new_cursor));
+        }
+
+        mongodb_cursor_info& clone_cursor(const cursor_request& request) {
+            auto loc = get_cursor(request);
+            auto next_id = get_next_cursor_id(loc.code_itr_);
+
+            auto cloned_cursor = loc.cursor().clone(next_id);
+            return add_cursor(loc.code_itr_, request.code, std::move(cloned_cursor));
         }
 
         void drop_db() {
@@ -723,9 +678,8 @@ namespace cyberway { namespace chaindb {
             }
 
             CYBERWAY_ASSERT(false, driver_absent_object_exception,
-                "External database doesn't contain object with the primary key ${pk} "
-                "in the table ${table} for the scope '${scope}'",
-                ("pk", pk)("table", get_full_table_name(table))("scope", get_scope_name(table)));
+                "External database doesn't contain object with the primary key ${pk} in the table ${table}",
+                ("pk", pk)("table", get_full_table_name(table)));
         }
 
     private:
@@ -961,72 +915,66 @@ namespace cyberway { namespace chaindb {
 
     const cursor_info& mongodb_driver::lower_bound(index_info index, variant key) {
         auto& cursor = impl_->create_cursor(std::move(index));
-        cursor.open(_detail::start_from(), std::move(key)).current();
+        cursor.open(direction::Forward, std::move(key), unset_primary_key);
         return cursor;
     }
 
     const cursor_info& mongodb_driver::upper_bound(index_info index, variant key) {
         auto& cursor = impl_->create_cursor(std::move(index));
-        cursor.open(_detail::start_after(), std::move(key)).current();
+        cursor.open(direction::Backward, std::move(key), unset_primary_key).next();
         return cursor;
     }
 
-    const cursor_info& mongodb_driver::find(index_info index, primary_key_t pk, variant key) {
+    const cursor_info& mongodb_driver::locate_to(index_info index, variant key, primary_key_t pk) {
         auto& cursor = impl_->create_cursor(std::move(index));
-        cursor.open(_detail::start_from(), std::move(key), pk).current();
+        cursor.open(direction::Forward, std::move(key), pk);
         return cursor;
     }
 
     const cursor_info& mongodb_driver::begin(index_info index) {
         auto& cursor = impl_->create_cursor(std::move(index));
-        cursor.open_begin().current();
+        cursor.open(direction::Forward, {}, unset_primary_key);
         return cursor;
     }
 
     const cursor_info& mongodb_driver::end(index_info index) {
         auto& cursor = impl_->create_cursor(std::move(index));
-        cursor.open_end();
-        return cursor;
-    }
-
-    const cursor_info& mongodb_driver::opt_find_by_pk(index_info index, primary_key_t pk, variant key) {
-        auto& cursor = impl_->create_cursor(std::move(index));
-        cursor.open_by_pk(std::move(key), pk).current();
+        cursor.open(direction::Backward, {}, end_primary_key);
         return cursor;
     }
 
     const cursor_info& mongodb_driver::current(const cursor_info& info) {
-        auto& cursor = const_cast<mongodb_cursor_info&>(static_cast<const mongodb_cursor_info&>(info));
+        auto& cursor = impl_->get_applied_cursor(info);
         cursor.current();
         return cursor;
     }
 
     const cursor_info& mongodb_driver::current(const cursor_request& request) {
-        auto& cursor = impl_->get_applied_cursor(request).cursor();
+        auto& cursor = impl_->get_applied_cursor(request);
         cursor.current();
         return cursor;
     }
 
     const cursor_info& mongodb_driver::next(const cursor_request& request) {
-        auto& cursor = impl_->get_applied_cursor(request).cursor();
+        auto& cursor = impl_->get_applied_cursor(request);
         cursor.next();
         return cursor;
     }
 
     const cursor_info& mongodb_driver::next(const cursor_info& info) {
-        auto& cursor = const_cast<mongodb_cursor_info&>(static_cast<const mongodb_cursor_info&>(info));
+        auto& cursor = impl_->get_applied_cursor(info);
         cursor.next();
         return cursor;
     }
 
     const cursor_info& mongodb_driver::prev(const cursor_request& request) {
-        auto& cursor = impl_->get_applied_cursor(request).cursor();
+        auto& cursor = impl_->get_applied_cursor(request);
         cursor.prev();
         return cursor;
     }
 
     const cursor_info& mongodb_driver::prev(const cursor_info& info) {
-        auto& cursor = const_cast<mongodb_cursor_info&>(static_cast<const mongodb_cursor_info&>(info));
+        auto& cursor = impl_->get_applied_cursor(info);
         cursor.prev();
         return cursor;
     }
@@ -1040,12 +988,12 @@ namespace cyberway { namespace chaindb {
     }
 
     const object_value& mongodb_driver::object_at_cursor(const cursor_info& info) {
-        auto& cursor = const_cast<mongodb_cursor_info&>(static_cast<const mongodb_cursor_info&>(info));
+        auto& cursor = impl_->get_applied_cursor(info);
         return cursor.get_object_value();
     }
 
     void mongodb_driver::set_blob(const cursor_info& info, bytes blob) {
-        auto& cursor = const_cast<mongodb_cursor_info&>(static_cast<const mongodb_cursor_info&>(info));
+        auto& cursor = impl_->get_applied_cursor(info);
         cursor.blob = std::move(blob);
     }
 

--- a/libraries/chain/chaindb/mongo_driver_utils.cpp
+++ b/libraries/chain/chaindb/mongo_driver_utils.cpp
@@ -390,7 +390,7 @@ namespace cyberway { namespace chaindb {
 
         obj.value = build_variant(&obj.service, src);
         if (obj.pk() == unset_primary_key) {
-            obj.service.pk = get_pk_value(info, src);
+            obj.service.pk    = get_pk_value(info, src);
             obj.service.code  = info.code;
             obj.service.scope = info.scope;
             obj.service.table = info.table->name;

--- a/libraries/chain/include/cyberway/chaindb/abi_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/abi_info.hpp
@@ -53,6 +53,12 @@ namespace cyberway { namespace chaindb {
             return to_bytes_("table", [&]{return get_full_table_name(info);}, info.table->type, value);
         }
 
+        bytes to_bytes(const index_info& info, const variant& value) const {
+            CYBERWAY_ASSERT(info.index, unknown_index_exception, "NULL index");
+            auto type = get_full_index_name(info);
+            return to_bytes_("index", [&]{return type;}, type, value);
+        }
+
         void mark_removed() {
             is_removed_ = true;
         }
@@ -78,6 +84,10 @@ namespace cyberway { namespace chaindb {
 
         static constexpr size_t max_index_cnt() {
             return 16;
+        }
+
+        static constexpr size_t max_path_depth() {
+            return 4;
         }
 
     private:

--- a/libraries/chain/include/cyberway/chaindb/abi_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/abi_info.hpp
@@ -72,13 +72,18 @@ namespace cyberway { namespace chaindb {
             return code_;
         }
 
-        static const size_t max_table_cnt;
-        static const size_t max_index_cnt;
+        static constexpr size_t max_table_cnt() {
+            return 64;
+        }
+
+        static constexpr size_t max_index_cnt() {
+            return 16;
+        }
 
     private:
         const account_name code_;
         eosio::chain::abi_serializer serializer_;
-        std::map<table_name_t, table_def> table_map_;
+        fc::flat_map<table_name_t, table_def> table_map_;
         bool is_removed_ = false;
         static const fc::microseconds max_abi_time_;
 

--- a/libraries/chain/include/cyberway/chaindb/cache_item.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_item.hpp
@@ -5,13 +5,19 @@
 #include <cyberway/chaindb/common.hpp>
 #include <cyberway/chaindb/object_value.hpp>
 
+#include <boost/smart_ptr/intrusive_ptr.hpp>
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
+
+#include <boost/intrusive/set.hpp>
+#include <boost/intrusive/list.hpp>
+
 namespace cyberway { namespace chaindb {
 
     class cache_item;
     struct cache_item_data;
     struct cache_converter_interface;
 
-    using cache_item_ptr = std::shared_ptr<cache_item>;
+    using cache_item_ptr = boost::intrusive_ptr<cache_item>;
     using cache_item_data_ptr = std::unique_ptr<cache_item_data>;
 
     struct cache_item_data {
@@ -25,7 +31,7 @@ namespace cyberway { namespace chaindb {
         virtual cache_item_data_ptr convert_variant(cache_item&, const object_value&) const = 0;
     }; // struct cache_load_interface
 
-    class cache_item final {
+    class cache_item final: public boost::intrusive_ref_counter<cache_item> {
         table_name   table_ = 0;
         object_value object_;
         bool         is_deleted_ = false;

--- a/libraries/chain/include/cyberway/chaindb/cache_item.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_item.hpp
@@ -39,7 +39,7 @@ namespace cyberway { namespace chaindb {
 
         const index_name    index;
         const data_t        data;
-        const cache_object& object;
+        const cache_object* object = nullptr;
 
         cache_index_value(index_name, data_t, const cache_object&);
         cache_index_value(cache_index_value&&) = default;

--- a/libraries/chain/include/cyberway/chaindb/cache_item.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_item.hpp
@@ -35,18 +35,19 @@ namespace cyberway { namespace chaindb {
     struct table_cache_map;
 
     struct cache_index_value final: public boost::intrusive::set_base_hook<> {
-        const account_name      code;
-        const account_name      scope;
-        const table_name        table;
-        const index_name        index;
-        const std::vector<char> data;
-        const cache_object&     object;
+        using data_t = std::vector<char>;
 
-        cache_index_value() = default;
+        const index_name    index;
+        const data_t        data;
+        const cache_object& object;
+
+        cache_index_value(index_name, data_t, const cache_object&);
         cache_index_value(cache_index_value&&) = default;
 
         ~cache_index_value() = default;
     }; // struct cache_index_value
+
+    using cache_indicies = std::vector<cache_index_value>;
 
     class cache_object final:
         public boost::intrusive_ref_counter<cache_object>,
@@ -56,6 +57,7 @@ namespace cyberway { namespace chaindb {
         table_cache_map* table_cache_map_ = nullptr;
         object_value     object_;
         cache_data_ptr   data_;
+        cache_indicies   indicies_;
     public:
         cache_object(table_cache_map& map, object_value obj)
         : table_cache_map_(&map), object_(std::move(obj)) {
@@ -95,6 +97,10 @@ namespace cyberway { namespace chaindb {
 
         const object_value& object() const {
             return object_;
+        }
+
+        const service_state& service() const {
+            return object_.service;
         }
 
         bool has_data() const {

--- a/libraries/chain/include/cyberway/chaindb/cache_item.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_item.hpp
@@ -59,10 +59,7 @@ namespace cyberway { namespace chaindb {
         cache_data_ptr   data_;
         cache_indicies   indicies_;
     public:
-        cache_object(table_cache_map& map, object_value obj)
-        : table_cache_map_(&map), object_(std::move(obj)) {
-        }
-
+        cache_object(table_cache_map&, object_value);
         cache_object(cache_object&&) = default;
 
         ~cache_object() = default;

--- a/libraries/chain/include/cyberway/chaindb/cache_item.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_item.hpp
@@ -2,6 +2,8 @@
 
 #include <memory>
 
+#include <eosio/chain/types.hpp>
+
 #include <cyberway/chaindb/common.hpp>
 #include <cyberway/chaindb/object_value.hpp>
 
@@ -12,6 +14,8 @@
 #include <boost/intrusive/list.hpp>
 
 namespace cyberway { namespace chaindb {
+
+    using  eosio::chain::bytes;
 
     class  cache_object;
     struct cache_data;
@@ -58,6 +62,8 @@ namespace cyberway { namespace chaindb {
         object_value     object_;
         cache_data_ptr   data_;
         cache_indicies   indicies_;
+        bytes            blob_;
+
     public:
         cache_object(table_cache_map&, object_value);
         cache_object(cache_object&&) = default;
@@ -88,6 +94,10 @@ namespace cyberway { namespace chaindb {
             data_ = std::make_unique<T>(*this, std::forward<Args>(args)...);
         }
 
+        void set_blob(bytes blob) {
+            blob_ = std::move(blob);
+        }
+
         primary_key_t pk() const {
             return object_.pk();
         }
@@ -104,10 +114,20 @@ namespace cyberway { namespace chaindb {
             return !!data_;
         }
 
-        template <typename T> T& get_data() const {
+        template <typename T> T& data() const {
             assert(has_data());
             return *static_cast<T*>(data_.get());
         }
+
+        bool has_blob() const {
+            return !blob_.empty();
+        }
+
+        const bytes& blob() const {
+            assert(has_blob());
+            return blob_;
+        }
+
     }; // class cache_object
 
 } } // namespace cyberway::chaindb

--- a/libraries/chain/include/cyberway/chaindb/cache_map.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_map.hpp
@@ -8,17 +8,17 @@ namespace cyberway { namespace chaindb {
 
     class cache_map final {
     public:
-        cache_map();
+        cache_map(abi_map&);
         ~cache_map();
 
         void set_cache_converter(const table_info&, const cache_converter_interface&) const;
 
         void set_next_pk(const table_info&, primary_key_t) const;
 
-        cache_item_ptr create(const table_info&) const;
-        cache_item_ptr find(const table_info&, primary_key_t) const;
+        cache_object_ptr create(const table_info&) const;
+        cache_object_ptr find(const table_info&, primary_key_t) const;
 
-        cache_item_ptr emplace(const table_info&, object_value) const;
+        cache_object_ptr emplace(const table_info&, object_value) const;
         void remove(const table_info&, primary_key_t) const;
         void set_revision(const object_value&, revision_t) const;
 

--- a/libraries/chain/include/cyberway/chaindb/cache_map.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_map.hpp
@@ -20,12 +20,12 @@ namespace cyberway { namespace chaindb {
 
         cache_item_ptr emplace(const table_info&, object_value) const;
         void remove(const table_info&, primary_key_t) const;
+        void set_revision(const object_value&, revision_t) const;
 
         void clear();
 
     private:
-        struct cache_map_impl_;
-        std::unique_ptr<cache_map_impl_> impl_;
+        std::unique_ptr<table_cache_map> impl_;
     }; // class cache_map
 
 } } // namespace cyberway::chaindb

--- a/libraries/chain/include/cyberway/chaindb/cache_map.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_map.hpp
@@ -17,6 +17,7 @@ namespace cyberway { namespace chaindb {
 
         cache_object_ptr create(const table_info&) const;
         cache_object_ptr find(const table_info&, primary_key_t) const;
+        cache_object_ptr find(const index_info&, const char*, size_t) const;
 
         cache_object_ptr emplace(const table_info&, object_value) const;
         void remove(const table_info&, primary_key_t) const;

--- a/libraries/chain/include/cyberway/chaindb/common.hpp
+++ b/libraries/chain/include/cyberway/chaindb/common.hpp
@@ -16,6 +16,9 @@ namespace cyberway { namespace chaindb {
     static constexpr primary_key_t unset_primary_key = (-2);
     static constexpr primary_key_t end_primary_key = (-1);
 
+    using cursor_t = int32_t;
+    static constexpr cursor_t invalid_cursor = (0);
+
     using std::string;
 
     using eosio::chain::account_name;
@@ -29,6 +32,24 @@ namespace cyberway { namespace chaindb {
     using table_name_t = table_name::value_type;
     using index_name_t = index_name::value_type;
     using account_name_t = account_name::value_type;
+
+    struct index_request final {
+        const account_name code;
+        const account_name scope;
+        const table_name_t table;
+        const index_name_t index;
+    }; // struct index_request
+
+    struct table_request final {
+        const account_name code;
+        const account_name scope;
+        const table_name_t table;
+    }; // struct table_request
+
+    struct cursor_request final {
+        const account_name code;
+        const cursor_t     id;
+    }; // struct cursor_request
 
     enum class chaindb_type {
         MongoDB,
@@ -52,6 +73,21 @@ namespace cyberway { namespace chaindb {
         : code(code), scope(scope) {
         }
     }; // struct table_info
+
+    struct index_info: public table_info {
+        const index_def* index = nullptr;
+
+        using table_info::table_info;
+
+        index_info(const table_info& src)
+            : table_info(src) {
+        }
+    }; // struct index_info
+
+    struct find_info final {
+        cursor_t      cursor = invalid_cursor;
+        primary_key_t pk     = end_primary_key;
+    }; // struct find_info
 
     class chaindb_session final {
     public:

--- a/libraries/chain/include/cyberway/chaindb/common.hpp
+++ b/libraries/chain/include/cyberway/chaindb/common.hpp
@@ -80,7 +80,7 @@ namespace cyberway { namespace chaindb {
         using table_info::table_info;
 
         index_info(const table_info& src)
-            : table_info(src) {
+        : table_info(src) {
         }
     }; // struct index_info
 

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -170,8 +170,8 @@ namespace cyberway { namespace chaindb {
         primary_key_t data(const cursor_request&, const char*, size_t);
 
         void set_cache_converter(const table_request&, const cache_converter_interface&);
-        cache_item_ptr create_cache_item(const table_request&);
-        cache_item_ptr get_cache_item(const cursor_request&, const table_request&, primary_key_t);
+        cache_object_ptr create_cache_object(const table_request&);
+        cache_object_ptr get_cache_object(const cursor_request&, const table_request&, primary_key_t);
 
         primary_key_t available_pk(const table_request&);
 
@@ -181,9 +181,9 @@ namespace cyberway { namespace chaindb {
 
         int64_t insert(const table_request&, primary_key_t, variant, const ram_payer_info&);
 
-        int64_t insert(cache_item&, variant, const ram_payer_info&);
-        int64_t update(cache_item&, variant, const ram_payer_info&);
-        int64_t remove(cache_item&, const ram_payer_info&);
+        int64_t insert(cache_object&, variant, const ram_payer_info&);
+        int64_t update(cache_object&, variant, const ram_payer_info&);
+        int64_t remove(cache_object&, const ram_payer_info&);
 
         variant value_by_pk(const table_request& request, primary_key_t pk);
         variant value_at_cursor(const cursor_request& request);

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -155,7 +155,7 @@ namespace cyberway { namespace chaindb {
         find_info lower_bound(const index_request& request, const fc::variant& orders) const;
         find_info upper_bound(const index_request& request, const fc::variant& orders) const;
 
-        find_info find(const index_request&, primary_key_t, const char* key, size_t);
+        find_info locate_to(const index_request&, const char* key, size_t, primary_key_t);
 
         find_info begin(const index_request&);
         find_info end(const index_request&);

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -173,7 +173,7 @@ namespace cyberway { namespace chaindb {
 
         void set_cache_converter(const table_request&, const cache_converter_interface&);
         cache_object_ptr create_cache_object(const table_request&);
-        cache_object_ptr get_cache_object(const cursor_request&, const table_request&, primary_key_t);
+        cache_object_ptr get_cache_object(const cursor_request&, bool with_blob);
 
         primary_key_t available_pk(const table_request&);
 

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -149,11 +149,13 @@ namespace cyberway { namespace chaindb {
         int64_t revision() const;
         void set_revision(uint64_t revision);
 
-        find_info lower_bound(const index_request&, const char* key, size_t);
-        find_info upper_bound(const index_request&, const char* key, size_t);
+        find_info lower_bound(const index_request&, const char* key, size_t) const;
+        find_info lower_bound(const index_request&, primary_key_t) const;
+        find_info lower_bound(const index_request& request, const variant&) const;
 
-        find_info lower_bound(const index_request& request, const fc::variant& orders) const;
-        find_info upper_bound(const index_request& request, const fc::variant& orders) const;
+        find_info upper_bound(const index_request&, const char* key, size_t) const;
+        find_info upper_bound(const index_request&, primary_key_t) const;
+        find_info upper_bound(const index_request& request, const variant&) const;
 
         find_info locate_to(const index_request&, const char* key, size_t, primary_key_t);
 

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -162,7 +162,6 @@ namespace cyberway { namespace chaindb {
         find_info begin(const index_request&);
         find_info end(const index_request&);
         find_info clone(const cursor_request&);
-        find_info opt_find_by_pk(const table_request& request, primary_key_t pk);
 
         primary_key_t current(const cursor_request&);
         primary_key_t next(const cursor_request&);

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -14,48 +14,8 @@ namespace cyberway { namespace chaindb {
 
     using eosio::chain::abi_def;
 
-    using table_name_t = eosio::chain::table_name::value_type;
-    using index_name_t = eosio::chain::index_name::value_type;
-    using account_name_t = account_name::value_type;
-
-    using cursor_t = int32_t;
-    static constexpr cursor_t invalid_cursor = (0);
-
     template<class> struct object_to_table;
     struct ram_payer_info;
-
-    struct index_request final {
-        const account_name code;
-        const account_name scope;
-        const table_name_t table;
-        const index_name_t index;
-    }; // struct index_request
-
-    struct table_request final {
-        const account_name code;
-        const account_name scope;
-        const table_name_t table;
-    }; // struct table_request
-
-    struct cursor_request final {
-        const account_name code;
-        const cursor_t     id;
-    }; // struct cursor_request
-
-    struct index_info: public table_info {
-        const index_def* index = nullptr;
-
-        using table_info::table_info;
-
-        index_info(const table_info& src)
-        : table_info(src) {
-        }
-    }; // struct index_info
-
-    struct find_info final {
-        cursor_t      cursor = invalid_cursor;
-        primary_key_t pk     = end_primary_key;
-    }; // struct find_info
 
     class chaindb_controller final {
     public:

--- a/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
+++ b/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
@@ -15,7 +15,6 @@ namespace cyberway { namespace chaindb {
         cursor_t      id = invalid_cursor;
         index_info    index;
         primary_key_t pk = end_primary_key;
-        bytes         blob; // serialized by controller value
     }; // struct cursor_info
 
     class driver_interface {
@@ -44,16 +43,13 @@ namespace cyberway { namespace chaindb {
         virtual cursor_info& begin(index_info) = 0;
         virtual cursor_info& end(index_info) = 0;
 
+        virtual cursor_info& cursor(const cursor_request&) = 0;
         virtual cursor_info& current(const cursor_info&) = 0;
-        virtual cursor_info& current(const cursor_request&) = 0;
-        virtual cursor_info& next(const cursor_request&) = 0;
         virtual cursor_info& next(const cursor_info&) = 0;
-        virtual cursor_info& prev(const cursor_request&) = 0;
         virtual cursor_info& prev(const cursor_info&) = 0;
 
         virtual       object_value  object_by_pk(const table_info&, primary_key_t) = 0;
         virtual const object_value& object_at_cursor(const cursor_info&) = 0;
-        virtual       void          set_blob(const cursor_info&, bytes blob) = 0;
 
         virtual primary_key_t available_pk(const table_info&) = 0;
     }; // class driver_interface

--- a/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
+++ b/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
@@ -39,8 +39,7 @@ namespace cyberway { namespace chaindb {
 
         virtual const cursor_info& lower_bound(index_info, variant key) = 0;
         virtual const cursor_info& upper_bound(index_info, variant key) = 0;
-        virtual const cursor_info& find(index_info, primary_key_t, variant key) = 0;
-        virtual const cursor_info& opt_find_by_pk(index_info, primary_key_t, variant key) = 0;
+        virtual const cursor_info& locate_to(index_info, variant key, primary_key_t) = 0;
 
         virtual const cursor_info& begin(index_info) = 0;
         virtual const cursor_info& end(index_info) = 0;

--- a/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
+++ b/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
@@ -37,19 +37,19 @@ namespace cyberway { namespace chaindb {
         virtual void apply_all_changes() = 0;
         virtual void apply_code_changes(const account_name& code) = 0;
 
-        virtual const cursor_info& lower_bound(index_info, variant key) = 0;
-        virtual const cursor_info& upper_bound(index_info, variant key) = 0;
-        virtual const cursor_info& locate_to(index_info, variant key, primary_key_t) = 0;
+        virtual cursor_info& lower_bound(index_info, variant key) = 0;
+        virtual cursor_info& upper_bound(index_info, variant key) = 0;
+        virtual cursor_info& locate_to(index_info, variant key, primary_key_t) = 0;
 
-        virtual const cursor_info& begin(index_info) = 0;
-        virtual const cursor_info& end(index_info) = 0;
+        virtual cursor_info& begin(index_info) = 0;
+        virtual cursor_info& end(index_info) = 0;
 
-        virtual const cursor_info& current(const cursor_info&) = 0;
-        virtual const cursor_info& current(const cursor_request&) = 0;
-        virtual const cursor_info& next(const cursor_request&) = 0;
-        virtual const cursor_info& next(const cursor_info&) = 0;
-        virtual const cursor_info& prev(const cursor_request&) = 0;
-        virtual const cursor_info& prev(const cursor_info&) = 0;
+        virtual cursor_info& current(const cursor_info&) = 0;
+        virtual cursor_info& current(const cursor_request&) = 0;
+        virtual cursor_info& next(const cursor_request&) = 0;
+        virtual cursor_info& next(const cursor_info&) = 0;
+        virtual cursor_info& prev(const cursor_request&) = 0;
+        virtual cursor_info& prev(const cursor_info&) = 0;
 
         virtual       object_value  object_by_pk(const table_info&, primary_key_t) = 0;
         virtual const object_value& object_at_cursor(const cursor_info&) = 0;

--- a/libraries/chain/include/cyberway/chaindb/exception.hpp
+++ b/libraries/chain/include/cyberway/chaindb/exception.hpp
@@ -93,7 +93,10 @@ namespace cyberway { namespace chaindb {
                                      3710016, "ChainDB driver has opened cursors")
 
         FC_DECLARE_DERIVED_EXCEPTION(driver_unsupported_operation_exception, chaindb_internal_exception,
-                                    3710017, "ChainDB driver does not support operation")
+                                     3710017, "ChainDB driver does not support operation")
+
+        FC_DECLARE_DERIVED_EXCEPTION(driver_wrong_object_exception, chaindb_internal_exception,
+                                     3710018, "ChainDB driver return wrong object")
 
     FC_DECLARE_DERIVED_EXCEPTION(chaindb_abi_exception, chaindb_exception,
                                  3720000, "ChainDB ABI exception")

--- a/libraries/chain/include/cyberway/chaindb/journal.hpp
+++ b/libraries/chain/include/cyberway/chaindb/journal.hpp
@@ -111,14 +111,14 @@ namespace cyberway { namespace chaindb {
         }
 
     private:
-        using undo_map_t_ = fc::flat_map<revision_t, write_operation>;
+        using undo_map_t_ = fc::flat_map<primary_key_t /* undo_pk */, write_operation>;
 
         struct info_t_ final {
             write_operation data;
             undo_map_t_     undo_map;
         }; // struct info_t_
 
-        using info_map_t_ = fc::flat_map<primary_key_t, info_t_>;
+        using info_map_t_ = fc::flat_map<primary_key_t /* pk */, info_t_>;
 
         struct table_t_ final: public table_object::object {
             using table_object::object::object;

--- a/libraries/chain/include/cyberway/chaindb/mongo_bigint_converter.hpp
+++ b/libraries/chain/include/cyberway/chaindb/mongo_bigint_converter.hpp
@@ -19,7 +19,7 @@ namespace fc {
 
 namespace cyberway { namespace chaindb {
 
-    class mongo_big_int_converter {
+    class mongo_bigint_converter {
         union raw_value {
             __int128            int128_val;
             unsigned __int128   uint128_val;
@@ -36,9 +36,9 @@ namespace cyberway { namespace chaindb {
         static const std::string STRING_FIELD;
 
     public:
-        mongo_big_int_converter(const bsoncxx::document::view& document);
-        mongo_big_int_converter(const __int128& int128_val);
-        mongo_big_int_converter(const unsigned __int128& int128_val);
+        mongo_bigint_converter(const bsoncxx::document::view& document);
+        mongo_bigint_converter(const __int128& int128_val);
+        mongo_bigint_converter(const unsigned __int128& int128_val);
 
         bool is_valid_value() const;
 

--- a/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
+++ b/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
@@ -35,16 +35,13 @@ namespace cyberway { namespace chaindb {
         cursor_info& begin(index_info) override;
         cursor_info& end(index_info) override;
 
+        cursor_info& cursor(const cursor_request&) override;
         cursor_info& current(const cursor_info&) override;
-        cursor_info& current(const cursor_request&) override;
-        cursor_info& next(const cursor_request&) override;
         cursor_info& next(const cursor_info&) override;
-        cursor_info& prev(const cursor_request&) override;
         cursor_info& prev(const cursor_info&) override;
 
               object_value  object_by_pk(const table_info&, primary_key_t) override;
         const object_value& object_at_cursor(const cursor_info&) override;
-              void          set_blob(const cursor_info&, bytes blob) override;
 
         primary_key_t available_pk(const table_info&) override;
 

--- a/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
+++ b/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
@@ -28,19 +28,19 @@ namespace cyberway { namespace chaindb {
         void apply_code_changes(const account_name& code) override;
         void apply_all_changes() override;
 
-        const cursor_info& lower_bound(index_info, variant key) override;
-        const cursor_info& upper_bound(index_info, variant key) override;
-        const cursor_info& locate_to(index_info, variant key, primary_key_t) override;
+        cursor_info& lower_bound(index_info, variant key) override;
+        cursor_info& upper_bound(index_info, variant key) override;
+        cursor_info& locate_to(index_info, variant key, primary_key_t) override;
 
-        const cursor_info& begin(index_info) override;
-        const cursor_info& end(index_info) override;
+        cursor_info& begin(index_info) override;
+        cursor_info& end(index_info) override;
 
-        const cursor_info& current(const cursor_info&) override;
-        const cursor_info& current(const cursor_request&) override;
-        const cursor_info& next(const cursor_request&) override;
-        const cursor_info& next(const cursor_info&) override;
-        const cursor_info& prev(const cursor_request&) override;
-        const cursor_info& prev(const cursor_info&) override;
+        cursor_info& current(const cursor_info&) override;
+        cursor_info& current(const cursor_request&) override;
+        cursor_info& next(const cursor_request&) override;
+        cursor_info& next(const cursor_info&) override;
+        cursor_info& prev(const cursor_request&) override;
+        cursor_info& prev(const cursor_info&) override;
 
               object_value  object_by_pk(const table_info&, primary_key_t) override;
         const object_value& object_at_cursor(const cursor_info&) override;

--- a/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
+++ b/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
@@ -30,8 +30,7 @@ namespace cyberway { namespace chaindb {
 
         const cursor_info& lower_bound(index_info, variant key) override;
         const cursor_info& upper_bound(index_info, variant key) override;
-        const cursor_info& find(index_info, primary_key_t, variant key) override;
-        const cursor_info& opt_find_by_pk(index_info, primary_key_t, variant key) override;
+        const cursor_info& locate_to(index_info, variant key, primary_key_t) override;
 
         const cursor_info& begin(index_info) override;
         const cursor_info& end(index_info) override;

--- a/libraries/chain/include/cyberway/chaindb/mongo_driver_utils.hpp
+++ b/libraries/chain/include/cyberway/chaindb/mongo_driver_utils.hpp
@@ -45,6 +45,8 @@ namespace cyberway { namespace chaindb {
 
     object_value build_object(const table_info&, const bsoncxx::document::view&);
 
+    basic::sub_document& append_pk_value(basic::sub_document&, const table_info&, primary_key_t);
+
     basic::sub_document& build_document(basic::sub_document&, const object_value&);
     basic::sub_document& build_document(basic::sub_document&, const std::string&, const fc::variant&);
     basic::sub_document& build_service_document(basic::sub_document&, const table_info&, const object_value&);

--- a/libraries/chain/include/cyberway/chaindb/multi_index.hpp
+++ b/libraries/chain/include/cyberway/chaindb/multi_index.hpp
@@ -57,7 +57,6 @@ namespace cyberway { namespace chaindb {
         static constexpr cursor_t state = 0;
         static constexpr cursor_t end = -1;
         static constexpr cursor_t begin = -2;
-        static constexpr cursor_t find_by_pk = -3;
     }
 
 template<typename O>
@@ -449,12 +448,6 @@ private:
             primary_key_ = info.pk;
         }
 
-        void lazy_open_find_by_pk() const {
-            auto info = controller().opt_find_by_pk(get_table_request(), primary_key_);
-            cursor_ = info.cursor;
-            primary_key_ = info.pk;
-        }
-
         void lazy_open() const {
             if (BOOST_LIKELY(is_cursor_initialized())) return;
 
@@ -465,10 +458,6 @@ private:
 
                 case uninitilized_cursor::end:
                     cursor_ = controller().end(get_index_request()).cursor;
-                    break;
-
-                case uninitilized_cursor::find_by_pk:
-                    lazy_open_find_by_pk();
                     break;
 
                 default:

--- a/libraries/chain/include/cyberway/chaindb/multi_index.hpp
+++ b/libraries/chain/include/cyberway/chaindb/multi_index.hpp
@@ -260,7 +260,7 @@ private:
         }
 
         static const T& get_T(const cache_object& cache) {
-            return static_cast<const T&>(cache.get_data<const item_data>().item);
+            return static_cast<const T&>(cache.data<const item_data>().item);
         }
 
         static const T& get_T(const cache_object_ptr& cache) {
@@ -450,7 +450,7 @@ private:
             CYBERWAY_ASSERT(primary_key_ != end_primary_key, chaindb_midx_pk_exception,
                 "Cannot load object from the end iterator for the index ${index}", ("index", get_index_name()));
 
-            auto ptr = controller().get_cache_object({code_name(), cursor_}, get_table_request(), primary_key_);
+            auto ptr = controller().get_cache_object({code_name(), cursor_}, false);
 
             auto& obj = item_data::get_T(ptr);
             auto ptr_pk = primary_key_extractor_type()(obj);

--- a/libraries/chain/include/cyberway/chaindb/multi_index.hpp
+++ b/libraries/chain/include/cyberway/chaindb/multi_index.hpp
@@ -177,7 +177,7 @@ struct key_comparator<boost::tuple<Indices...>> {
 
 template<typename Key>
 struct key_converter {
-    static Key convert(const Key& key) {
+    static const Key& convert(const Key& key) {
         return key;
     }
 }; // struct key_converter
@@ -479,11 +479,11 @@ private:
                 ("pk", primary_key_)("index", get_index_name()));
         }
 
-        static table_request& get_table_request() {
+        static const table_request& get_table_request() {
             return multi_index::get_table_request();
         }
 
-        static index_request get_index_request() {
+        static const index_request& get_index_request() {
             static index_request request{code_name(), scope_name(), table_name(), index_name()};
             return request;
         }
@@ -622,7 +622,7 @@ public:
 
         const_iterator iterator_to(const T& obj) const {
             const auto& d = item_data::get_cache(obj);
-            CYBERWAY_ASSERT(d.is_valid_table(table_name()), chaindb_midx_logic_exception,
+            CYBERWAY_ASSERT(d.is_valid_table(get_table_request()), chaindb_midx_logic_exception,
                 "Object ${obj} passed to iterator_to is not from the index ${index}",
                 ("obj", obj)("index", get_index_name()));
 
@@ -671,7 +671,7 @@ public:
         template<typename Lambda>
         int64_t modify(const T& obj, const ram_payer_info& ram, Lambda&& updater) const {
             auto& itm = item_data::get_cache(obj);
-            CYBERWAY_ASSERT(itm.is_valid_table(table_name()), chaindb_midx_logic_exception,
+            CYBERWAY_ASSERT(itm.is_valid_table(get_table_request()), chaindb_midx_logic_exception,
                 "Object ${obj} passed to modify is not from the index ${index}",
                 ("obj", obj)("index", get_index_name()));
 
@@ -697,7 +697,7 @@ public:
 
         int64_t erase(const T& obj, const ram_payer_info& ram = {}) const {
             auto& itm = item_data::get_cache(obj);
-            CYBERWAY_ASSERT(itm.is_valid_table(table_name()), chaindb_midx_logic_exception,
+            CYBERWAY_ASSERT(itm.is_valid_table(get_table_request()), chaindb_midx_logic_exception,
                 "Object ${obj} passed to erase is not from the index ${index}",
                 ("obj", obj)("index", get_index_name()));
 
@@ -730,7 +730,7 @@ public:
     constexpr static account_name_t code_name()  { return 0; }
     constexpr static account_name_t scope_name() { return 0; }
 
-    static table_request& get_table_request() {
+    static const table_request& get_table_request() {
         static table_request request{code_name(), scope_name(), table_name()};
         return request;
     }

--- a/libraries/chain/include/cyberway/chaindb/undo_state.hpp
+++ b/libraries/chain/include/cyberway/chaindb/undo_state.hpp
@@ -28,7 +28,9 @@ namespace cyberway { namespace chaindb {
         chaindb_session start_undo_session(bool enabled);
 
         void set_revision(revision_t rev);
-        revision_t revision() const;
+        revision_t revision() const {
+            return revision_;
+        }
         bool enabled() const;
 
         void apply_changes(revision_t rev);
@@ -76,6 +78,7 @@ namespace cyberway { namespace chaindb {
     private:
         struct undo_stack_impl_;
         std::unique_ptr<undo_stack_impl_> impl_;
+        revision_t revision_;
     }; // class table_undo_stack
 
 } } // namespace cyberway::chaindb

--- a/libraries/chain/wasm_chaindb_interface.ipp
+++ b/libraries/chain/wasm_chaindb_interface.ipp
@@ -31,10 +31,10 @@ namespace eosio { namespace chain {
         }
 
         cursor_t chaindb_lower_bound_pk(
-            account_name_t code, account_name_t scope, table_name_t table, index_name_t index, primary_key_t pk
+            account_name_t code, account_name_t scope, table_name_t table, primary_key_t pk
         ) {
             context.lazy_init_chaindb_abi(code);
-            return context.chaindb.lower_bound({code, scope, table, index}, pk).cursor;
+            return context.chaindb.lower_bound({code, scope, table, 0}, pk).cursor;
         }
 
         cursor_t chaindb_upper_bound(
@@ -46,10 +46,10 @@ namespace eosio { namespace chain {
         }
 
         cursor_t chaindb_upper_bound_pk(
-            account_name_t code, account_name_t scope, table_name_t table, index_name_t index, primary_key_t pk
+            account_name_t code, account_name_t scope, table_name_t table, primary_key_t pk
         ) {
             context.lazy_init_chaindb_abi(code);
-            return context.chaindb.upper_bound({code, scope, table, index}, pk).cursor;
+            return context.chaindb.upper_bound({code, scope, table, 0}, pk).cursor;
         }
 
         cursor_t chaindb_locate_to(
@@ -81,7 +81,8 @@ namespace eosio { namespace chain {
 
         primary_key_t chaindb_next(account_name_t code, cursor_t cursor) {
             // cursor is already opened -> no reason to check ABI for it
-            return context.chaindb.next({code, cursor});
+            auto pk = context.chaindb.next({code, cursor});
+            return pk;
         }
 
         primary_key_t chaindb_prev(account_name_t code, cursor_t cursor) {
@@ -92,24 +93,37 @@ namespace eosio { namespace chain {
         int32_t chaindb_datasize(account_name_t code, cursor_t cursor) {
             // cursor is already opened -> no reason to check ABI for it
 
-            auto  cache = context.chaindb.get_cache_object({code, cursor}, true);
-            auto& blob  = cache->blob();
-            CYBERWAY_ASSERT(blob.size() < 1024 * 1024, cyberway::chaindb::invalid_data_size_exception,
-                "Wrong data size ${data_size}", ("object_size", blob.size()));
-            return static_cast<int32_t>(blob.size());
+            auto cache = context.chaindb.get_cache_object({code, cursor}, true);
+            if (cache) {
+                auto& blob = cache->blob();
+                CYBERWAY_ASSERT(blob.size() < 1024 * 1024, cyberway::chaindb::invalid_data_size_exception,
+                    "Wrong data size ${data_size}", ("object_size", blob.size()));
+                return static_cast<int32_t>(blob.size());
+            }
+            return 0;
         }
 
         primary_key_t chaindb_data(account_name_t code, cursor_t cursor, array_ptr<char> data, size_t size) {
             // cursor is already opened -> no reason to check ABI for it
 
-            auto  cache = context.chaindb.get_cache_object({code, cursor}, false);
-            auto& blob  = cache->blob();
-            CYBERWAY_ASSERT(blob.size() == size, cyberway::chaindb::invalid_data_size_exception,
-                "Wrong data size (${data_size} != ${object_size})",
-                ("data_size", size)("object_size", blob.size()));
+            auto   cache = context.chaindb.get_cache_object({code, cursor}, false);
+            size_t blob_size = 0;
 
-            std::memcpy(data.value, blob.data(), blob.size());
-            return cache->pk();
+            if (cache) {
+                blob_size = cache->blob().size();
+            }
+
+            CYBERWAY_ASSERT(blob_size == size, cyberway::chaindb::invalid_data_size_exception,
+                "Wrong data size (${data_size} != ${object_size})",
+                ("data_size", size)("object_size", blob_size));
+
+            if (cache) {
+                auto& blob = cache->blob();
+                std::memcpy(data.value, blob.data(), blob.size());
+                return cache->pk();
+            }
+
+            return cyberway::chaindb::end_primary_key;
         }
 
         primary_key_t chaindb_available_primary_key(account_name_t code, account_name_t scope, table_name_t table) {
@@ -165,9 +179,9 @@ namespace eosio { namespace chain {
         (chaindb_locate_to,   int(int64_t, int64_t, int64_t, int64_t, int64_t, int, int) )
 
         (chaindb_lower_bound,    int(int64_t, int64_t, int64_t, int64_t, int, int) )
-        (chaindb_lower_bound_pk, int(int64_t, int64_t, int64_t, int64_t, int64_t)  )
+        (chaindb_lower_bound_pk, int(int64_t, int64_t, int64_t, int64_t)           )
         (chaindb_upper_bound,    int(int64_t, int64_t, int64_t, int64_t, int, int) )
-        (chaindb_upper_bound_pk, int(int64_t, int64_t, int64_t, int64_t, int64_t)  )
+        (chaindb_upper_bound_pk, int(int64_t, int64_t, int64_t, int64_t)           )
 
         (chaindb_current,     int64_t(int64_t, int) )
         (chaindb_next,        int64_t(int64_t, int) )

--- a/libraries/chain/wasm_chaindb_interface.ipp
+++ b/libraries/chain/wasm_chaindb_interface.ipp
@@ -30,6 +30,13 @@ namespace eosio { namespace chain {
             return context.chaindb.lower_bound({code, scope, table, index}, key, size).cursor;
         }
 
+        cursor_t chaindb_lower_bound_pk(
+            account_name_t code, account_name_t scope, table_name_t table, index_name_t index, primary_key_t pk
+        ) {
+            context.lazy_init_chaindb_abi(code);
+            return context.chaindb.lower_bound({code, scope, table, index}, pk).cursor;
+        }
+
         cursor_t chaindb_upper_bound(
             account_name_t code, account_name_t scope, table_name_t table, index_name_t index,
             array_ptr<const char> key, size_t size
@@ -38,17 +45,26 @@ namespace eosio { namespace chain {
             return context.chaindb.upper_bound({code, scope, table, index}, key, size).cursor;
         }
 
-        cursor_t chaindb_opt_find_by_pk(account_name_t code, account_name_t scope, table_name_t table, primary_key_t pk) {
+        cursor_t chaindb_upper_bound_pk(
+            account_name_t code, account_name_t scope, table_name_t table, index_name_t index, primary_key_t pk
+        ) {
             context.lazy_init_chaindb_abi(code);
-            return context.chaindb.opt_find_by_pk({code, scope, table}, pk).cursor;
+            return context.chaindb.upper_bound({code, scope, table, index}, pk).cursor;
         }
 
-        cursor_t chaindb_find(
+        cursor_t chaindb_locate_to(
             account_name_t code, account_name_t scope, table_name_t table, index_name_t index,
             primary_key_t pk, array_ptr<const char> key, size_t size
         ) {
             context.lazy_init_chaindb_abi(code);
             return context.chaindb.locate_to({code, scope, table, index}, key, size, pk).cursor;
+        }
+
+        cursor_t chaindb_begin(
+            account_name_t code, account_name_t scope, table_name_t table, index_name_t index
+        ) {
+            context.lazy_init_chaindb_abi(code);
+            return context.chaindb.begin({code, scope, table, index}).cursor;
         }
 
         cursor_t chaindb_end(
@@ -75,12 +91,25 @@ namespace eosio { namespace chain {
 
         int32_t chaindb_datasize(account_name_t code, cursor_t cursor) {
             // cursor is already opened -> no reason to check ABI for it
-            return context.chaindb.datasize({code, cursor});
+
+            auto  cache = context.chaindb.get_cache_object({code, cursor}, true);
+            auto& blob  = cache->blob();
+            CYBERWAY_ASSERT(blob.size() < 1024 * 1024, cyberway::chaindb::invalid_data_size_exception,
+                "Wrong data size ${data_size}", ("object_size", blob.size()));
+            return static_cast<int32_t>(blob.size());
         }
 
-        primary_key_t chaindb_data(account_name_t code, cursor_t cursor, array_ptr<const char> data, size_t size) {
+        primary_key_t chaindb_data(account_name_t code, cursor_t cursor, array_ptr<char> data, size_t size) {
             // cursor is already opened -> no reason to check ABI for it
-            return context.chaindb.data({code, cursor}, data, size);
+
+            auto  cache = context.chaindb.get_cache_object({code, cursor}, false);
+            auto& blob  = cache->blob();
+            CYBERWAY_ASSERT(blob.size() == size, cyberway::chaindb::invalid_data_size_exception,
+                "Wrong data size (${data_size} != ${object_size})",
+                ("data_size", size)("object_size", blob.size()));
+
+            std::memcpy(data.value, blob.data(), blob.size());
+            return cache->pk();
         }
 
         primary_key_t chaindb_available_primary_key(account_name_t code, account_name_t scope, table_name_t table) {
@@ -130,12 +159,15 @@ namespace eosio { namespace chain {
         (chaindb_clone,       int(int64_t, int)  )
         (chaindb_close,       void(int64_t, int) )
 
-        (chaindb_opt_find_by_pk, int(int64_t, int64_t, int64_t, int64_t))
+        (chaindb_begin,       int(int64_t, int64_t, int64_t, int64_t) )
+        (chaindb_end,         int(int64_t, int64_t, int64_t, int64_t) )
 
-        (chaindb_lower_bound, int(int64_t, int64_t, int64_t, int64_t, int, int)          )
-        (chaindb_upper_bound, int(int64_t, int64_t, int64_t, int64_t, int, int)          )
-        (chaindb_find,        int(int64_t, int64_t, int64_t, int64_t, int64_t, int, int) )
-        (chaindb_end,         int(int64_t, int64_t, int64_t, int64_t)                    )
+        (chaindb_locate_to,   int(int64_t, int64_t, int64_t, int64_t, int64_t, int, int) )
+
+        (chaindb_lower_bound,    int(int64_t, int64_t, int64_t, int64_t, int, int) )
+        (chaindb_lower_bound_pk, int(int64_t, int64_t, int64_t, int64_t, int64_t)  )
+        (chaindb_upper_bound,    int(int64_t, int64_t, int64_t, int64_t, int, int) )
+        (chaindb_upper_bound_pk, int(int64_t, int64_t, int64_t, int64_t, int64_t)  )
 
         (chaindb_current,     int64_t(int64_t, int) )
         (chaindb_next,        int64_t(int64_t, int) )

--- a/libraries/chain/wasm_chaindb_interface.ipp
+++ b/libraries/chain/wasm_chaindb_interface.ipp
@@ -48,7 +48,7 @@ namespace eosio { namespace chain {
             primary_key_t pk, array_ptr<const char> key, size_t size
         ) {
             context.lazy_init_chaindb_abi(code);
-            return context.chaindb.find({code, scope, table, index}, pk, key, size).cursor;
+            return context.chaindb.locate_to({code, scope, table, index}, key, size, pk).cursor;
         }
 
         cursor_t chaindb_end(

--- a/unittests/identity_tests.cpp
+++ b/unittests/identity_tests.cpp
@@ -124,7 +124,7 @@ public:
 
    fc::variant get_certrow(uint64_t identity, const string& property, uint64_t trusted, const string& certifier) {
       auto& chaindb = control->chaindb();
-      auto find = cyberway::chaindb::lower_bound(
+      auto find = cyberway::chaindb::lower_bound<false>()(
          chaindb,
          {N(identity), identity, N( certs ), N(bytuple)},
          boost::make_tuple(string_to_name(property.c_str()), trusted, string_to_name(certifier.c_str())));

--- a/unittests/special_accounts_tests.cpp
+++ b/unittests/special_accounts_tests.cpp
@@ -31,8 +31,7 @@ BOOST_AUTO_TEST_SUITE(special_account_tests)
 BOOST_FIXTURE_TEST_CASE(accounts_exists, tester)
 { try {
 
-      tester test;
-      chain::controller *control = test.control.get();
+      chain::controller *control = this->control.get();
       auto& chain1_db = control->chaindb();
 
       auto nobody = chain1_db.find<account_object, by_name>(config::null_account_name);


### PR DESCRIPTION
Resolve #425 - implement LRU for cache items.
Resolve #426 - refactor mongodb to use min/max instead of find
Resolve #427 - using of cache for find requests from interchain-tables
Resolve #515 - using of cache for find requests from contract-tables.