### PR TITLE
Compensate rounding when convert genesis balances #519

### DIFF
--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -2,6 +2,7 @@
 #include "golos_objects.hpp"
 #include "genesis_create.hpp"
 #include "golos_state_container.hpp"
+#include "supply_distributor.hpp"
 #include "serializer.hpp"
 #include <eosio/chain/config.hpp>
 #include <eosio/chain/authorization_manager.hpp>
@@ -47,7 +48,7 @@ static constexpr uint64_t gls_post_account_name  = N(gls.publish);
 constexpr auto GBG = SY(3,GBG);
 constexpr auto GLS = SY(3,GOLOS);
 constexpr auto GESTS = SY(6,GESTS);
-constexpr auto VESTS = SY(6,GOLOS);                 // Cyberway vesting
+constexpr auto VESTS = SY(6,GOLOS);                 // Golos dApp vesting
 constexpr auto posting_auth_name = "posting";
 constexpr auto golos_account_name = "golos";
 constexpr auto issuer_account_name = config::system_account_name;   // ?cyberfounder
@@ -66,7 +67,6 @@ constexpr uint64_t permissions_tbl_start_id = 17;       // Note: usage_id is id-
 
 account_name generate_name(string n);
 string pubkey_string(const golos::public_key_type& k, bool prefix = true);
-asset convert_asset(const asset& src, const golos::price& price);
 asset golos2sys(const asset& golos);
 
 
