### PR TITLE
 Import stake agents and grants to genesis #378

### DIFF
--- a/libraries/chain/genesis/genesis_import.cpp
+++ b/libraries/chain/genesis/genesis_import.cpp
@@ -71,7 +71,7 @@ struct genesis_import::impl final {
                             abi_def abi;
                             if (abi_serializer::to_abi(abi_bytes, abi) ) {
                                 db.add_abi(n, abi);
-                                std::cout << "  add " << n << " abi";
+                                std::cout << "  add " << n << " abi" << std::endl;
                             } else {
                                 elog("Failed to read abi provided in ${a} contract", ("a",n));
                             }

--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -6,6 +6,7 @@
 #include <eosio/chain/config.hpp>
 #include <eosio/chain/authorization_manager.hpp>
 #include <eosio/chain/resource_limits.hpp>
+#include <eosio/chain/stake_object.hpp>
 #include <fc/io/raw.hpp>
 #include <fc/variant.hpp>
 #include <boost/filesystem/path.hpp>
@@ -58,8 +59,8 @@ constexpr uint64_t permissions_tbl_start_id = 17;       // Note: usage_id is id-
 
 
 account_name generate_name(string n);
-string pubkey_string(const golos::public_key_type& k);
-asset gbg2golos(const asset& gbg, const golos::price& price);
+string pubkey_string(const golos::public_key_type& k, bool prefix = true);
+asset convert_asset(const asset& src, const golos::price& price);
 asset golos2sys(const asset& golos);
 
 
@@ -226,6 +227,8 @@ struct genesis_create::genesis_create_impl final {
 
     state_object_visitor _visitor;
     fc::flat_map<acc_idx, account_name> _acc_names;
+
+    asset _total_staked;
 
     genesis_create_impl() {
         db.set_autoincrement<permission_object>(permissions_tbl_start_id);
@@ -426,7 +429,7 @@ struct genesis_create::genesis_create_impl final {
                 vector<key_weight> keys;
                 for (const auto& k: a.key_auths) {
                     // can't construct public key directly, constructor is private. transform to string first:
-                    const auto key = string(fc::crypto::config::public_key_legacy_prefix) + pubkey_string(k.first);
+                    const auto key = pubkey_string(k.first);
                     keys.emplace_back(key_weight{public_key_type(key), k.second});
                 }
                 vector<permission_level_weight> accounts;
@@ -474,10 +477,185 @@ struct genesis_create::genesis_create_impl final {
         std::cout << "Done." << std::endl;
     }
 
-    void store_balances() {
-        std::cout << "Creating balances..." << std::endl;
+    void store_stakes() {
+        std::cout << "Creating staking agents and grants..." << std::endl;
+        _total_staked = golos2sys(_visitor.gpo.total_vesting_fund_steem);
+        const auto sys_sym = asset().get_symbol();
+        const auto vests_sym = symbol(6,"GOLOS");   // Cyberway vesting
+        golos::price vprice{_visitor.gpo.total_vesting_shares, _total_staked};
 
-        // check invariants first
+        db.start_section(config::system_account_name, N(stake.stat), "stat_struct", 1);
+        db.emplace<stake_stat_object>([&](auto& s) {
+            s.token_code = sys_sym.to_symbol_code();
+            s.total_staked = _total_staked.get_amount();
+            s.enabled = false;      // ?
+        });
+        db.start_section(config::system_account_name, N(stake.param), "param_struct", 1);
+        db.emplace<stake_param_object>([&](auto& p) {
+            const auto inf = _info.params.stake;
+            p.token_symbol = sys_sym;
+            p.max_proxies = inf.max_proxies;
+            p.frame_length = inf.frame_length;
+            p.payout_step_length = inf.payout_step_length;
+            p.payout_steps_num = inf.payout_steps_num;
+            p.min_own_staked_for_election = inf.min_own_staked_for_election;
+        });
+
+        // first prepare staking balances and sort agents by levels. keys and proxy info requierd to do this
+        fc::flat_map<acc_idx,public_key_type> keys;         // agent:key
+        for (const auto& w: _visitor.witnesses) {
+            auto key = pubkey_string(w.signing_key);
+            keys[w.owner.id.value] = public_key_type(key);
+        }
+        fc::flat_map<acc_idx,acc_idx> proxies;              // grantor:agent
+        const auto& empty_acc = std::distance(_accs_map.begin(), std::find(_accs_map.begin(), _accs_map.end(), string("")));
+        for (const auto& a: _visitor.accounts) {
+            const auto& proxy = a.second.proxy.id.value;
+            if (proxy != empty_acc) {
+                proxies[a.first] = proxy;
+            }
+        }
+        std::map<name,string> names;
+        struct agent {
+            account_name name;
+            uint8_t level;
+            int64_t balance;
+            int64_t proxied;
+            int64_t own_share;
+            int64_t shares_sum;
+        };
+        using agents_map = fc::flat_map<acc_idx,agent>;
+        std::vector<agents_map> agents_by_level{5};
+        auto find_proxy_level = [&](acc_idx a) {
+            uint8_t l = 0;
+            if (keys.count(a)) {
+                return l;           // BP
+            }
+            l++;
+            while (l <= 4 && proxies.count(a) > 0) {
+                a = proxies[a];
+                l++;
+            }
+            return l;
+        };
+
+        std::cout << "  SYS staked = " << _total_staked << std::endl;
+        asset staked(0);
+        for (const auto& v: _visitor.vests) {
+            auto acc = v.first;
+            auto amount = convert_asset(asset(v.second.vesting, vests_sym), vprice);
+            staked += amount;
+            auto s = amount.get_amount();
+            agent x{generate_name(_accs_map[acc]), find_proxy_level(acc), s, 0, s, s};
+            agents_by_level[x.level].emplace(acc, std::move(x));
+            names[x.name] = _accs_map[acc];
+        }
+        std::cout << "  actual staked = " << staked << std::endl;
+        std::cout << "    diff staked = " << (_total_staked - staked) << std::endl;     // TODO: diff should be 0 #519
+
+        auto find_agent_level = [&](acc_idx acc, int upper_level) {
+            do {
+                upper_level--;
+            } while (upper_level > 0 && agents_by_level[upper_level].count(acc) == 0);
+            return upper_level;
+        };
+
+        // now it's possible to fill grants while moving by agents from largest level to 0
+        struct grant_info {
+            account_name from;
+            account_name to;
+            int16_t pct;
+            int64_t granted;
+        };
+        std::vector<grant_info> grants;
+        auto grant = [&](agent& from, agent& to, int64_t balance, int16_t pct) {
+            from.balance -= balance;
+            from.proxied += balance;
+            to.balance += balance;
+            to.shares_sum += balance;
+            grants.emplace_back(grant_info{from.name, to.name, pct, balance});
+        };
+
+        // process proxies first (levels 4-2) and direct votes later (level 1); level 0 have no grants, so skip it
+        for (int l = agents_by_level.size() - 1; l > 0; l--) {
+            auto& agents = agents_by_level[l];
+            for (auto& ag: agents) {
+                auto acc = ag.first;
+                auto& a = ag.second;
+                if (proxies.count(acc) > 0) {
+                    auto proxy = proxies[acc];
+                    auto proxy_lvl = find_agent_level(proxy, l);
+                    if (proxy_lvl >= 0) {
+                        grant(a, agents_by_level[proxy_lvl][proxy], a.balance, config::percent_100);
+                    } else {
+                        wlog("Proxy of ${a} not found from level ${l}", ("l",l-1)("a",names[a.name]));
+                    }
+                } else {
+                    if (l == 1) {
+                        // direct votes at this level
+                        const int max_votes = 30;
+                        const int16_t pct = config::percent_100 / max_votes;
+                        const auto& votes = _visitor.witness_votes[acc];
+                        auto& bps = agents_by_level[0];
+                        auto part = a.balance / max_votes;
+                        int n = 0;
+                        for (const auto& v: votes) {
+                            bool can_vote = bps.count(v) > 0;
+                            if (can_vote) {
+                                n++;
+                                bool last = n == max_votes;
+                                grant(a, bps[v], last ? a.balance : part, pct + (last ? config::percent_100 % max_votes : 0));
+                            } else {
+                                wlog("Skipping ${a} vote for ${w} (not BP)", ("a",names[a.name])("w",_accs_map[v]));
+                            }
+                        }
+                    } else {
+                        elog("No proxy for level ${l} (${a})", ("l",l)("a",names[a.name]));
+                    }
+                }
+            }
+        }
+        db.start_section(config::system_account_name, N(stake.grant), "grant_struct", grants.size());
+        for (const auto& g: grants) {
+            db.emplace<stake_grant_object>([&](auto& o) {
+                o.token_code = sys_sym.to_symbol_code(),
+                o.grantor_name = g.from,
+                o.agent_name = g.to,
+                o.pct = g.pct,
+                o.share = g.granted;
+                o.granted = g.granted;
+                o.break_fee = 0;
+                o.break_min_own_staked = 0;
+            });
+        }
+
+        db.start_section(config::system_account_name, N(stake.agent), "agent_struct", _visitor.vests.size());
+        for (const auto& abl: agents_by_level) {
+            for (auto& ag: abl) {
+                auto acc = ag.first;
+                auto& x = ag.second;
+                db.emplace<stake_agent_object>([&](auto& a) {
+                    a.token_code = sys_sym.to_symbol_code();
+                    a.account = x.name;
+                    a.proxy_level = x.level;
+                    a.votes = x.level ? 0 : x.balance;
+                    a.last_proxied_update = _conf.initial_timestamp;
+                    a.balance = x.balance;
+                    a.proxied = x.proxied;
+                    a.own_share = x.own_share;
+                    a.shares_sum = x.shares_sum;
+                    a.fee = 0;
+                    a.min_own_staked = 0;
+                    a.signing_key =
+                        (x.balance + x.proxied >= _info.params.stake.min_own_staked_for_election && keys.count(acc)) ?
+                            keys[acc] : public_key_type();      // TODO: reset key if old HF used #518
+                });
+            }
+        }
+        std::cout << "Done." << std::endl;
+    }
+
+    void check_assets_invariants() {
         auto& data = _visitor;
         const auto& gp = data.gpo;
         std::cout << " Global Properties:" << std::endl;
@@ -507,7 +685,14 @@ struct genesis_create::genesis_create_impl final {
         EOS_ASSERT(gests_diff.get_amount() == 0 && gls_diff.get_amount() == 0 && gbg_diff.get_amount() == 0,
             genesis_exception,
             "Failed while check balances invariants", ("gests", gests_diff)("golos", gls_diff)("gbg", gbg_diff));
+    }
 
+    void store_balances() {
+        std::cout << "Creating balances..." << std::endl;
+        check_assets_invariants();
+
+        auto& data = _visitor;
+        const auto& gp = data.gpo;
         golos::price price;
         if (gp.is_forced_min_price) {
             // This price limits SBD to 10% market cap
@@ -515,15 +700,11 @@ struct genesis_create::genesis_create_impl final {
         } else {
             EOS_ASSERT(false, genesis_exception, "Not implemented");
         }
-        auto gbg2gls = gbg2golos(gp.current_sbd_supply, price);
+        auto gbg2gls = convert_asset(gp.current_sbd_supply, price);
         std::cout << "GBG 2 GOLOS = " << gbg2gls << std::endl;
 
         // token stats
-#ifdef IMPORT_SYS_BALANCES
         const auto n_stats = 2;
-#else
-        const auto n_stats = 1;
-#endif
         db.start_section(config::token_account_name, N(stat), "currency_stats", n_stats);
 
         auto supply = gp.current_supply + gbg2gls;
@@ -542,9 +723,9 @@ struct genesis_create::genesis_create_impl final {
         const auto sys_sym = asset().get_symbol();
         const auto golos_sym = symbol(GLS);
         const auto vests_sym = symbol(6,"GOLOS");   // Cyberway vesting
-#ifdef IMPORT_SYS_BALANCES
-        auto sys_pk = insert_stat_record(sys_sym, golos2sys(supply), system_max_supply, config::system_account_name);
-#endif
+
+        auto sys_supply = golos2sys(supply - gp.total_reward_fund_steem);
+        auto sys_pk = insert_stat_record(sys_sym, sys_supply, system_max_supply, config::system_account_name);
         auto gls_pk = insert_stat_record(golos_sym, supply, golos_max_supply, issuer_account_name);
 
         // vesting info
@@ -557,13 +738,10 @@ struct genesis_create::genesis_create_impl final {
         db.insert(tbl, vests_pk, vests_info, ram_payer);
 
         // funds
-#ifdef IMPORT_SYS_BALANCES
-        const auto n_balances = 2 + 2*data.gbg.size();
-#else
-        const auto n_balances = 2 + data.gbg.size();
-#endif
+        const auto n_balances = 3 + 2*data.gbg.size();
         db.start_section(config::token_account_name, N(accounts), "account", n_balances);
-        // TODO: convert vesting to staking and burn system tokens in reward pool?
+        db.insert({config::token_account_name, config::stake_account_name, N(accounts)}, sys_pk,
+            mvo("balance", _total_staked)("payments", asset(0, golos_sym)), ram_payer);
         db.insert({config::token_account_name, gls_vest_account_name, N(accounts)}, gls_pk,
             mvo("balance", gp.total_vesting_fund_steem)("payments", asset(0, golos_sym)), ram_payer);
         db.insert({config::token_account_name, gls_post_account_name, N(accounts)}, gls_pk,
@@ -575,15 +753,13 @@ struct genesis_create::genesis_create_impl final {
         for (const auto& balance: data.gbg) {
             auto acc = balance.first;
             auto gbg = balance.second;
-            auto gls = data.gls[acc] + gbg2golos(gbg, price);
+            auto gls = data.gls[acc] + convert_asset(gbg, price);
             total_gls += gls;
             auto n = generate_name(_accs_map[acc]);
             db.insert({config::token_account_name, n, N(accounts)}, gls_pk,
                 mvo("balance", gls)("payments", asset(0, golos_sym)), ram_payer);
-#ifdef IMPORT_SYS_BALANCES
             db.insert({config::token_account_name, n, N(accounts)}, sys_pk,
                 mvo("balance", golos2sys(gls))("payments", asset(0, sys_sym)), ram_payer);
-#endif
         }
 
         db.start_section(gls_vest_account_name, N(accounts), "account", data.vests.size());
@@ -604,7 +780,7 @@ struct genesis_create::genesis_create_impl final {
             const auto n = generate_name(_accs_map[acc]);
             db.insert({gls_vest_account_name, n, N(accounts)}, vests_pk, vests_obj, ram_payer);
         }
-        // TODO: update gbg2golos to uniformly distribute rounded amount
+        // TODO: update convert_asset to uniformly distribute rounded amount #519
         std::cout << " Total accounts' GOLOS + converted GBG = " << total_gls << "; diff = " <<
             (supply - (gp.total_vesting_fund_steem + gp.total_reward_fund_steem) - total_gls) << std::endl;
 
@@ -660,7 +836,7 @@ struct genesis_create::genesis_create_impl final {
             const auto& a = acc.second;
             if (a.proxy.id.value != empty_acc) {
                 bool found = false;
-                auto final_proxy = a.proxy.id;
+                auto final_proxy = a.proxy.id.value;
                 for (int depth = 0; !found && depth < 4; depth++) {
                     const auto& proxy = _visitor.accounts[final_proxy].proxy.id.value;
                     found = proxy == empty_acc;
@@ -747,6 +923,7 @@ void genesis_create::write_genesis(
     _impl->prepare_writer(out_file);
     _impl->store_contracts();
     _impl->store_accounts();
+    _impl->store_stakes();
     _impl->store_balances();
     _impl->store_delegation_records();    // TODO: withdrawals
     _impl->store_witnesses();
@@ -766,22 +943,24 @@ account_name generate_name(string n) {
     return account_name(h & 0xFFFFFFFFFFFFFFF0);
 }
 
-string pubkey_string(const golos::public_key_type& k) {
+string pubkey_string(const golos::public_key_type& k, bool prefix/* = true*/) {
     using checksummer = fc::crypto::checksummed_data<golos::public_key_type>;
     checksummer wrapper;
     wrapper.data = k;
     wrapper.check = checksummer::calculate_checksum(wrapper.data);
     auto packed = raw::pack(wrapper);
-    return fc::to_base58(packed.data(), packed.size());
+    auto tail = fc::to_base58(packed.data(), packed.size());
+    return prefix ? string(fc::crypto::config::public_key_legacy_prefix) + tail : tail;
 }
 
-asset gbg2golos(const asset& gbg, const golos::price& price) {
+asset convert_asset(const asset& src, const golos::price& price) {
     return asset(
-        static_cast<int64_t>(static_cast<eosio::chain::int128_t>(gbg.get_amount()) * price.quote.get_amount() / price.base.get_amount()),
+        static_cast<int64_t>(static_cast<eosio::chain::int128_t>(src.get_amount()) * price.quote.get_amount() / price.base.get_amount()),
         price.quote.get_symbol()
     );
 }
 
+// TODO: remove hardcode #519
 asset golos2sys(const asset& golos) {
     return asset(golos.get_amount() * (10000/1000));
 }

--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -496,7 +496,7 @@ struct genesis_create::genesis_create_impl final {
             p.token_symbol = sys_sym;
             p.max_proxies = inf.max_proxies;
             p.frame_length = inf.frame_length;
-            p.payout_step_length = inf.payout_step_length;
+            p.payout_step_lenght = inf.payout_step_length;
             p.payout_steps_num = inf.payout_steps_num;
             p.min_own_staked_for_election = inf.min_own_staked_for_election;
         });

--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -645,7 +645,7 @@ struct genesis_create::genesis_create_impl final {
                 o.pct = g.pct,
                 o.share = g.granted;
                 o.granted = g.granted;
-                o.break_fee = 0;
+                o.break_fee = config::percent_100;
                 o.break_min_own_staked = 0;
             });
         }
@@ -665,7 +665,7 @@ struct genesis_create::genesis_create_impl final {
                     a.proxied = x.proxied;
                     a.own_share = x.own_share;
                     a.shares_sum = x.shares_sum;
-                    a.fee = 0;
+                    a.fee = config::percent_100;
                     a.min_own_staked = 0;
                     a.signing_key =
                         (x.own_staked() >= _info.params.stake.min_own_staked_for_election && keys.count(acc)) ?

--- a/programs/create-genesis/genesis_info.hpp
+++ b/programs/create-genesis/genesis_info.hpp
@@ -26,10 +26,27 @@ struct genesis_info {
     bfs::path state_file;   // ? file_hash
     bfs::path genesis_json;
     std::vector<account> accounts;
+
+    // parameters
+    struct stake_params {
+        std::vector<uint8_t> max_proxies;
+        int64_t frame_length;
+        int64_t payout_step_length;
+        uint16_t payout_steps_num;
+        int64_t min_own_staked_for_election = 0;
+    };
+
+    struct parameters {
+        stake_params stake;
+    } params;
+    // parameters params;
 };
 
 }} // cyberway::genesis
 
 FC_REFLECT(cyberway::genesis::genesis_info::file_hash, (path)(hash))
 FC_REFLECT(cyberway::genesis::genesis_info::account, (name)(owner_key)(active_key)(abi)(code))
-FC_REFLECT(cyberway::genesis::genesis_info, (state_file)(genesis_json)(accounts))
+FC_REFLECT(cyberway::genesis::genesis_info::stake_params,
+    (max_proxies)(frame_length)(payout_step_length)(payout_steps_num)(min_own_staked_for_election))
+FC_REFLECT(cyberway::genesis::genesis_info::parameters, (stake))
+FC_REFLECT(cyberway::genesis::genesis_info, (state_file)(genesis_json)(accounts)(params))

--- a/programs/create-genesis/serializer.hpp
+++ b/programs/create-genesis/serializer.hpp
@@ -20,7 +20,8 @@ const fc::microseconds abi_serializer_max_time = fc::seconds(10);
 
 using resource_limits::resource_usage_object;
 // There sould be proper way to get type name for abi, but it was faster to implement this
-template<typename T> type_name get_type_name() { return ""; }
+template<typename T> bool get_type_name_fail() { return false; }
+template<typename T> type_name get_type_name() { static_assert(get_type_name_fail<T>(), "specialize type"); return ""; }
 template<> type_name get_type_name<permission_object>()         { return "permission_object"; }
 template<> type_name get_type_name<permission_usage_object>()   { return "permission_usage_object"; }
 template<> type_name get_type_name<account_object>()            { return "account_object"; }
@@ -28,6 +29,10 @@ template<> type_name get_type_name<account_sequence_object>()   { return "accoun
 template<> type_name get_type_name<resource_usage_object>()     { return "resource_usage_object"; }
 template<> type_name get_type_name<domain_object>()             { return "domain_object"; }
 template<> type_name get_type_name<username_object>()           { return "username_object"; }
+template<> type_name get_type_name<stake_agent_object>()        { return "stake_agent_object"; }
+template<> type_name get_type_name<stake_grant_object>()        { return "stake_grant_object"; }
+template<> type_name get_type_name<stake_param_object>()        { return "stake_param_object"; }
+template<> type_name get_type_name<stake_stat_object>()         { return "stake_stat_object"; }
 
 
 enum class stored_contract_tables: int {
@@ -36,6 +41,9 @@ enum class stored_contract_tables: int {
     token_balance,  vesting_balance,
     delegation,     rdelegation,
     witness_vote,   witness_info,
+    // the following are system tables, but it's simpler to have them here
+    stake_agents,   stake_grants,
+    stake_stats,    stake_params,
 
     _max                // to simplify setting tables_count of genesis container
 };


### PR DESCRIPTION
Import rules:
1. All witnesses become BPs, votes, casted by them removed (BPs vote only for self)
2. Votes for witnesses transformed to grants giving 1/30th of voter's balance and 3.33% (self votes removed)
3. If account have proxy, then his votes ignored and created grant with 100%

Other changes:
+ import to system balances enabled
+ genesis_info.json now contains stake parameters
+ invariants check moved to it's own function
+ better helper functions
+ static assert added to prevent usage non-specialized `get_type_name()`
***
Note: set `min_own_staked_for_election` in genesis-info.json to disable witnesses (miners, etc) with low own stake.