### PR TITLE
475 provideram ramowner

### DIFF
--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -4,6 +4,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/genesis_state_root_key.cpp.in ${CMAKE
 file(GLOB HEADERS "include/eosio/chain/*.hpp"
                   "include/eosio/chain/webassembly/*.hpp"
                   "include/cyberway/chaindb/*.hpp"
+                  "include/cyberway/chain/*.hpp"
                   "include/cyberway/genesis/*.hpp"
                   "${CMAKE_CURRENT_BINARY_DIR}/include/eosio/chain/core_symbol.hpp" )
 
@@ -53,7 +54,8 @@ add_library( eosio_chain
              chaindb/abi_info.cpp
              chaindb/ram_calculator.cpp
 
-             domain_name.cpp
+             cyberway/domain_name.cpp
+             cyberway/cyberway_contract.cpp
              genesis/genesis_import.cpp
              ${CHAINDB_SRCS}
 

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -12,6 +12,7 @@
 #include <boost/container/flat_set.hpp>
 
 #include <cyberway/chaindb/controller.hpp>
+#include <cyberway/chain/domain_object.hpp>
 
 using boost::container::flat_set;
 
@@ -148,10 +149,10 @@ void apply_context::exec( action_trace& trace )
 
 
 bool apply_context::is_domain(const domain_name& domain) const {
-   return nullptr != chaindb.find<domain_object,by_name>(domain);
+   return nullptr != chaindb.find<cyberway::chain::domain_object,by_name>(domain);
 }
 bool apply_context::is_username(const account_name& scope, const username& name) const {
-   return nullptr != chaindb.find<username_object,by_scope_name>(boost::make_tuple(scope,name));
+   return nullptr != chaindb.find<cyberway::chain::username_object,by_scope_name>(boost::make_tuple(scope,name));
 }
 account_name apply_context::get_domain_owner(const domain_name& domain) const {
    return control.get_domain(domain).owner;

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -240,7 +240,8 @@ struct controller_impl {
    SET_APP_HANDLER(cyber, cyber, unlinkauth);
 
    SET_APP_HANDLER(cyber, cyber, providebw);
-   SET_APP_HANDLER(cyber, cyber, requestbw);
+//TODO: requestbw
+//   SET_APP_HANDLER(cyber, cyber, requestbw);
    SET_APP_HANDLER(cyber, cyber, provideram);
 /*
    SET_APP_HANDLER(cyber, cyber, postrecovery);
@@ -798,41 +799,42 @@ struct controller_impl {
       return push_scheduled_transaction( *itr, deadline, billed_cpu_time_us, explicit_billed_cpu_time );
    }
 
-    void call_approvebw_actions(signed_transaction& call_provide_trx, transaction_context& trx_context) {
-        call_provide_trx.expiration = self.pending_block_time() + fc::microseconds(999'999); // Round up to avoid appearing expired
-        call_provide_trx.set_reference_block( self.head_block_id() );
-
-        trx_context.init_for_implicit_trx();
-        trx_context.exec();
-        trx_context.validate_bw_usage();
-
-        auto restore = make_block_restore_point();
-        fc::move_append( pending->_actions, move(trx_context.executed) );
-        trx_context.squash();
-        restore.cancel();
-    }
-
-    bandwith_request_result get_provided_bandwith(const vector<action>& actions, fc::time_point deadline)  {
-        signed_transaction call_provide_trx;
-        transaction_context trx_context( self, call_provide_trx, call_provide_trx.id());
-        for (const auto& action : actions) {
-            if (action.account == config::system_account_name && action.name == config::request_bw_action) {
-                const auto request_bw = action.data_as<requestbw>();
-                call_provide_trx.actions.emplace_back(
-                    vector<permission_level>{{request_bw.provider, config::active_name}},
-                    request_bw.provider,
-                    config::approve_bw_action,
-                    fc::raw::pack(approvebw(request_bw.account)));
-            }
-        }
-
-        if (!call_provide_trx.actions.empty()) {
-            trx_context.deadline = deadline;
-            call_approvebw_actions(call_provide_trx, trx_context);
-        }
-
-        return {trx_context.get_provided_bandwith(), trx_context.get_net_usage(), trx_context.get_cpu_usage()};
-    }
+// TODO: request bw, why provided?
+//    void call_approvebw_actions(signed_transaction& call_provide_trx, transaction_context& trx_context) {
+//        call_provide_trx.expiration = self.pending_block_time() + fc::microseconds(999'999); // Round up to avoid appearing expired
+//        call_provide_trx.set_reference_block( self.head_block_id() );
+//
+//        trx_context.init_for_implicit_trx();
+//        trx_context.exec();
+//        trx_context.validate_bw_usage();
+//
+//        auto restore = make_block_restore_point();
+//        fc::move_append( pending->_actions, move(trx_context.executed) );
+//        trx_context.squash();
+//        restore.cancel();
+//    }
+//
+//    bandwith_request_result get_provided_bandwith(const vector<action>& actions, fc::time_point deadline)  {
+//        signed_transaction call_provide_trx;
+//        transaction_context trx_context( self, call_provide_trx, call_provide_trx.id());
+//        for (const auto& action : actions) {
+//            if (action.account == config::system_account_name && action.name == config::request_bw_action) {
+//                const auto request_bw = action.data_as<requestbw>();
+//                call_provide_trx.actions.emplace_back(
+//                    vector<permission_level>{{request_bw.provider, config::active_name}},
+//                    request_bw.provider,
+//                    config::approve_bw_action,
+//                    fc::raw::pack(approvebw(request_bw.account)));
+//            }
+//        }
+//
+//        if (!call_provide_trx.actions.empty()) {
+//            trx_context.deadline = deadline;
+//            call_approvebw_actions(call_provide_trx, trx_context);
+//        }
+//
+//        return {trx_context.get_provided_bandwith(), trx_context.get_net_usage(), trx_context.get_cpu_usage()};
+//    }
 
    transaction_trace_ptr push_scheduled_transaction( const generated_transaction_object& gto, fc::time_point deadline, uint32_t billed_cpu_time_us, bool explicit_billed_cpu_time = false )
    try {
@@ -890,6 +892,7 @@ struct controller_impl {
       trx_context.billed_cpu_time_us = billed_cpu_time_us;
       trace = trx_context.trace;
       try {
+         //TODO: request bw, why provided?
          //auto bandwith_request_result = get_provided_bandwith(dtrx.actions, deadline);
          //trx_context.set_provided_bandwith(std::move(bandwith_request_result.bandwith));
          //trx_context.add_cpu_usage(bandwith_request_result.used_cpu);
@@ -1034,6 +1037,7 @@ struct controller_impl {
          trx_context.billed_cpu_time_us = billed_cpu_time_us;
          trace = trx_context.trace;
          try {
+            //TODO: request bw, why provided?
             //auto bandwith_request_result = get_provided_bandwith(trn.actions, deadline);
 
             //trx_context.set_provided_bandwith(std::move(bandwith_request_result.bandwith));

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -599,7 +599,7 @@ struct controller_impl {
       const auto& active_permission = authorization.create_permission({}, name, config::active_name, owner_permission.id,
                                                                       active, conf.genesis.initial_timestamp );
 
-      resource_limits.initialize_account(name);
+      resource_limits.initialize_account(name, {});
 
       // Does exist any reason to calculate ram usage for system accounts?
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -28,6 +28,8 @@
 
 #include <cyberway/chaindb/controller.hpp>
 #include <cyberway/genesis/genesis_import.hpp>
+#include <cyberway/chain/cyberway_contract_types.hpp>
+#include <cyberway/chain/cyberway_contract.hpp>
 
 namespace eosio { namespace chain {
 
@@ -41,8 +43,8 @@ using controller_index_set = index_set<
    block_summary_table,
    transaction_table,
    generated_transaction_table,
-   domain_table,
-   username_table
+   cyberway::chain::domain_table,
+   cyberway::chain::username_table
 >;
 
 class maybe_session {
@@ -231,6 +233,9 @@ struct controller_impl {
 #define SET_APP_HANDLER( receiver, contract, action) \
    set_apply_handler( #receiver, #contract, #action, &BOOST_PP_CAT(apply_, BOOST_PP_CAT(contract, BOOST_PP_CAT(_,action) ) ) )
 
+#define SET_CYBER_HANDLER( receiver, contract, action) \
+   set_apply_handler( #receiver, #contract, #action, &BOOST_PP_CAT(cyberway::chain::apply_, BOOST_PP_CAT(contract, BOOST_PP_CAT(_,action) ) ) )
+
    SET_APP_HANDLER(cyber, cyber, newaccount);
    SET_APP_HANDLER(cyber, cyber, setcode);
    SET_APP_HANDLER(cyber, cyber, setabi);
@@ -238,22 +243,22 @@ struct controller_impl {
    SET_APP_HANDLER(cyber, cyber, deleteauth);
    SET_APP_HANDLER(cyber, cyber, linkauth);
    SET_APP_HANDLER(cyber, cyber, unlinkauth);
+   SET_APP_HANDLER(cyber, cyber, canceldelay);
 
-   SET_APP_HANDLER(cyber, cyber, providebw);
+   SET_CYBER_HANDLER(cyber, cyber, providebw);
 //TODO: requestbw
-//   SET_APP_HANDLER(cyber, cyber, requestbw);
-   SET_APP_HANDLER(cyber, cyber, provideram);
+//   SET_CYBER_HANDLER(cyber, cyber, requestbw);
+   SET_CYBER_HANDLER(cyber, cyber, provideram);
 /*
-   SET_APP_HANDLER(cyber, cyber, postrecovery);
-   SET_APP_HANDLER(cyber, cyber, passrecovery);
-   SET_APP_HANDLER(cyber, cyber, vetorecovery);
+   SET_CYBER_HANDLER(cyber, cyber, postrecovery);
+   SET_CYBER_HANDLER(cyber, cyber, passrecovery);
+   SET_CYBER_HANDLER(cyber, cyber, vetorecovery);
 */
 
-   SET_APP_HANDLER(cyber, cyber, canceldelay);
 
 #define SET_CONTRACT_HANDLER(contract, action, function) set_apply_handler(contract, contract, #action, function);
 #define SET_DOTCONTRACT_HANDLER(base, sub, action) SET_CONTRACT_HANDLER(#base "." #sub, action, \
-    &BOOST_PP_CAT(apply_, BOOST_PP_CAT(base, BOOST_PP_CAT(_, BOOST_PP_CAT(sub, BOOST_PP_CAT(_,action))))))
+    &BOOST_PP_CAT(cyberway::chain::apply_, BOOST_PP_CAT(base, BOOST_PP_CAT(_, BOOST_PP_CAT(sub, BOOST_PP_CAT(_,action))))))
 #define SET_CYBER_DOMAIN_HANDLER(action) SET_DOTCONTRACT_HANDLER(cyber, domain, action)
 
     SET_CYBER_DOMAIN_HANDLER(newusername);

--- a/libraries/chain/cyberway/cyberway_contract.cpp
+++ b/libraries/chain/cyberway/cyberway_contract.cpp
@@ -1,0 +1,111 @@
+#include <eosio/chain/controller.hpp>
+#include <eosio/chain/transaction_context.hpp>
+#include <eosio/chain/apply_context.hpp>
+#include <eosio/chain/transaction.hpp>
+#include <eosio/chain/exceptions.hpp>
+
+#include <eosio/chain/account_object.hpp>
+
+#include <eosio/chain/authorization_manager.hpp>
+#include <eosio/chain/resource_limits.hpp>
+
+#include <cyberway/chaindb/controller.hpp>
+#include <cyberway/chain/cyberway_contract.hpp>
+#include <cyberway/chain/cyberway_contract_types.hpp>
+
+namespace cyberway { namespace chain {
+
+void apply_cyber_providebw(apply_context& context) {
+    auto args = context.act.data_as<providebw>();
+    context.require_authorization(args.provider);
+}
+
+// TODO: requestbw
+//void apply_cyber_requestbw(apply_context& context) {
+//   auto args = context.act.data_as<requestbw>();
+//   context.require_authorization(args.account);
+//}
+
+void apply_cyber_provideram(apply_context& context) {
+    auto args = context.act.data_as<provideram>();
+    context.require_authorization(args.provider);
+}
+
+void apply_cyber_domain_newdomain(apply_context& context) {
+    auto op = context.act.data_as<newdomain>();
+    try {
+        context.require_authorization(op.creator);
+        validate_domain_name(op.name);             // TODO: can move validation to domain_name deserializer
+        auto& chaindb = context.chaindb;
+        auto exists = chaindb.find<domain_object, by_name>(op.name);
+        EOS_ASSERT(exists == nullptr, eosio::chain::domain_exists_exception,
+            "Cannot create domain named ${n}, as that name is already taken", ("n", op.name));
+        chaindb.emplace<domain_object>(context.get_ram_payer(op.creator), [&](auto& d) {
+            d.owner = op.creator;
+            d.creation_date = context.control.pending_block_time();
+            d.name = op.name;
+        });
+    } FC_CAPTURE_AND_RETHROW((op))
+}
+
+void apply_cyber_domain_passdomain(apply_context& context) {
+    auto op = context.act.data_as<passdomain>();
+    try {
+        context.require_authorization(op.from);   // TODO: special case if nobody owns domain
+        validate_domain_name(op.name);
+        const auto& domain = context.control.get_domain(op.name);
+        EOS_ASSERT(op.from == domain.owner, eosio::chain::action_validate_exception, "Only owner can pass domain name");
+        context.chaindb.modify(domain, context.get_ram_payer(op.to), [&](auto& d) {
+            d.owner = op.to;
+        });
+    } FC_CAPTURE_AND_RETHROW((op))
+}
+
+void apply_cyber_domain_linkdomain(apply_context& context) {
+    auto op = context.act.data_as<linkdomain>();
+    try {
+        context.require_authorization(op.owner);
+        validate_domain_name(op.name);
+        const auto& domain = context.control.get_domain(op.name);
+        EOS_ASSERT(op.owner == domain.owner, eosio::chain::action_validate_exception, "Only owner can change domain link");
+        EOS_ASSERT(op.to != domain.linked_to, eosio::chain::action_validate_exception, "Domain name already linked to the same account");
+        context.chaindb.modify(domain, context.get_ram_payer(domain.owner), [&](auto& d) {
+            d.linked_to = op.to;
+        });
+    } FC_CAPTURE_AND_RETHROW((op))
+}
+
+void apply_cyber_domain_unlinkdomain(apply_context& context) {
+    auto op = context.act.data_as<unlinkdomain>();
+    try {
+        context.require_authorization(op.owner);
+        validate_domain_name(op.name);
+        const auto& domain = context.control.get_domain(op.name);
+        EOS_ASSERT(op.owner == domain.owner, eosio::chain::action_validate_exception, "Only owner can unlink domain");
+        EOS_ASSERT(domain.linked_to != account_name(), eosio::chain::action_validate_exception, "Domain name already unlinked");
+        context.chaindb.modify(domain, context.get_ram_payer(domain.owner), [&](auto& d) {
+            d.linked_to = account_name();
+        });
+    } FC_CAPTURE_AND_RETHROW((op))
+}
+
+void apply_cyber_domain_newusername(apply_context& context) {
+    auto op = context.act.data_as<newusername>();
+    try {
+        context.require_authorization(op.creator);
+        validate_username(op.name);               // TODO: can move validation to username deserializer
+        auto& chaindb = context.chaindb;
+        auto exists = chaindb.find<username_object, by_scope_name>(boost::make_tuple(op.creator, op.name));
+        EOS_ASSERT(exists == nullptr, eosio::chain::username_exists_exception,
+            "Cannot create username ${n} in scope ${s}, as it's already taken", ("n", op.name)("s", op.creator));
+        auto owner = chaindb.find<eosio::chain::account_object, by_name>(op.owner);
+        EOS_ASSERT(owner, eosio::chain::account_name_exists_exception, "Username owner (${o}) must exist", ("o", op.owner));
+        chaindb.emplace<username_object>(context.get_ram_payer(op.creator), [&](auto& d) {
+            d.owner = op.owner;
+            d.scope = op.creator;
+            d.name = op.name;
+        });
+    } FC_CAPTURE_AND_RETHROW((op))
+}
+
+} } // namespace cyberway::chain

--- a/libraries/chain/cyberway/domain_name.cpp
+++ b/libraries/chain/cyberway/domain_name.cpp
@@ -1,9 +1,12 @@
-#include <eosio/chain/domain_name.hpp>
+#include <cyberway/chain/domain_name.hpp>
 #include <boost/algorithm/string.hpp>
 #include <eosio/chain/exceptions.hpp>
 #include <boost/algorithm/string.hpp>
 
-namespace eosio { namespace chain {
+namespace cyberway { namespace chain {
+
+using eosio::chain::domain_name_type_exception;
+using eosio::chain::username_type_exception;
 
 using std::string;
 
@@ -99,4 +102,4 @@ void validate_username(const username& n) {
 }
 
 
-} } /// eosio::chain
+} } /// cyberway::chain

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -440,10 +440,11 @@ void apply_cyber_providebw(apply_context& context) {
    context.require_authorization(args.provider);
 }
 
-void apply_cyber_requestbw(apply_context& context) {
-   auto args = context.act.data_as<requestbw>();
-   context.require_authorization(args.account);
-}
+// TODO: requestbw
+//void apply_cyber_requestbw(apply_context& context) {
+//   auto args = context.act.data_as<requestbw>();
+//   context.require_authorization(args.account);
+//}
 
 void apply_cyber_provideram(apply_context& context) {
    auto args = context.act.data_as<provideram>();

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -104,14 +104,17 @@ void apply_cyber_newaccount(apply_context& context) {
               "Cannot create account named ${name}, as that name is already taken",
               ("name", create.name));
 
-   context.control.get_mutable_resource_limits_manager().initialize_account(create.name);
+   // CyberWay: set RAM usage to creator, it can rewrite memory usage to account, so no troubles
+   auto ram_payer = context.get_ram_payer(create.name, create.creator);
 
-   chaindb.emplace<account_object>({context, create.name}, [&](auto& a) {
+   context.control.get_mutable_resource_limits_manager().initialize_account(create.name, ram_payer);
+
+   chaindb.emplace<account_object>(ram_payer, [&](auto& a) {
       a.name = create.name;
       a.creation_date = context.control.pending_block_time();
    });
 
-   chaindb.emplace<account_sequence_object>({context, create.name}, [&](auto& a) {
+   chaindb.emplace<account_sequence_object>(ram_payer, [&](auto& a) {
       a.name = create.name;
    });
 
@@ -119,10 +122,10 @@ void apply_cyber_newaccount(apply_context& context) {
       validate_authority_precondition( context, auth );
    }
 
-   const auto& owner_permission  = authorization.create_permission( {context, create.name},
+   const auto& owner_permission  = authorization.create_permission( ram_payer,
                                                                     create.name, config::owner_name, 0,
                                                                     std::move(create.owner) );
-   const auto& active_permission = authorization.create_permission( {context, create.name},
+   const auto& active_permission = authorization.create_permission( ram_payer,
                                                                     create.name, config::active_name, owner_permission.id,
                                                                     std::move(create.active) );
 
@@ -198,7 +201,8 @@ void apply_cyber_setcode(apply_context& context) {
         EOS_ASSERT(allowed, protected_contract_code, "can't change code of protected account");
     }
 
-   chaindb.modify( account, {context}, [&]( auto& a ) {
+   auto ram_payer = context.get_ram_payer(act.account);
+   chaindb.modify( account, ram_payer, [&]( auto& a ) {
       /** TODO: consider whether a microsecond level local timestamp is sufficient to detect code version changes*/
       // TODO: update setcode message to include the hash, then validate it in validate
       a.last_code_update = context.control.pending_block_time();
@@ -209,7 +213,7 @@ void apply_cyber_setcode(apply_context& context) {
 
    });
 
-   chaindb.modify( account_sequence, [&]( auto& aso ) {
+   chaindb.modify( account_sequence, ram_payer, [&]( auto& aso ) {
       aso.code_sequence += 1;
    });
 
@@ -246,13 +250,15 @@ void apply_cyber_setabi(apply_context& context) {
         EOS_ASSERT(allowed, protected_contract_code, "can't change abi of protected account");
     }
 
-   chaindb.modify( account, {context}, [&]( auto& a ) {
+   auto ram_payer = context.get_ram_payer(act.account);
+
+   chaindb.modify( account, ram_payer, [&]( auto& a ) {
       a.abi.resize( abi_size );
       if( abi_size > 0 )
          memcpy( const_cast<char*>(a.abi.data()), act.abi.data(), abi_size );
    });
 
-   chaindb.modify( account_sequence, [&]( auto& aso ) {
+   chaindb.modify( account_sequence, ram_payer, [&]( auto& aso ) {
       aso.abi_sequence += 1;
    });
 
@@ -307,6 +313,8 @@ void apply_cyber_updateauth(apply_context& context) {
       parent_id = parent.id;
    }
 
+   auto ram_payer = context.get_ram_payer(update.account);
+
    if( permission ) {
       EOS_ASSERT(parent_id == permission->parent, action_validate_exception,
                  "Changing parent authority is not currently supported");
@@ -315,7 +323,7 @@ void apply_cyber_updateauth(apply_context& context) {
 // TODO: Removed by CyberWay
 //      int64_t old_size = (int64_t)(config::billable_size_v<permission_object> + permission->auth.get_billable_size());
 
-      authorization.modify_permission( *permission, {context}, update.auth );
+      authorization.modify_permission( *permission, ram_payer, update.auth );
 
 // TODO: Removed by CyberWay
 //      int64_t new_size = (int64_t)(config::billable_size_v<permission_object> + permission->auth.get_billable_size());
@@ -324,7 +332,7 @@ void apply_cyber_updateauth(apply_context& context) {
 // TODO: Removed by CyberWay
 //      const auto& p =
 
-      authorization.create_permission( {context, update.account}, update.account, update.permission, parent_id, update.auth );
+      authorization.create_permission( ram_payer, update.account, update.permission, parent_id, update.auth );
 
 // TODO: Removed by CyberWay
 //      int64_t new_size = (int64_t)(config::billable_size_v<permission_object> + p.auth.get_billable_size());
@@ -359,7 +367,7 @@ void apply_cyber_deleteauth(apply_context& context) {
 // TODO: Removed by CyberWay
 //   int64_t old_size = config::billable_size_v<permission_object> + permission.auth.get_billable_size();
 
-   authorization.remove_permission( permission, {context} );
+   authorization.remove_permission( permission, context.get_ram_payer() );
 
 // TODO: Removed by CyberWay
 //   context.add_ram_usage( remove.account, -old_size );
@@ -390,15 +398,16 @@ void apply_cyber_linkauth(apply_context& context) {
 
       auto link_key = boost::make_tuple(requirement.account, requirement.code, requirement.type);
       auto link = chaindb.find<permission_link_object, by_action_name>(link_key);
+      auto ram_payer = context.get_ram_payer(requirement.account);
 
       if( link ) {
          EOS_ASSERT(link->required_permission != requirement.requirement, action_validate_exception,
                     "Attempting to update required authority, but new requirement is same as old");
-         chaindb.modify(*link, {context}, [requirement = requirement.requirement](permission_link_object& link) {
+         chaindb.modify(*link, ram_payer, [requirement = requirement.requirement](permission_link_object& link) {
              link.required_permission = requirement;
          });
       } else {
-         chaindb.emplace<permission_link_object>({context, requirement.account}, [&requirement](permission_link_object& link) {
+         chaindb.emplace<permission_link_object>(ram_payer, [&requirement](permission_link_object& link) {
             link.account = requirement.account;
             link.code = requirement.code;
             link.message_type = requirement.type;
@@ -432,7 +441,7 @@ void apply_cyber_unlinkauth(apply_context& context) {
 //      -(int64_t)(config::billable_size_v<permission_link_object>)
 //   );
 
-   chaindb.erase(*link, {context});
+   chaindb.erase(*link, context.get_ram_payer());
 }
 
 void apply_cyber_providebw(apply_context& context) {
@@ -470,7 +479,7 @@ void apply_cyber_domain_newdomain(apply_context& context) {
       auto exists = chaindb.find<domain_object, by_name>(op.name);
       EOS_ASSERT(exists == nullptr, domain_exists_exception,
          "Cannot create domain named ${n}, as that name is already taken", ("n", op.name));
-      chaindb.emplace<domain_object>({context, op.creator}, [&](auto& d) {
+      chaindb.emplace<domain_object>(context.get_ram_payer(op.creator), [&](auto& d) {
          d.owner = op.creator;
          d.creation_date = context.control.pending_block_time();
          d.name = op.name;
@@ -484,7 +493,7 @@ void apply_cyber_domain_passdomain(apply_context& context) {
       validate_domain_name(op.name);
       const auto& domain = context.control.get_domain(op.name);
       EOS_ASSERT(op.from == domain.owner, action_validate_exception, "Only owner can pass domain name");
-      context.chaindb.modify(domain, {context, op.to}, [&](auto& d) {
+      context.chaindb.modify(domain, context.get_ram_payer(op.to), [&](auto& d) {
          d.owner = op.to;
       });
 } FC_CAPTURE_AND_RETHROW((op)) }
@@ -497,7 +506,7 @@ void apply_cyber_domain_linkdomain(apply_context& context) {
       const auto& domain = context.control.get_domain(op.name);
       EOS_ASSERT(op.owner == domain.owner, action_validate_exception, "Only owner can change domain link");
       EOS_ASSERT(op.to != domain.linked_to, action_validate_exception, "Domain name already linked to the same account");
-      context.chaindb.modify(domain, {context, domain.owner}, [&](auto& d) {
+      context.chaindb.modify(domain, context.get_ram_payer(domain.owner), [&](auto& d) {
          d.linked_to = op.to;
       });
 } FC_CAPTURE_AND_RETHROW((op)) }
@@ -510,7 +519,7 @@ void apply_cyber_domain_unlinkdomain(apply_context& context) {
       const auto& domain = context.control.get_domain(op.name);
       EOS_ASSERT(op.owner == domain.owner, action_validate_exception, "Only owner can unlink domain");
       EOS_ASSERT(domain.linked_to != account_name(), action_validate_exception, "Domain name already unlinked");
-      context.chaindb.modify(domain, {context, domain.owner}, [&](auto& d) {
+      context.chaindb.modify(domain, context.get_ram_payer(domain.owner), [&](auto& d) {
          d.linked_to = account_name();
       });
 } FC_CAPTURE_AND_RETHROW((op)) }
@@ -526,7 +535,7 @@ void apply_cyber_domain_newusername(apply_context& context) {
          "Cannot create username ${n} in scope ${s}, as it's already taken", ("n", op.name)("s", op.creator));
       auto owner = chaindb.find<account_object, by_name>(op.owner);
       EOS_ASSERT(owner, account_name_exists_exception, "Username owner (${o}) must exist", ("o", op.owner));
-      chaindb.emplace<username_object>({context, op.creator}, [&](auto& d) {
+      chaindb.emplace<username_object>(context.get_ram_payer(op.creator), [&](auto& d) {
          d.owner = op.owner;
          d.scope = op.creator;
          d.name = op.name;

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -618,13 +618,13 @@ abi_def eosio_contract_abi(abi_def eos_abi)
          {"account", "account_name"},
       }
    });
-
-   eos_abi.structs.emplace_back( struct_def {
-      "requestbw", "", {
-         {"provider", "account_name"},
-         {"account", "account_name"},
-      }
-   });
+// TODO: requestbw
+//   eos_abi.structs.emplace_back( struct_def {
+//      "requestbw", "", {
+//         {"provider", "account_name"},
+//         {"account", "account_name"},
+//      }
+//   });
 
    eos_abi.structs.emplace_back( struct_def {
       "provideram", "", {
@@ -662,7 +662,8 @@ abi_def eosio_contract_abi(abi_def eos_abi)
    eos_abi.actions.push_back( action_def{name("linkauth"), "linkauth"} );
    eos_abi.actions.push_back( action_def{name("unlinkauth"), "unlinkauth"} );
    eos_abi.actions.push_back( action_def{name("providebw"), "providebw"} );
-   eos_abi.actions.push_back( action_def{name("requestbw"), "requestbw"} );
+// TODO: requestbw
+//   eos_abi.actions.push_back( action_def{name("requestbw"), "requestbw"} );
    eos_abi.actions.push_back( action_def{name("provideram"), "provideram"} );
    eos_abi.actions.push_back( action_def{name("canceldelay"), "canceldelay"} );
    eos_abi.actions.push_back( action_def{name("onerror"), "onerror"} );

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -278,7 +278,6 @@ abi_def eosio_contract_abi(abi_def eos_abi)
          {"trx_id", "checksum256"},
          {"sender", "name"},
          {"sender_id", "uint128"},
-         {"payer", "name"},
          {"delay_until", "time_point"},
          {"expiration", "time_point"},
          {"published", "time_point"},

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -630,7 +630,6 @@ abi_def eosio_contract_abi(abi_def eos_abi)
       "provideram", "", {
          {"provider", "account_name"},
          {"account", "account_name"},
-         {"contracts", "account_name[]"},
       }
    });
 

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -6,12 +6,13 @@
 #include <eosio/chain/block_summary_object.hpp>
 #include <eosio/chain/transaction_object.hpp>
 #include <eosio/chain/generated_transaction_object.hpp>
-#include <eosio/chain/domain_object.hpp>
 #include <eosio/chain/stake_object.hpp>
 #include <eosio/chain/permission_object.hpp>
 #include <eosio/chain/permission_link_object.hpp>
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/resource_limits_private.hpp>
+
+#include <cyberway/chain/domain_object.hpp>
 
 namespace eosio { namespace chain {
 
@@ -306,7 +307,7 @@ abi_def eosio_contract_abi(abi_def eos_abi)
    });
 
    eos_abi.tables.emplace_back(eosio::chain::table_def{
-      cyberway::chaindb::tag<domain_object>::get_code(), "domain_object", {
+      cyberway::chaindb::tag<cyberway::chain::domain_object>::get_code(), "domain_object", {
          {cyberway::chaindb::tag<by_id>::get_code(), true, {{"id", "asc"}}},
          {cyberway::chaindb::tag<by_name>::get_code(), true, {{"name", "asc"}}},
          {cyberway::chaindb::tag<by_owner>::get_code(), true, {{"owner", "asc"},{"name", "asc"}}}
@@ -323,7 +324,7 @@ abi_def eosio_contract_abi(abi_def eos_abi)
    });
 
    eos_abi.tables.emplace_back(eosio::chain::table_def{
-      cyberway::chaindb::tag<username_object>::get_code(), "username_object", {
+      cyberway::chaindb::tag<cyberway::chain::username_object>::get_code(), "username_object", {
          {cyberway::chaindb::tag<by_id>::get_code(), true, {{"id", "asc"}}},
          {cyberway::chaindb::tag<by_scope_name>::get_code(), true, {{"scope", "asc"},{"name", "asc"}}},
          {cyberway::chaindb::tag<by_owner>::get_code(), true, {{"owner","asc"},{"scope","asc"},{"name","asc"}}}

--- a/libraries/chain/include/cyberway/chain/cyberway_contract.hpp
+++ b/libraries/chain/include/cyberway/chain/cyberway_contract.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <eosio/chain/types.hpp>
+#include <eosio/chain/contract_types.hpp>
+
+namespace eosio { namespace chain {
+    class apply_context;
+} } // namespace eosio::chain
+
+namespace cyberway { namespace chain {
+    using eosio::chain::apply_context;
+
+    /**
+     * @defgroup native_action_handlers Native Action Handlers
+     */
+    ///@{
+    // TODO: requestbw
+    // void apply_cyber_requestbw(apply_context&);
+
+    void apply_cyber_providebw(apply_context&);
+    void apply_cyber_provideram(apply_context&);
+
+    void apply_cyber_domain_newdomain(apply_context&);
+    void apply_cyber_domain_passdomain(apply_context&);
+    void apply_cyber_domain_linkdomain(apply_context&);
+    void apply_cyber_domain_unlinkdomain(apply_context&);
+    void apply_cyber_domain_newusername(apply_context&);
+
+    /*
+    void apply_cyber_postrecovery(apply_context&);
+    void apply_cyber_passrecovery(apply_context&);
+    void apply_cyber_vetorecovery(apply_context&);
+    */
+
+} } // namespace cyberway::chain

--- a/libraries/chain/include/cyberway/chain/cyberway_contract_types.hpp
+++ b/libraries/chain/include/cyberway/chain/cyberway_contract_types.hpp
@@ -1,0 +1,136 @@
+#pragma once
+
+#include <eosio/chain/authority.hpp>
+#include <eosio/chain/chain_config.hpp>
+#include <eosio/chain/config.hpp>
+#include <eosio/chain/types.hpp>
+
+namespace cyberway { namespace chain {
+
+    using eosio::chain::account_name;
+    using eosio::chain::action_name;
+
+    struct providebw final {
+        account_name    provider;
+        account_name    account;
+
+        providebw() = default;
+        providebw(const account_name& provider, const account_name& account)
+            : provider(provider), account(account)
+        {}
+
+        static account_name get_account() {
+            return eosio::chain::config::system_account_name;
+        }
+
+        static action_name get_name() {
+            return N(providebw);
+        }
+    };
+
+// TODO: requestbw
+//struct requestbw final {
+//    account_name    provider;
+//    account_name    account;
+//
+//    requestbw() = default;
+//    requestbw(const account_name& provider, const account_name& account)
+//    : provider(provider), account(account)
+//    {}
+//
+//    static account_name get_account() {
+//        return eosio::chain::config::system_account_name;
+//    }
+//
+//    static action_name get_name() {
+//        return N(requestbw);
+//    }
+//};
+//
+//struct approvebw final {
+//    account_name    account;
+//
+//    approvebw() = default;
+//    approvebw(const account_name& account)
+//    : account(account)
+//    {}
+//
+//    static account_name get_account() {
+//       return eosio::chain::config::system_account_name;
+//    }
+//
+//    static action_name get_name() {
+//        return N(approvebw);
+//    }
+//};
+
+    struct provideram final {
+        account_name provider;
+        account_name account;
+
+        provideram() = default;
+        provideram(const account_name& provider, const account_name& account)
+            : provider(provider), account(account) {
+        }
+
+        static account_name get_account() {
+            return eosio::chain::config::system_account_name;
+        }
+
+        static action_name get_name() {
+            return N(provideram);
+        }
+    };
+
+
+// it's ugly, but removes boilerplate. TODO: write better
+#define SYS_ACTION_STRUCT(NAME) struct NAME final { \
+    NAME() = default; \
+    static account_name get_account() { return eosio::chain::config::domain_account_name; } \
+    static action_name get_name()     { return N(NAME); }
+#define SYS_ACTION_STRUCT_END };
+
+    SYS_ACTION_STRUCT(newdomain)
+        account_name creator;
+        domain_name name;
+    SYS_ACTION_STRUCT_END;
+
+    SYS_ACTION_STRUCT(passdomain)
+        account_name from;
+        account_name to;
+        domain_name name;
+    SYS_ACTION_STRUCT_END;
+
+    SYS_ACTION_STRUCT(linkdomain)
+        account_name owner;
+        account_name to;
+        domain_name name;
+    SYS_ACTION_STRUCT_END;
+
+    SYS_ACTION_STRUCT(unlinkdomain)
+        account_name owner;
+        domain_name name;
+    SYS_ACTION_STRUCT_END;
+
+    SYS_ACTION_STRUCT(newusername)
+        account_name creator;
+        account_name owner;
+        username name;
+    SYS_ACTION_STRUCT_END;
+
+#undef SYS_ACTION_STRUCT
+#undef SYS_ACTION_STRUCT_END
+
+} } // namespace cyberway::chain
+
+FC_REFLECT(cyberway::chain::providebw                        , (provider)(account))
+//TODO: requestbw
+//FC_REFLECT(cyberway::chain::requestbw                        , (provider)(account))
+//FC_REFLECT(cyberway::chain::approvebw                        , (account) )
+FC_REFLECT(cyberway::chain::provideram                       , (provider)(account))
+
+FC_REFLECT(cyberway::chain::newdomain,    (creator)(name))
+FC_REFLECT(cyberway::chain::passdomain,   (from)(to)(name))
+FC_REFLECT(cyberway::chain::linkdomain,   (owner)(to)(name))
+FC_REFLECT(cyberway::chain::unlinkdomain, (owner)(name))
+FC_REFLECT(cyberway::chain::newusername,  (creator)(owner)(name))

--- a/libraries/chain/include/cyberway/chain/domain_name.hpp
+++ b/libraries/chain/include/cyberway/chain/domain_name.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <string>
 
-namespace eosio { namespace chain {
+namespace cyberway { namespace chain {
 
 using domain_name = std::string;    // TODO: separate class to embed restrictions into deserializer
 using username = std::string;
@@ -9,5 +9,5 @@ using username = std::string;
 void validate_domain_name(const domain_name& n);
 void validate_username(const username& n);
 
-} } // eosio::chain
+} } // cyberway::chain
 

--- a/libraries/chain/include/cyberway/chain/domain_object.hpp
+++ b/libraries/chain/include/cyberway/chain/domain_object.hpp
@@ -8,9 +8,12 @@
 #include <eosio/chain/block_timestamp.hpp>
 #include <eosio/chain/multi_index_includes.hpp>
 
-namespace eosio { namespace chain {
+namespace cyberway { namespace chain {
 
-class domain_object : public cyberway::chaindb::object<domain_object_type, domain_object> {
+using eosio::chain::account_name;
+using eosio::chain::block_timestamp_type;
+
+class domain_object : public cyberway::chaindb::object<eosio::chain::domain_object_type, domain_object> {
    OBJECT_CTOR(domain_object)
 
    id_type              id;
@@ -21,8 +24,8 @@ class domain_object : public cyberway::chaindb::object<domain_object_type, domai
 };
 using domain_id_type = domain_object::id_type;
 
-struct by_name;
-struct by_owner;
+using eosio::chain::by_name;
+using eosio::chain::by_owner;
 using domain_table = cyberway::chaindb::table_container<
    domain_object,
    cyberway::chaindb::indexed_by<
@@ -38,7 +41,7 @@ using domain_table = cyberway::chaindb::table_container<
    >
 >;
 
-class username_object : public cyberway::chaindb::object<username_object_type, username_object> {
+class username_object : public cyberway::chaindb::object<eosio::chain::username_object_type, username_object> {
    OBJECT_CTOR(username_object)
 
    id_type              id;
@@ -48,8 +51,8 @@ class username_object : public cyberway::chaindb::object<username_object_type, u
 };
 using username_id_type = username_object::id_type;
 
-struct by_scope_name;
-struct by_owner;
+using eosio::chain::by_scope_name;
+using eosio::chain::by_owner;
 using username_table = cyberway::chaindb::table_container<
    username_object,
    cyberway::chaindb::indexed_by<
@@ -69,12 +72,12 @@ using username_table = cyberway::chaindb::table_container<
    >
 >;
 
-} } // eosio::chain
+} } // cyberway::chain
 
-CHAINDB_SET_TABLE_TYPE(eosio::chain::domain_object, eosio::chain::domain_table)
-CHAINDB_TAG(eosio::chain::domain_object, domain)
-CHAINDB_SET_TABLE_TYPE(eosio::chain::username_object, eosio::chain::username_table)
-CHAINDB_TAG(eosio::chain::username_object, username)
+CHAINDB_SET_TABLE_TYPE(cyberway::chain::domain_object, cyberway::chain::domain_table)
+CHAINDB_TAG(cyberway::chain::domain_object, domain)
+CHAINDB_SET_TABLE_TYPE(cyberway::chain::username_object, cyberway::chain::username_table)
+CHAINDB_TAG(cyberway::chain::username_object, username)
 
-FC_REFLECT(eosio::chain::domain_object, (id)(owner)(linked_to)(creation_date)(name))
-FC_REFLECT(eosio::chain::username_object, (id)(owner)(scope)(name))
+FC_REFLECT(cyberway::chain::domain_object, (id)(owner)(linked_to)(creation_date)(name))
+FC_REFLECT(cyberway::chain::username_object, (id)(owner)(scope)(name))

--- a/libraries/chain/include/cyberway/chaindb/multi_index.hpp
+++ b/libraries/chain/include/cyberway/chaindb/multi_index.hpp
@@ -344,6 +344,14 @@ private:
             lazy_load_object();
             return &item_data::get_T(item_);
         }
+        const primary_key_t pk() const {
+            lazy_load_object();
+            return primary_key_;
+        }
+        const service_state& service() const {
+            lazy_load_object();
+            return item_->service();
+        }
 
         const_iterator_impl operator++(int) {
             const_iterator_impl result(*this);

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -11,7 +11,10 @@
 #include <algorithm>
 #include <set>
 
-namespace cyberway { namespace chaindb { class chaindb_controller; }}
+namespace cyberway { namespace chaindb {
+    class chaindb_controller;
+    struct ram_payer_info;
+}}
 
 namespace chainbase { class database; }
 
@@ -611,6 +614,7 @@ class apply_context {
       uint64_t next_recv_sequence( account_name receiver );
       uint64_t next_auth_sequence( account_name actor );
 
+      cyberway::chaindb::ram_payer_info get_ram_payer( const account_name& ram_owner = account_name(), const account_name& ram_payer = account_name() );
       void add_ram_usage( const account_name& account, int64_t ram_delta );
       void finalize_trace( action_trace& trace, const fc::time_point& start );
 

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -49,11 +49,6 @@ const static uint64_t owner_name  = N(owner);
 const static uint64_t eosio_any_name = N(cyber.any);
 const static uint64_t eosio_code_name = N(cyber.code);
 
-// TODO: requestbw
-//const static uint64_t request_bw_action = N(requestbw);
-//const static uint64_t approve_bw_action = N(approvebw);
-const static uint64_t provide_bw_action = N(providebw);
-
 const static int      block_interval_ms = 3000;
 const static int      block_interval_us = block_interval_ms*1000;
 const static uint64_t block_timestamp_epoch = 946684800000ll; // epoch is year 2000.

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -49,8 +49,9 @@ const static uint64_t owner_name  = N(owner);
 const static uint64_t eosio_any_name = N(cyber.any);
 const static uint64_t eosio_code_name = N(cyber.code);
 
-const static uint64_t request_bw_action = N(requestbw);
-const static uint64_t approve_bw_action = N(approvebw);
+// TODO: requestbw
+//const static uint64_t request_bw_action = N(requestbw);
+//const static uint64_t approve_bw_action = N(approvebw);
 const static uint64_t provide_bw_action = N(providebw);
 
 const static int      block_interval_ms = 3000;

--- a/libraries/chain/include/eosio/chain/contract_types.hpp
+++ b/libraries/chain/include/eosio/chain/contract_types.hpp
@@ -156,23 +156,24 @@ struct providebw {
     }
 };
 
-struct requestbw {
-    account_name    provider;
-    account_name    account;
-
-    requestbw() = default;
-    requestbw(const account_name& provider, const account_name& account)
-    : provider(provider), account(account)
-    {}
-
-    static account_name get_account() {
-        return config::system_account_name;
-    }
-
-    static action_name get_name() {
-        return config::request_bw_action;
-    }
-};
+// TODO: requestbw
+//struct requestbw {
+//    account_name    provider;
+//    account_name    account;
+//
+//    requestbw() = default;
+//    requestbw(const account_name& provider, const account_name& account)
+//    : provider(provider), account(account)
+//    {}
+//
+//    static account_name get_account() {
+//        return config::system_account_name;
+//    }
+//
+//    static action_name get_name() {
+//        return config::request_bw_action;
+//    }
+//};
 
 struct provideram {
     account_name        provider;
@@ -249,22 +250,23 @@ struct onerror {
    }
 };
 
-struct approvebw {
-    account_name    account;
-
-    approvebw() = default;
-    approvebw(const account_name& account)
-    : account(account)
-    {}
-
-    static account_name get_account() {
-       return config::system_account_name;
-    }
-
-    static action_name get_name() {
-        return config::approve_bw_action;
-    }
-};
+// TODO: requestbw
+//struct approvebw {
+//    account_name    account;
+//
+//    approvebw() = default;
+//    approvebw(const account_name& account)
+//    : account(account)
+//    {}
+//
+//    static account_name get_account() {
+//       return config::system_account_name;
+//    }
+//
+//    static action_name get_name() {
+//        return config::approve_bw_action;
+//    }
+//};
 
 } } /// namespace eosio::chain
 
@@ -276,8 +278,9 @@ FC_REFLECT( eosio::chain::deleteauth                       , (account)(permissio
 FC_REFLECT( eosio::chain::linkauth                         , (account)(code)(type)(requirement) )
 FC_REFLECT( eosio::chain::unlinkauth                       , (account)(code)(type) )
 FC_REFLECT( eosio::chain::providebw                        , (provider)(account) )
-FC_REFLECT( eosio::chain::requestbw                        , (provider)(account) )
-FC_REFLECT( eosio::chain::approvebw                        , (account) )
+//TODO: requestbw
+//FC_REFLECT( eosio::chain::requestbw                        , (provider)(account) )
+//FC_REFLECT( eosio::chain::approvebw                        , (account) )
 FC_REFLECT( eosio::chain::provideram                       , (provider)(account)(contracts) )
 FC_REFLECT( eosio::chain::canceldelay                      , (canceling_auth)(trx_id) )
 FC_REFLECT( eosio::chain::onerror                          , (sender_id)(sent_trx) )

--- a/libraries/chain/include/eosio/chain/contract_types.hpp
+++ b/libraries/chain/include/eosio/chain/contract_types.hpp
@@ -138,101 +138,6 @@ struct canceldelay {
    }
 };
 
-struct providebw final {
-    account_name    provider;
-    account_name    account;
-
-    providebw() = default;
-    providebw(const account_name& provider, const account_name& account)
-    : provider(provider), account(account)
-    {}
-
-    static account_name get_account() {
-        return config::system_account_name;
-    }
-
-    static action_name get_name() {
-        return config::provide_bw_action;
-    }
-};
-
-// TODO: requestbw
-//struct requestbw {
-//    account_name    provider;
-//    account_name    account;
-//
-//    requestbw() = default;
-//    requestbw(const account_name& provider, const account_name& account)
-//    : provider(provider), account(account)
-//    {}
-//
-//    static account_name get_account() {
-//        return config::system_account_name;
-//    }
-//
-//    static action_name get_name() {
-//        return config::request_bw_action;
-//    }
-//};
-
-struct provideram final {
-    account_name provider;
-    account_name account;
-
-    provideram() = default;
-    provideram(const account_name& provider, const account_name& account)
-    : provider(provider), account(account) {
-    }
-
-    static account_name get_account() {
-        return config::system_account_name;
-    }
-
-    static action_name get_name() {
-        return N(provideram);
-    }
-};
-
-
-// it's ugly, but removes boilerplate. TODO: write better
-#define SYS_ACTION_STRUCT(NAME) struct NAME { \
-    NAME() = default; \
-    static account_name get_account() { return config::domain_account_name; } \
-    static action_name get_name()     { return N(NAME); }
-#define SYS_ACTION_STRUCT_END };
-
-SYS_ACTION_STRUCT(newdomain)
-   account_name creator;
-   domain_name name;
-SYS_ACTION_STRUCT_END;
-
-SYS_ACTION_STRUCT(passdomain)
-   account_name from;
-   account_name to;
-   domain_name name;
-SYS_ACTION_STRUCT_END;
-
-SYS_ACTION_STRUCT(linkdomain)
-   account_name owner;
-   account_name to;
-   domain_name name;
-SYS_ACTION_STRUCT_END;
-
-SYS_ACTION_STRUCT(unlinkdomain)
-   account_name owner;
-   domain_name name;
-SYS_ACTION_STRUCT_END;
-
-SYS_ACTION_STRUCT(newusername)
-   account_name creator;
-   account_name owner;
-   username name;
-SYS_ACTION_STRUCT_END;
-
-#undef SYS_ACTION_STRUCT
-#undef SYS_ACTION_STRUCT_END
-
-
 struct onerror {
    uint128_t      sender_id;
    bytes          sent_trx;
@@ -249,24 +154,6 @@ struct onerror {
    }
 };
 
-// TODO: requestbw
-//struct approvebw {
-//    account_name    account;
-//
-//    approvebw() = default;
-//    approvebw(const account_name& account)
-//    : account(account)
-//    {}
-//
-//    static account_name get_account() {
-//       return config::system_account_name;
-//    }
-//
-//    static action_name get_name() {
-//        return config::approve_bw_action;
-//    }
-//};
-
 } } /// namespace eosio::chain
 
 FC_REFLECT( eosio::chain::newaccount                       , (creator)(name)(owner)(active) )
@@ -276,16 +163,5 @@ FC_REFLECT( eosio::chain::updateauth                       , (account)(permissio
 FC_REFLECT( eosio::chain::deleteauth                       , (account)(permission) )
 FC_REFLECT( eosio::chain::linkauth                         , (account)(code)(type)(requirement) )
 FC_REFLECT( eosio::chain::unlinkauth                       , (account)(code)(type) )
-FC_REFLECT( eosio::chain::providebw                        , (provider)(account) )
-//TODO: requestbw
-//FC_REFLECT( eosio::chain::requestbw                        , (provider)(account) )
-//FC_REFLECT( eosio::chain::approvebw                        , (account) )
-FC_REFLECT( eosio::chain::provideram                       , (provider)(account) )
 FC_REFLECT( eosio::chain::canceldelay                      , (canceling_auth)(trx_id) )
 FC_REFLECT( eosio::chain::onerror                          , (sender_id)(sent_trx) )
-
-FC_REFLECT(eosio::chain::newdomain,    (creator)(name))
-FC_REFLECT(eosio::chain::passdomain,   (from)(to)(name))
-FC_REFLECT(eosio::chain::linkdomain,   (owner)(to)(name))
-FC_REFLECT(eosio::chain::unlinkdomain, (owner)(name))
-FC_REFLECT(eosio::chain::newusername,  (creator)(owner)(name))

--- a/libraries/chain/include/eosio/chain/contract_types.hpp
+++ b/libraries/chain/include/eosio/chain/contract_types.hpp
@@ -138,7 +138,7 @@ struct canceldelay {
    }
 };
 
-struct providebw {
+struct providebw final {
     account_name    provider;
     account_name    account;
 
@@ -175,15 +175,14 @@ struct providebw {
 //    }
 //};
 
-struct provideram {
-    account_name        provider;
-    account_name        account;
-    std::vector<account_name>   contracts;
+struct provideram final {
+    account_name provider;
+    account_name account;
 
     provideram() = default;
-    provideram(const account_name& provider, const account_name& account, std::vector<name> contracts)
-        : provider(provider), account(account), contracts(std::move(contracts))
-    {}
+    provideram(const account_name& provider, const account_name& account)
+    : provider(provider), account(account) {
+    }
 
     static account_name get_account() {
         return config::system_account_name;
@@ -281,7 +280,7 @@ FC_REFLECT( eosio::chain::providebw                        , (provider)(account)
 //TODO: requestbw
 //FC_REFLECT( eosio::chain::requestbw                        , (provider)(account) )
 //FC_REFLECT( eosio::chain::approvebw                        , (account) )
-FC_REFLECT( eosio::chain::provideram                       , (provider)(account)(contracts) )
+FC_REFLECT( eosio::chain::provideram                       , (provider)(account) )
 FC_REFLECT( eosio::chain::canceldelay                      , (canceling_auth)(trx_id) )
 FC_REFLECT( eosio::chain::onerror                          , (sender_id)(sent_trx) )
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -6,10 +6,11 @@
 
 #include <eosio/chain/abi_serializer.hpp>
 #include <eosio/chain/account_object.hpp>
-#include <eosio/chain/domain_object.hpp>
 #include <eosio/chain/snapshot.hpp>
 
 #include <cyberway/chaindb/common.hpp>
+#include <cyberway/chain/domain_name.hpp>
+#include <cyberway/chain/domain_object.hpp>
 
 namespace chainbase {
    class database;
@@ -23,6 +24,11 @@ namespace eosio { namespace chain {
    using cyberway::chaindb::chaindb_controller;
    using cyberway::chaindb::chaindb_type;
    using cyberway::chaindb::chaindb_session;
+
+   using cyberway::chain::domain_name;
+   using cyberway::chain::domain_object;
+   using cyberway::chain::username;
+   using cyberway::chain::username_object;
 
    class authorization_manager;
 

--- a/libraries/chain/include/eosio/chain/eosio_contract.hpp
+++ b/libraries/chain/include/eosio/chain/eosio_contract.hpp
@@ -20,27 +20,8 @@ namespace eosio { namespace chain {
    void apply_cyber_deleteauth(apply_context&);
    void apply_cyber_linkauth(apply_context&);
    void apply_cyber_unlinkauth(apply_context&);
-
-   void apply_cyber_providebw(apply_context&);
-// TODO: requestbw
-//   void apply_cyber_requestbw(apply_context&);
-   void apply_cyber_provideram(apply_context&);
-
-   void apply_cyber_domain_newdomain(apply_context&);
-   void apply_cyber_domain_passdomain(apply_context&);
-   void apply_cyber_domain_linkdomain(apply_context&);
-   void apply_cyber_domain_unlinkdomain(apply_context&);
-   void apply_cyber_domain_newusername(apply_context&);
-
-   /*
-   void apply_cyber_postrecovery(apply_context&);
-   void apply_cyber_passrecovery(apply_context&);
-   void apply_cyber_vetorecovery(apply_context&);
-   */
-
    void apply_cyber_setcode(apply_context&);
    void apply_cyber_setabi(apply_context&);
-
    void apply_cyber_canceldelay(apply_context&);
    ///@}  end action handlers
 

--- a/libraries/chain/include/eosio/chain/eosio_contract.hpp
+++ b/libraries/chain/include/eosio/chain/eosio_contract.hpp
@@ -22,7 +22,8 @@ namespace eosio { namespace chain {
    void apply_cyber_unlinkauth(apply_context&);
 
    void apply_cyber_providebw(apply_context&);
-   void apply_cyber_requestbw(apply_context&);
+// TODO: requestbw
+//   void apply_cyber_requestbw(apply_context&);
    void apply_cyber_provideram(apply_context&);
 
    void apply_cyber_domain_newdomain(apply_context&);

--- a/libraries/chain/include/eosio/chain/generated_transaction_object.hpp
+++ b/libraries/chain/include/eosio/chain/generated_transaction_object.hpp
@@ -30,7 +30,6 @@ namespace eosio { namespace chain {
          transaction_id_type           trx_id;
          account_name                  sender;
          uint128_t                     sender_id = 0; /// ID given this transaction by the sender
-         account_name                  payer;
          time_point                    delay_until; /// this generated transaction will not be applied until the specified time
          time_point                    expiration; /// this generated transaction will not be applied after this time
          time_point                    published;
@@ -84,7 +83,6 @@ namespace eosio { namespace chain {
          :trx_id(gto.trx_id)
          ,sender(gto.sender)
          ,sender_id(gto.sender_id)
-         ,payer(gto.payer)
          ,delay_until(gto.delay_until)
          ,expiration(gto.expiration)
          ,published(gto.published)
@@ -97,7 +95,6 @@ namespace eosio { namespace chain {
          transaction_id_type           trx_id;
          account_name                  sender;
          uint128_t                     sender_id;
-         account_name                  payer;
          time_point                    delay_until; /// this generated transaction will not be applied until the specified time
          time_point                    expiration; /// this generated transaction will not be applied after this time
          time_point                    published;
@@ -116,5 +113,5 @@ namespace eosio { namespace chain {
 
 CHAINDB_SET_TABLE_TYPE(eosio::chain::generated_transaction_object, eosio::chain::generated_transaction_table)
 CHAINDB_TAG(eosio::chain::generated_transaction_object, gtransaction)
-FC_REFLECT(eosio::chain::generated_transaction_object, (id)(trx_id)(sender)(sender_id)(payer)(delay_until)(expiration)(published)(packed_trx))
+FC_REFLECT(eosio::chain::generated_transaction_object, (id)(trx_id)(sender)(sender_id)(delay_until)(expiration)(published)(packed_trx))
 

--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -8,18 +8,16 @@
 
 #include <set>
 
-#include <cyberway/chaindb/common.hpp>
 #include <eosio/chain/int_arithmetic.hpp>
 
 namespace cyberway { namespace chaindb {
+    class chaindb_controller;
     struct ram_payer_info;
 }} // namespace cyberway::chaindb
 
 namespace eosio { namespace chain {
 
 namespace resource_limits {
-   using cyberway::chaindb::ram_payer_info;
-
    namespace impl {
       template<typename T>
       struct ratio {
@@ -74,7 +72,7 @@ namespace resource_limits {
          void add_to_snapshot( const snapshot_writer_ptr& snapshot ) const;
          void read_from_snapshot( const snapshot_reader_ptr& snapshot );
 
-         void initialize_account( const account_name& account );
+         void initialize_account( const account_name& account, const cyberway::chaindb::ram_payer_info& );
          void set_block_parameters( const elastic_limit_parameters& cpu_limit_parameters, const elastic_limit_parameters& net_limit_parameters );
 
          void update_account_usage( const flat_set<account_name>& accounts, uint32_t ordinal );

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -122,7 +122,8 @@ namespace eosio { namespace chain {
 
          void validate_referenced_accounts(const transaction& trx) const;
 
-         account_name get_ram_provider(account_name running_contract, account_name user) const;
+         const account_name& get_ram_provider(const account_name& ram_owner) const;
+         cyberway::chaindb::ram_payer_info get_ram_payer(const account_name& ram_owner);
 
       private:
 

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -6,36 +6,37 @@
 
 namespace eosio { namespace chain {
 
-   struct provided_bandwith {
-       provided_bandwith() = default;
-
-       void confirm(account_name provider);
-
-       bool is_confirmed() const {return confirmed_;}
-
-       int64_t get_net_limit() const {return net_limit_;}
-       int64_t get_cpu_limit() const {return cpu_limit_;}
-
-       void set_net_limit(int64_t net_limit);
-       void set_cpu_limit(int64_t cpu_limit);
-
-       account_name get_provider() const {return provider_;}
-
-   private:
-
-       void verify_limits_not_confirmed();
-
-       int64_t net_limit_ = 0;
-       int64_t cpu_limit_ = 0;
-       bool confirmed_ = false;
-       account_name provider_;
-   };
-   
-   struct bandwith_request_result {
-       std::map<account_name, provided_bandwith> bandwith;
-       uint64_t used_net;
-       uint64_t used_cpu;
-   };
+// TODO: request bw, why provided?
+//   struct provided_bandwith {
+//       provided_bandwith() = default;
+//
+//       void confirm(account_name provider);
+//
+//       bool is_confirmed() const {return confirmed_;}
+//
+//       int64_t get_net_limit() const {return net_limit_;}
+//       int64_t get_cpu_limit() const {return cpu_limit_;}
+//
+//       void set_net_limit(int64_t net_limit);
+//       void set_cpu_limit(int64_t cpu_limit);
+//
+//       account_name get_provider() const {return provider_;}
+//
+//   private:
+//
+//       void verify_limits_not_confirmed();
+//
+//       int64_t net_limit_ = 0;
+//       int64_t cpu_limit_ = 0;
+//       bool confirmed_ = false;
+//       account_name provider_;
+//   };
+//
+//   struct bandwith_request_result {
+//       std::map<account_name, provided_bandwith> bandwith;
+//       uint64_t used_net;
+//       uint64_t used_cpu;
+//   };
 
    struct deadline_timer {
          deadline_timer();
@@ -100,19 +101,20 @@ namespace eosio { namespace chain {
 
          void add_ram_usage( account_name account, int64_t ram_delta );
 
-         uint64_t get_provided_net_limit(account_name account) const;
-
-         uint64_t get_provided_cpu_limit(account_name account) const;
-
-         std::map<account_name, provided_bandwith> get_provided_bandwith() const {return provided_bandwith_;}
-
-         bool is_provided_bandwith_confirmed(account_name account) const;
-
-         void set_provided_bandwith(std::map<account_name, provided_bandwith>&& bandwith);
-
-         void set_provided_bandwith_limits(account_name account, uint64_t net_limit, uint64_t cpu_limit);
-
-         void confirm_provided_bandwith_limits(account_name account, account_name provider);
+// TODO: request bw, why provided?
+//         uint64_t get_provided_net_limit(account_name account) const;
+//
+//         uint64_t get_provided_cpu_limit(account_name account) const;
+//
+//         std::map<account_name, provided_bandwith> get_provided_bandwith() const {return provided_bandwith_;}
+//
+//         bool is_provided_bandwith_confirmed(account_name account) const;
+//
+//         void set_provided_bandwith(std::map<account_name, provided_bandwith>&& bandwith);
+//
+//         void set_provided_bandwith_limits(account_name account, uint64_t net_limit, uint64_t cpu_limit);
+//
+//         void confirm_provided_bandwith_limits(account_name account, account_name provider);
 
          void validate_referenced_accounts(const transaction& trx) const;
 
@@ -184,7 +186,8 @@ namespace eosio { namespace chain {
 
          deadline_timer                _deadline_timer;
 
-         std::map<account_name, provided_bandwith> provided_bandwith_;
+// TODO: request bw, why provided?
+//         std::map<account_name, provided_bandwith> provided_bandwith_;
 
          using contract_for_user = std::pair<account_name, account_name>;
 

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -8,6 +8,10 @@ namespace cyberway { namespace chaindb {
     struct ram_payer_info;
 } } // namespace cyberway::chaindb
 
+namespace cyberway { namespace chain {
+    struct provideram;
+} } // namespace cyberway::chaindb
+
 namespace eosio { namespace chain {
 
 // TODO: request bw, why provided?
@@ -55,7 +59,6 @@ namespace eosio { namespace chain {
          static bool initialized;
    };
 
-   struct provideram;
    class transaction_context {
       private:
          void init( uint64_t initial_net_usage);
@@ -130,7 +133,7 @@ namespace eosio { namespace chain {
          friend struct controller_impl;
          friend class apply_context;
 
-         void add_ram_provider(const provideram& provide_ram);
+         void add_ram_provider(const cyberway::chain::provideram& provide_ram);
 
          void dispatch_action( action_trace& trace, const action& a, account_name receiver, bool context_free = false, uint32_t recurse_depth = 0 );
          inline void dispatch_action( action_trace& trace, const action& a, bool context_free = false ) {

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -4,6 +4,10 @@
 #include "resource_limits.hpp"
 #include <signal.h>
 
+namespace cyberway { namespace chaindb {
+    struct ram_payer_info;
+} } // namespace cyberway::chaindb
+
 namespace eosio { namespace chain {
 
 // TODO: request bw, why provided?
@@ -126,7 +130,6 @@ namespace eosio { namespace chain {
          friend class apply_context;
 
          void add_ram_provider(const provideram& provide_ram);
-         void add_ram_provider(account_name contract, account_name user, account_name provider);
 
          void dispatch_action( action_trace& trace, const action& a, account_name receiver, bool context_free = false, uint32_t recurse_depth = 0 );
          inline void dispatch_action( action_trace& trace, const action& a, bool context_free = false ) {
@@ -189,9 +192,7 @@ namespace eosio { namespace chain {
 // TODO: request bw, why provided?
 //         std::map<account_name, provided_bandwith> provided_bandwith_;
 
-         using contract_for_user = std::pair<account_name, account_name>;
-
-         std::map<contract_for_user, account_name> ram_providers_;
+        fc::flat_map<account_name, account_name> ram_providers;
          
         class available_resources_t {
             struct limit {

--- a/libraries/chain/include/eosio/chain/types.hpp
+++ b/libraries/chain/include/eosio/chain/types.hpp
@@ -4,12 +4,13 @@
  */
 #pragma once
 #include <eosio/chain/name.hpp>
-#include <eosio/chain/domain_name.hpp>
 #include <eosio/chain/chain_id_type.hpp>
 
 #include <chainbase/chainbase.hpp>
 
 #include <eosio/chain/fc_pack.hpp>
+
+#include <cyberway/chain/domain_name.hpp>
 
 #include <fc/container/flat_fwd.hpp>
 #include <fc/io/varint.hpp>
@@ -203,7 +204,6 @@ namespace eosio { namespace chain {
 
    class account_object;
    class producer_object;
-   class domain_object;
    class stake_agent_object;
    class stake_grant_object;
    class stake_param_object;

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -75,8 +75,8 @@ void resource_limits_manager::read_from_snapshot( const snapshot_reader_ptr& sna
    // TODO: Removed by CyberWay
 }
 
-void resource_limits_manager::initialize_account(const account_name& account) {
-   _chaindb.emplace<resource_usage_object>([&]( resource_usage_object& bu ) {
+void resource_limits_manager::initialize_account(const account_name& account, const cyberway::chaindb::ram_payer_info& ram_payer) {
+   _chaindb.emplace<resource_usage_object>(ram_payer, [&]( resource_usage_object& bu ) {
       bu.owner = account;
    });
 }

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -8,6 +8,7 @@
 #include <eosio/chain/global_property_object.hpp>
 
 #include <cyberway/chaindb/controller.hpp>
+#include <cyberway/chain/cyberway_contract_types.hpp>
 
 #pragma push_macro("N")
 #undef N
@@ -248,6 +249,9 @@ namespace bacc = boost::accumulators;
       // Record accounts to be billed for network and CPU usage
       flat_set<account_name> provided_accounts;
 
+      using cyberway::chain::providebw;
+      using cyberway::chain::provideram;
+
       provided_accounts.reserve(trx.actions.size());
       ram_providers.reserve(trx.actions.size());
       for( const auto& act : trx.actions ) {
@@ -302,7 +306,7 @@ namespace bacc = boost::accumulators;
       is_initialized = true;
    }
 
-   void transaction_context::add_ram_provider(const provideram& ram) {
+   void transaction_context::add_ram_provider(const cyberway::chain::provideram& ram) {
        EOS_ASSERT(ram.provider != ram.account, ram_provider_error,
            "Fail to set the provider ${provider} for the account ${account}, because it is the same account",
            ("account", ram.account)("provider", ram.provider));

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -86,25 +86,26 @@ namespace bacc = boost::accumulators;
    volatile sig_atomic_t deadline_timer_verify::hit;
    static deadline_timer_verify deadline_timer_verification;
 
-   void provided_bandwith::confirm(account_name provider) {
-       verify_limits_not_confirmed();
-       confirmed_ = true;
-       provider_ = provider;
-   }
-
-   void provided_bandwith::set_net_limit(int64_t net_limit) {
-       verify_limits_not_confirmed();
-       this->net_limit_ = net_limit;
-   }
-
-   void provided_bandwith::set_cpu_limit(int64_t cpu_limit) {
-       verify_limits_not_confirmed();
-       this->cpu_limit_ = cpu_limit;
-   }
-
-   void provided_bandwith::verify_limits_not_confirmed() {
-        EOS_ASSERT(!confirmed_,  bandwith_already_confirmed, "Bandwith has been already confirmed. No changes could be done");
-   }
+// TODO: request bw, why provided?
+//   void provided_bandwith::confirm(account_name provider) {
+//       verify_limits_not_confirmed();
+//       confirmed_ = true;
+//       provider_ = provider;
+//   }
+//
+//   void provided_bandwith::set_net_limit(int64_t net_limit) {
+//       verify_limits_not_confirmed();
+//       this->net_limit_ = net_limit;
+//   }
+//
+//   void provided_bandwith::set_cpu_limit(int64_t cpu_limit) {
+//       verify_limits_not_confirmed();
+//       this->cpu_limit_ = cpu_limit;
+//   }
+//
+//   void provided_bandwith::verify_limits_not_confirmed() {
+//        EOS_ASSERT(!confirmed_,  bandwith_already_confirmed, "Bandwith has been already confirmed. No changes could be done");
+//   }
 
    deadline_timer::deadline_timer() {
       if(initialized)
@@ -255,12 +256,13 @@ namespace bacc = boost::accumulators;
             add_ram_provider(act.data_as<provideram>());
          }
          for( const auto& auth : act.authorization ) {
-             const auto provided_bw_it = provided_bandwith_.find(auth.actor);
-             if(provided_bw_it != provided_bandwith_.end()) {
-                 bill_to_accounts.insert( provided_bw_it->second.get_provider() );
-             } else {
+// TODO: requestbw
+//             const auto provided_bw_it = provided_bandwith_.find(auth.actor);
+//             if(provided_bw_it != provided_bandwith_.end()) {
+//                 bill_to_accounts.insert( provided_bw_it->second.get_provider() );
+//             } else {
                  bill_to_accounts.insert( auth.actor );
-             }
+//             }
          }
       }
 
@@ -549,48 +551,49 @@ namespace bacc = boost::accumulators;
       return static_cast<uint32_t>(billed_cpu_time_us);
    }
 
-   uint64_t transaction_context::get_provided_net_limit(account_name account) const {
-       const auto provided_bw_it = provided_bandwith_.find(account);
-
-       if (provided_bw_it == provided_bandwith_.end()) {
-           return 0;
-       }
-
-       return provided_bw_it->second.get_net_limit();
-   }
-
-   uint64_t transaction_context::get_provided_cpu_limit(account_name account) const {
-       const auto provided_bw_it = provided_bandwith_.find(account);
-
-       if (provided_bw_it == provided_bandwith_.end()) {
-           return 0;
-       }
-
-       return provided_bw_it->second.get_cpu_limit();
-   }
-
-   bool transaction_context::is_provided_bandwith_confirmed(account_name account) const {
-       const auto provided_bw_it = provided_bandwith_.find(account);
-
-       if (provided_bw_it == provided_bandwith_.end()) {
-           return 0;
-       }
-
-       return provided_bw_it->second.is_confirmed();
-   }
-
-   void transaction_context::set_provided_bandwith(std::map<account_name, provided_bandwith>&& bandwith) {
-       provided_bandwith_ = std::move(bandwith);
-   }
-
-   void transaction_context::set_provided_bandwith_limits(account_name account, uint64_t net_limit, uint64_t cpu_limit) {
-        provided_bandwith_[account].set_net_limit(net_limit);
-        provided_bandwith_[account].set_cpu_limit(cpu_limit);
-   }
-
-   void transaction_context::confirm_provided_bandwith_limits(account_name account, account_name provider) {
-        provided_bandwith_[account].confirm(provider);
-   }
+// TODO: requested bw, why provided ?
+//   uint64_t transaction_context::get_provided_net_limit(account_name account) const {
+//       const auto provided_bw_it = provided_bandwith_.find(account);
+//
+//       if (provided_bw_it == provided_bandwith_.end()) {
+//           return 0;
+//       }
+//
+//       return provided_bw_it->second.get_net_limit();
+//   }
+//
+//   uint64_t transaction_context::get_provided_cpu_limit(account_name account) const {
+//       const auto provided_bw_it = provided_bandwith_.find(account);
+//
+//       if (provided_bw_it == provided_bandwith_.end()) {
+//           return 0;
+//       }
+//
+//       return provided_bw_it->second.get_cpu_limit();
+//   }
+//
+//   bool transaction_context::is_provided_bandwith_confirmed(account_name account) const {
+//       const auto provided_bw_it = provided_bandwith_.find(account);
+//
+//       if (provided_bw_it == provided_bandwith_.end()) {
+//           return 0;
+//       }
+//
+//       return provided_bw_it->second.is_confirmed();
+//   }
+//
+//   void transaction_context::set_provided_bandwith(std::map<account_name, provided_bandwith>&& bandwith) {
+//       provided_bandwith_ = std::move(bandwith);
+//   }
+//
+//   void transaction_context::set_provided_bandwith_limits(account_name account, uint64_t net_limit, uint64_t cpu_limit) {
+//        provided_bandwith_[account].set_net_limit(net_limit);
+//        provided_bandwith_[account].set_cpu_limit(cpu_limit);
+//   }
+//
+//   void transaction_context::confirm_provided_bandwith_limits(account_name account, account_name provider) {
+//        provided_bandwith_[account].confirm(provider);
+//   }
 
    void transaction_context::dispatch_action( action_trace& trace, const action& a, account_name receiver, bool context_free, uint32_t recurse_depth ) {
       apply_context  acontext( control, *this, a, recurse_depth );

--- a/libraries/chain/wasm_chaindb_interface.ipp
+++ b/libraries/chain/wasm_chaindb_interface.ipp
@@ -144,7 +144,7 @@ namespace eosio { namespace chain {
                 "must specify a valid account to pay for new record");
             validate_db_access_violation(code);
             context.lazy_init_chaindb_abi(code);
-            context.chaindb.insert({code, scope, table}, {context, payer}, pk, data, size);
+            context.chaindb.insert({code, scope, table}, context.get_ram_payer(payer), pk, data, size);
             return pk;
         }
 
@@ -154,7 +154,7 @@ namespace eosio { namespace chain {
         ) {
             validate_db_access_violation(code);
             context.lazy_init_chaindb_abi(code);
-            context.chaindb.update({code, scope, table}, {context, payer}, pk, data, size);
+            context.chaindb.update({code, scope, table}, context.get_ram_payer(payer), pk, data, size);
             return pk;
         }
 
@@ -163,7 +163,7 @@ namespace eosio { namespace chain {
         ) {
             validate_db_access_violation(code);
             context.lazy_init_chaindb_abi(code);
-            context.chaindb.remove({code, scope, table}, {context}, pk);
+            context.chaindb.remove({code, scope, table}, context.get_ram_payer(), pk);
             return pk;
         }
 

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -1095,44 +1095,32 @@ class console_api : public context_aware_api {
       bool ignore;
 };
 
-
-class bandwith_api : public context_aware_api {
-    public:
-        bandwith_api( apply_context& ctx )
-        : context_aware_api(ctx,true) {}
-
-        int64_t get_bw_cpu_limit(account_name account) const {
-            return context.trx_context.get_provided_cpu_limit(account);
-        }
-
-        int64_t get_bw_net_limit(account_name account) const {
-            return context.trx_context.get_provided_net_limit(account);
-        }
-
-        bool is_provided_bw_confirmed(account_name account) const {
-            return context.trx_context.is_provided_bandwith_confirmed(account);
-        }
-
-        void set_bw_limits(account_name account, int64_t net_limit, int64_t cpu_limit) {
-            context.trx_context.set_provided_bandwith_limits(account, net_limit, cpu_limit);
-        }
-
-        void confirm_bw_limits(account_name account) {
-            context.trx_context.confirm_provided_bandwith_limits(account, context.receiver);
-        }
-};
-
-class ram_provide_api : public context_aware_api {
-    public:
-        ram_provide_api( apply_context& ctx )
-        : context_aware_api(ctx,true) {}
-
-        account_name get_ram_provider(account_name user) const {
-            const account_name running_contract = context.receiver;
-            return context.trx_context.get_ram_provider(running_contract, user);
-        }
-};
-
+//TODO: requestbw
+//class bandwith_api : public context_aware_api {
+//    public:
+//        bandwith_api( apply_context& ctx )
+//        : context_aware_api(ctx,true) {}
+//
+//        int64_t get_bw_cpu_limit(account_name account) const {
+//            return context.trx_context.get_provided_cpu_limit(account);
+//        }
+//
+//        int64_t get_bw_net_limit(account_name account) const {
+//            return context.trx_context.get_provided_net_limit(account);
+//        }
+//
+//        bool is_provided_bw_confirmed(account_name account) const {
+//            return context.trx_context.is_provided_bandwith_confirmed(account);
+//        }
+//
+//        void set_bw_limits(account_name account, int64_t net_limit, int64_t cpu_limit) {
+//            context.trx_context.set_provided_bandwith_limits(account, net_limit, cpu_limit);
+//        }
+//
+//        void confirm_bw_limits(account_name account) {
+//            context.trx_context.confirm_provided_bandwith_limits(account, context.receiver);
+//        }
+//};
 
 #define DB_API_METHOD_WRAPPERS_SIMPLE_SECONDARY(IDX, TYPE)\
       int db_##IDX##_store( uint64_t scope, uint64_t table, uint64_t payer, uint64_t id, const TYPE& secondary ) {\
@@ -1884,18 +1872,15 @@ REGISTER_INTRINSICS(console_api,
    (printhex,              void(int, int) )
 );
 
-
-REGISTER_INTRINSICS(bandwith_api,
-    (get_bw_cpu_limit, int64_t(int64_t))
-    (get_bw_net_limit, int64_t(int64_t ))
-    (is_provided_bw_confirmed, int(int64_t))
-    (set_bw_limits, void(int64_t, int64_t, int64_t))
-    (confirm_bw_limits, void(int64_t))
-);
-
-REGISTER_INTRINSICS(ram_provide_api,
-    (get_ram_provider, int64_t(int64_t))
-);
+// TODO: Rename
+//
+//REGISTER_INTRINSICS(bandwith_api,
+//    (get_bw_cpu_limit, int64_t(int64_t))
+//    (get_bw_net_limit, int64_t(int64_t ))
+//    (is_provided_bw_confirmed, int(int64_t))
+//    (set_bw_limits, void(int64_t, int64_t, int64_t))
+//    (confirm_bw_limits, void(int64_t))
+//);
 
 REGISTER_INTRINSICS(context_free_transaction_api,
    (read_transaction,       int(int, int)            )

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -274,7 +274,7 @@ resolve_names_results chain_api_plugin_impl::resolve_names(const resolve_names_p
     resolve_names_results r;
 
     auto set_domain = [&](const auto& n, resolve_names_item& item) {
-        chain::validate_domain_name(n);
+        cyberway::chain::validate_domain_name(n);
         item.resolved_domain = chain_controller_.get_domain(n).linked_to;
     };
 
@@ -298,7 +298,7 @@ resolve_names_results chain_api_plugin_impl::resolve_names(const resolve_names_p
             auto username = n.substr(0, at);
             bool have_username = username.size() > 0;
             if (have_username) {
-                chain::validate_username(username);
+                cyberway::chain::validate_username(username);
             }
 
             auto tail = n.substr(tail_pos, n.length() - tail_pos);

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -438,10 +438,15 @@ get_table_rows_result chain_api_plugin_impl::walk_table_row_range(const get_tabl
 
     for(unsigned int count = 0;
         cur_time <= end_time && count < p.limit && itr.pk != end_pk;
-        itr.pk = chaindb.next(cursor), ++count, cur_time = fc::time_point::now()) {
+        itr.pk = chaindb.next(cursor), ++count, cur_time = fc::time_point::now()
+    ) {
         if (p.show_payer && *p.show_payer) {
             const auto object = chaindb.object_at_cursor(cursor);
-            auto value = fc::mutable_variant_object()("data", object.value)("payer", object.service.payer);
+            auto value = fc::mutable_variant_object()
+                ("data",  object.value)
+                ("payer", object.service.payer)
+                ("owner", object.service.owner)
+                ("size",  object.service.size);
             result.rows.push_back(std::move(value));
         } else {
             result.rows.push_back(chaindb.value_at_cursor(cursor));
@@ -680,7 +685,8 @@ get_scheduled_transactions_result chain_api_plugin_impl::get_scheduled_transacti
               ("trx_id", itr->trx_id)
               ("sender", itr->sender)
               ("sender_id", itr->sender_id)
-              ("payer", itr->payer)
+              ("owner", itr.service().owner)
+              ("payer", itr.service().payer)
               ("delay_until", itr->delay_until)
               ("expiration", itr->expiration)
               ("published", itr->published)

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -96,6 +96,8 @@ Options:
 
 #include <eosio/chain/contract_types.hpp>
 
+#include <cyberway/chain/cyberway_contract_types.hpp>
+
 #pragma push_macro("N")
 #undef N
 
@@ -449,14 +451,18 @@ fc::variant push_transaction( signed_transaction& trx, int32_t extra_kcpu = 1000
       if (!bandwidth_provider.empty()) {
          auto providers = get_bandwidth_providers({bandwidth_provider});
          for (const auto& prov: providers) {
-            trx.actions.emplace_back(vector<chain::permission_level>{prov.second}, providebw{prov.second.actor, prov.first} );
+            trx.actions.emplace_back(
+                vector<chain::permission_level>{prov.second},
+                cyberway::chain::providebw{prov.second.actor, prov.first} );
          }
       }
 
       if (!ram_providers.empty()) {
           for (const auto& ram_provider : ram_providers) {
               const provide_ram_params provide_params(ram_provider);
-              trx.actions.emplace_back(vector<chain::permission_level>{provide_params.permission}, provideram{provide_params.provider, provide_params.actor});
+              trx.actions.emplace_back(
+                  vector<chain::permission_level>{provide_params.permission},
+                  cyberway::chain::provideram{provide_params.provider, provide_params.actor});
           }
 
       }

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -332,8 +332,8 @@ struct provide_ram_params {
     provide_ram_params(const string& providers) {
         vector<string> pieces;
         split(pieces, providers, boost::algorithm::is_any_of("/"));
-        if (pieces.size() != 3) {
-           std::cerr << localized("Ram provider ${p} not in 'account/provider[@permission]/list,of,contracts' form", ("p", providers)) << std::endl;
+        if (pieces.size() != 2) {
+           std::cerr << localized("Ram provider ${p} not in 'account/provider[@permission]' form", ("p", providers)) << std::endl;
            return;
         }
         actor = pieces[0];
@@ -344,23 +344,10 @@ struct provide_ram_params {
         provider = provider_and_authority[0];
         permission.permission = provider_and_authority.size() == 1 ? "active" : provider_and_authority[1];
         permission.actor = provider;
-
-        std::vector<string> contracts_as_strings;
-
-        split(contracts_as_strings, pieces[2], boost::algorithm::is_any_of(","));
-        if (contracts_as_strings.empty()) {
-            std::cerr << localized("List of contracts is empty") << std::endl;
-            return;
-        }
-
-        for (const auto& contract : contracts_as_strings) {
-            contracts.emplace_back(contract);
-        }
     }
 
     account_name provider;
     account_name actor;
-    std::vector<account_name> contracts;
     chain::permission_level permission;
 };
 
@@ -469,7 +456,7 @@ fc::variant push_transaction( signed_transaction& trx, int32_t extra_kcpu = 1000
       if (!ram_providers.empty()) {
           for (const auto& ram_provider : ram_providers) {
               const provide_ram_params provide_params(ram_provider);
-              trx.actions.emplace_back(vector<chain::permission_level>{provide_params.permission}, provideram{provide_params.provider, provide_params.actor, provide_params.contracts});
+              trx.actions.emplace_back(vector<chain::permission_level>{provide_params.permission}, provideram{provide_params.provider, provide_params.actor});
           }
 
       }

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -27,6 +27,8 @@
 #include <deep_nested.abi.hpp>
 #include <large_nested.abi.hpp>
 
+#include <cyberway/chain/cyberway_contract_types.hpp>
+
 using namespace eosio;
 using namespace chain;
 
@@ -955,16 +957,16 @@ BOOST_AUTO_TEST_CASE(providebw_test)
 
    auto var = fc::json::from_string(test_data);
 
-   auto pbw = var.as<providebw>();
+   auto pbw = var.as<cyberway::chain::providebw>();
    BOOST_TEST("provbw.prov" == pbw.provider);
    BOOST_TEST("provbw.acct" == pbw.account);
 
    auto var2 = verify_byte_round_trip_conversion( abis, "providebw", var );
-   auto providebw2 = var2.as<providebw>();
+   auto providebw2 = var2.as<cyberway::chain::providebw>();
    BOOST_TEST(pbw.provider == providebw2.provider);
    BOOST_TEST(pbw.account == providebw2.account);
 
-   verify_type_round_trip_conversion<providebw>( abis, "providebw", var);
+   verify_type_round_trip_conversion<cyberway::chain::providebw>( abis, "providebw", var);
 
 } FC_LOG_AND_RETHROW() }
 

--- a/unittests/providebw_tests.cpp
+++ b/unittests/providebw_tests.cpp
@@ -17,6 +17,8 @@
 
 #include <fc/variant_object.hpp>
 
+#include <cyberway/chain/cyberway_contract_types.hpp>
+
 #ifdef NON_VALIDATING_TEST
 #define TESTER tester
 #else
@@ -181,7 +183,7 @@ BOOST_FIXTURE_TEST_CASE( providebw_test, system_contract_tester ) {
         BOOST_REQUIRE_EXCEPTION( push_transaction(trx), tx_net_usage_exceeded, [](auto&){return true;});
 
         trx.actions.emplace_back( vector<permission_level>{{"provider", config::active_name}},
-                                  providebw(N(provider), N(user)));
+                                  cyberway::chain::providebw(N(provider), N(user)));
         set_transaction_headers(trx);
 
         // Check that user can publish transaction using provider bandwidth
@@ -215,7 +217,7 @@ BOOST_FIXTURE_TEST_CASE( providebw_test, system_contract_tester ) {
 
         // Check operation success with 2 providebw
         trx.actions.emplace_back( vector<permission_level>{{"provider", config::active_name}},
-                                  providebw(N(provider), N(user2)));
+                                  cyberway::chain::providebw(N(provider), N(user2)));
         set_transaction_headers(trx);
         trx.signatures.clear();
         trx.sign( get_private_key("user", "active"), control->get_chain_id() );


### PR DESCRIPTION
Resolve #475 
- pass provider as ram-payer in interchain-objects
- change ram-owner in create account from created account to creator. 
-- creator can set ram-payer as an additional `changepayer`
-- this is default case for application - they can create account on its balance

Resolve #476 
- pass provider as ram-payer contacts-objects

First step for #479:
- move cyberway objects to external source-files
-- this should simplify import changes from EOS