@@ -495,8 +495,6 @@ struct genesis_create::genesis_create_impl final {
         std::cout << "Creating staking agents and grants..." << std::endl;
         _total_staked = golos2sys(_visitor.gpo.total_vesting_fund_steem);
         const auto sys_sym = asset().get_symbol();
-        const auto vests_sym = symbol(6,"GOLOS");   // Cyberway vesting
-        golos::price vprice{_visitor.gpo.total_vesting_shares, _total_staked};
 
         db.start_section(config::system_account_name, N(stake.stat), "stat_struct", 1);
         db.emplace<stake_stat_object>([&](auto& s) {
@@ -558,10 +556,11 @@ struct genesis_create::genesis_create_impl final {
         };
 
         std::cout << "  SYS staked = " << _total_staked << std::endl;
+        supply_distributor to_sys(_total_staked, _visitor.gpo.total_vesting_shares);
         asset staked(0);
         for (const auto& v: _visitor.vests) {
             auto acc = v.first;
-            auto amount = convert_asset(asset(v.second.vesting, vests_sym), vprice);
+            auto amount = to_sys.convert(asset(v.second.vesting, symbol(VESTS)));
             staked += amount;
             auto s = amount.get_amount();
             agent x{generate_name(_accs_map[acc]), find_proxy_level(acc), s, 0, s, s};
@@ -569,7 +568,8 @@ struct genesis_create::genesis_create_impl final {
             names[x.name] = _accs_map[acc];
         }
         std::cout << "  actual staked = " << staked << std::endl;
-        std::cout << "    diff staked = " << (_total_staked - staked) << std::endl;     // TODO: diff should be 0 #519
+        std::cout << "    diff staked = " << (_total_staked - staked) << std::endl;
+        EOS_ASSERT(_total_staked == staked, genesis_exception, "Staking supply differs from sum of balances");
 
         auto find_agent_level = [&](acc_idx acc, int upper_level) {
             do {
@@ -721,14 +721,16 @@ struct genesis_create::genesis_create_impl final {
         } else {
             EOS_ASSERT(false, genesis_exception, "Not implemented");
         }
-        auto gbg2gls = convert_asset(gp.current_sbd_supply, price);
-        std::cout << "GBG 2 GOLOS = " << gbg2gls << std::endl;
+        supply_distributor to_gls(price.quote, price.base);     // flip price to convert GBG to GOLOS
+        auto golos_from_gbg = to_gls.convert(gp.current_sbd_supply);
+        std::cout << "GBG 2 GOLOS = " << golos_from_gbg << std::endl;
+        to_gls.reset();
 
         // token stats
         const auto n_stats = 2;
         db.start_section(config::token_account_name, N(stat), "currency_stats", n_stats);
 
-        auto supply = gp.current_supply + gbg2gls;
+        auto supply = gp.current_supply + golos_from_gbg;
         ram_payer_info ram_payer{};
         auto insert_stat_record = [&](const symbol& sym, const asset& supply, int64_t max_supply, name issuer) {
             table_request tbl{config::token_account_name, sym.value(), N(stat)};
@@ -768,12 +770,12 @@ struct genesis_create::genesis_create_impl final {
             mvo("balance", gp.total_reward_fund_steem)("payments", asset(0, golos_sym)), ram_payer);
         // TODO: internal pool of posting contract
 
-        // accounts GOLOS/GESTS
+        // accounts GOLOS
         asset total_gls = asset(0, golos_sym);
         for (const auto& balance: data.gbg) {
             auto acc = balance.first;
             auto gbg = balance.second;
-            auto gls = data.gls[acc] + convert_asset(gbg, price);
+            auto gls = data.gls[acc] + to_gls.convert(gbg);
             total_gls += gls;
             auto n = generate_name(_accs_map[acc]);
             db.insert({config::token_account_name, n, N(accounts)}, gls_pk,
@@ -781,7 +783,12 @@ struct genesis_create::genesis_create_impl final {
             db.insert({config::token_account_name, n, N(accounts)}, sys_pk,
                 mvo("balance", golos2sys(gls))("payments", asset(0, sys_sym)), ram_payer);
         }
+        const auto liquid_supply = supply - (gp.total_vesting_fund_steem + gp.total_reward_fund_steem); // no funds
+        std::cout << " Total sum of GOLOS + converted GBG = " << total_gls
+            << "; diff = " << (liquid_supply - total_gls) << std::endl;
+        EOS_ASSERT(liquid_supply == total_gls, genesis_exception, "GOLOS supply differs from sum of balances");
 
+        // accounts GESTS
         db.start_section(gls_vest_account_name, N(accounts), "account", data.vests.size());
         for (const auto& v: data.vests) {
             auto acc = v.first;
@@ -800,9 +807,6 @@ struct genesis_create::genesis_create_impl final {
             const auto n = generate_name(_accs_map[acc]);
             db.insert({gls_vest_account_name, n, N(accounts)}, vests_pk, vests_obj, ram_payer);
         }
-        // TODO: update convert_asset to uniformly distribute rounded amount #519
-        std::cout << " Total accounts' GOLOS + converted GBG = " << total_gls << "; diff = " <<
-            (supply - (gp.total_vesting_fund_steem + gp.total_reward_fund_steem) - total_gls) << std::endl;
 
         std::cout << "Done." << std::endl;
     }
@@ -998,8 +1002,8 @@ void genesis_create::write_genesis(
 
 
 account_name generate_name(string n) {
-    // TODO: replace with better function
-    // TODO: remove dots from result (+append trailing to length of 12 characters)
+    // TODO: replace with better function #527
+    // TODO: remove dots from result (+append trailing to length of 12 characters) #527
     uint64_t h = std::hash<std::string>()(n);
     return account_name(h & 0xFFFFFFFFFFFFFFF0);
 }
@@ -1014,16 +1018,10 @@ string pubkey_string(const golos::public_key_type& k, bool prefix/* = true*/) {
     return prefix ? string(fc::crypto::config::public_key_legacy_prefix) + tail : tail;
 }
 
-asset convert_asset(const asset& src, const golos::price& price) {
-    return asset(
-        static_cast<int64_t>(static_cast<eosio::chain::int128_t>(src.get_amount()) * price.quote.get_amount() / price.base.get_amount()),
-        price.quote.get_symbol()
-    );
-}
-
-// TODO: remove hardcode #519
 asset golos2sys(const asset& golos) {
-    return asset(golos.get_amount() * (10000/1000));
+    static const int64_t sys_precision = asset().get_symbol().precision();
+    return asset(eosio::chain::int_arithmetic::safe_prop(
+        golos.get_amount(), sys_precision, static_cast<int64_t>(golos.get_symbol().precision())));
 }
 
 }} // cyberway

--- a/programs/create-genesis/supply_distributor.hpp
+++ b/programs/create-genesis/supply_distributor.hpp
@@ -1,0 +1,37 @@
+#pragma once
+#include <eosio/chain/asset.hpp>
+#include <eosio/chain/int_arithmetic.hpp>
+
+namespace cyberway { namespace genesis {
+
+using namespace eosio::chain;
+
+
+class supply_distributor {
+    const int fract_bits = 18;                      // 18 bits is enough to cover rounding of all balances
+    const uint64_t mask = (1 << fract_bits) - 1;
+
+    uint32_t fraction;      // accumulating fraction from previous convertions to compensate rounding
+    asset price_base;       // premultiplied
+    asset price_quote;
+
+public:
+    supply_distributor(const asset& base, const asset& quote)
+    : price_base(asset(base.get_amount() << fract_bits, base.get_symbol()))
+    , price_quote(quote) {
+        reset();
+    }
+    asset convert(const asset& x) {
+        auto extended = int_arithmetic::safe_prop(x.get_amount(), price_base.get_amount(), price_quote.get_amount());
+        extended += fraction;
+        fraction = extended & mask;
+        return asset(extended >> fract_bits, price_base.get_symbol());
+    }
+    void reset() {
+        fraction = mask;    // mask is equal to max fractional part. makes 1st division ceil to compensate accumulated rounding in multiplied units
+    }
+
+};
+
+
+}} // cyberway::genesis


### PR DESCRIPTION
The problem is: 
1. supply == ∑balance
2. convert(supply) > ∑convert(balance)

It's required the second to be `==` too.
***
The idea is to accumulate fraction and "distribute" it when it "overflows" to integer. To achieve this, the price numerator pre-multiplied to make it fixed point.

Accumulated rounding issue may still occur. The number of bits (fract_bits) to extend should be enough to store number of balances (N): `N < (1<<fract_bits)`. This guarantees that even if each balance rounds down with lose, then initial fraction (set to make 1st division ceil) will cover final result.
In other words, each conversion possible rounds losing value of `1/fraction_mult`. But there at most N conversions, which is less than `fraction_mult`. So setting initial fraction to `fraction_mult-1` will compensate any rounding.

*Note: looks like there can be edge cases for handpicked numerator/denominator pair and balances, but it's not the case for genesis data.*