### PR TITLE
Send EventEngine genesis #544

### DIFF
--- a/libraries/chain/include/cyberway/genesis/ee_genesis_container.hpp
+++ b/libraries/chain/include/cyberway/genesis/ee_genesis_container.hpp
@@ -1,20 +1,29 @@
 #pragma once
 
 #include <eosio/chain/types.hpp>
+#include <eosio/chain/abi_def.hpp>
 #include <fc/reflect/reflect.hpp>
 
 namespace cyberway { namespace genesis {
 
 using namespace eosio::chain;
 
-struct genesis_ee_header {
-    char magic[14] = "CyberwayEEGen";
+struct ee_genesis_header {
+    char magic[12] = "CyberwayEEG";
     uint32_t version = 1;
+    fc::sha256 hash;
 
     bool is_valid() {
-        genesis_ee_header oth;
+        ee_genesis_header oth;
         return string(magic) == oth.magic && version == oth.version;
     }
+};
+
+struct ee_table_header {
+    account_name code;
+    table_name   name;
+    type_name    abi_type;
+    uint32_t     count;
 };
 
 enum class section_ee_type {
@@ -45,6 +54,7 @@ struct message_ee_object {
 
 }} // cyberway::genesis
 
+FC_REFLECT(cyberway::genesis::ee_table_header, (code)(name)(abi_type)(count))
 FC_REFLECT_ENUM(cyberway::genesis::section_ee_type, (messages))
 FC_REFLECT(cyberway::genesis::section_ee_header, (type))
 

--- a/libraries/chain/include/cyberway/genesis/ee_genesis_serializer.hpp
+++ b/libraries/chain/include/cyberway/genesis/ee_genesis_serializer.hpp
@@ -1,0 +1,63 @@
+#pragma once
+#include <boost/filesystem/fstream.hpp>
+#include <cyberway/chaindb/common.hpp>
+#include <cyberway/genesis/ee_genesis_container.hpp>
+#include <eosio/chain/abi_serializer.hpp>
+
+namespace cyberway { namespace genesis {
+
+using namespace chaindb;
+namespace bfs = boost::filesystem;
+
+//const fc::microseconds abi_serializer_max_time = fc::seconds(10);
+
+struct ee_genesis_serializer {
+
+private:
+    bfs::ofstream out;
+    int _row_count = 0;
+    ee_table_header _section;
+    abi_serializer serializer;
+
+public:
+    void start(const bfs::path& out_file, const fc::sha256& hash, const abi_def& abi, 
+            const fc::microseconds abi_serializer_max_time = fc::seconds(10)) {
+
+        out.exceptions(std::ofstream::failbit | std::ofstream::badbit);
+        out.open(out_file, std::ios_base::binary);
+
+        ee_genesis_header hdr;
+        out.write((char*)(&hdr), sizeof(hdr));
+
+        fc::raw::pack(out, abi);
+        serializer.set_abi(abi, abi_serializer_max_time);
+    }
+
+    void finalize() {
+        finish_section();
+    }
+
+    void start_section(account_name code, table_name name, std::string abi_type, uint32_t count) {
+        finish_section();
+
+        ee_table_header h{code, name, abi_type, count};
+        wlog("Starting section: ${s}", ("s", h));
+        fc::raw::pack(out, h);
+        _row_count = count;
+        _section = h;
+    }
+
+    void finish_section() {
+        EOS_ASSERT(_row_count == 0, genesis_exception, "Section contains wrong number of rows",
+            ("section",_section)("diff",_row_count));
+    }
+
+    void insert(const variant& v, const fc::microseconds abi_serializer_max_time = fc::seconds(10)) {
+        bytes data = serializer.variant_to_binary(_section.abi_type, v, abi_serializer_max_time);
+        fc::raw::pack(out, data);
+        _row_count--;
+    }
+};
+
+
+}} // cyberway::genesis

--- a/plugins/event_engine_plugin/event_engine_plugin.cpp
+++ b/plugins/event_engine_plugin/event_engine_plugin.cpp
@@ -2,18 +2,23 @@
  *  @file
  *  @copyright defined in eos/LICENSE.txt
  */
+#include <boost/filesystem/path.hpp>
+#include <boost/filesystem/fstream.hpp>
 #include <eosio/event_engine_plugin/event_engine_plugin.hpp>
 #include <eosio/event_engine_plugin/messages.hpp>
 #include <eosio/chain_plugin/chain_plugin.hpp>
 #include <fc/exception/exception.hpp>
 #include <fc/variant_object.hpp>
 #include <fc/io/json.hpp>
+#include <cyberway/genesis/ee_genesis_container.hpp>
 
 #include <fstream>
 
 using namespace eosio::chain;
 
 namespace eosio {
+   FC_DECLARE_EXCEPTION(ee_extract_genesis_exception, 10000000, "event engine genesis extract exception");
+
    static appbase::abstract_plugin& _event_engine_plugin = app().register_plugin<event_engine_plugin>();
 
 class abi_info final {
@@ -65,12 +70,15 @@ public:
     controller &db;
     fc::microseconds abi_serializer_max_time;
     std::set<account_name> receiver_filter;
+    std::vector<bfs::path> genesis_files;
 
     void set_abi(name account, const abi_def& abi);
     void accepted_block( const chain::block_state_ptr& );
     void irreversible_block(const chain::block_state_ptr&);
     void accepted_transaction(const chain::transaction_metadata_ptr&);
     void applied_transaction(const chain::transaction_trace_ptr&);
+
+    void send_genesis_file(const bfs::path& genesis_file);
 
     bool is_handled_contract(const account_name n) const;
 
@@ -201,6 +209,49 @@ bool event_engine_plugin_impl::is_handled_contract(const account_name n) const {
     return receiver_filter.empty() || receiver_filter.find(n) != receiver_filter.end();
 }
 
+void event_engine_plugin_impl::send_genesis_file(const bfs::path& genesis_file) {
+    using cyberway::genesis::ee_genesis_header;
+    using cyberway::genesis::ee_table_header;
+
+    std::cout << "Reading event engine genesis data from " << genesis_file << "..." << std::endl;
+    bfs::ifstream in(genesis_file);
+    ee_genesis_header h{"", 0};
+
+    in.read((char*)&h, sizeof(h));
+    std::cout << "Header magic: " << h.magic << "; ver: " << h.version << std::endl;
+    EOS_ASSERT(h.is_valid(), ee_extract_genesis_exception, "Unknown format of the Genesis state file.");
+
+    // Read ABI
+    abi_def abi;
+    abi_serializer serializer;
+
+    fc::raw::unpack(in, abi);
+    serializer.set_abi(abi, abi_serializer_max_time);
+
+    while (in) {
+        ee_table_header t;
+        fc::raw::unpack(in, t);
+        if (!in)
+            break;
+
+        std::cout << "Reading " << t.count << " record(s) with type: " << t.abi_type << std::endl;
+        for (unsigned i = 0; i < t.count; ++i) {
+            bytes data;
+            fc::raw::unpack(in, data);
+
+            fc::variant args;
+            if (data.size() != 0) {
+                fc::datastream<const char*> ds(static_cast<const char*>(data.data()), data.size());
+                args = serializer.binary_to_variant(t.abi_type, ds, abi_serializer_max_time);
+            }
+
+            GenesisDataMessage msg(BaseMessage::GenesisData, t.code, t.name, args);
+            send_message(msg);
+        }
+    }
+    std::cout << "Done reading Event Engine Genesis data from " << genesis_file << std::endl;
+}
+
 void event_engine_plugin_impl::applied_transaction(const chain::transaction_trace_ptr& trx_trace) {
     ilog("Applied trx: ${block_num}, ${id}", ("block_num", trx_trace->block_num)("id", trx_trace->id));
 
@@ -254,6 +305,7 @@ void event_engine_plugin::set_program_options(options_description&, options_desc
         ("event-engine-dumpfile", bpo::value<string>()->default_value(""))
         ("event-engine-contract", bpo::value<vector<string>>()->composing()->multitoken(),
          "Smart-contracts for which event_engine will handle events (may specify multiple times)")
+        ("event-engine-genesis",  bpo::value<vector<string>>()->composing()->multitoken())
         ;
 }
 
@@ -272,6 +324,7 @@ void event_engine_plugin::plugin_initialize(const variables_map& options) {
         my.reset(new event_engine_plugin_impl(chain, chain_plug->get_abi_serializer_max_time()));
 
         LOAD_VALUE_SET(options, "event-engine-contract", my->receiver_filter);
+        LOAD_VALUE_SET(options, "event-engine-genesis", my->genesis_files);
 
         std::string dump_filename = options.at("event-engine-dumpfile").as<string>();
         if(dump_filename != "") {
@@ -308,7 +361,13 @@ void event_engine_plugin::plugin_initialize(const variables_map& options) {
 }
 
 void event_engine_plugin::plugin_startup() {
+   auto& chain = app().find_plugin<chain_plugin>()->chain();
    // Make the magic happen
+   if (chain.head_block_num() == 1) {
+       for(const auto& file: my->genesis_files) {
+           my->send_genesis_file(file);
+       }
+   }
 }
 
 void event_engine_plugin::plugin_shutdown() {

--- a/plugins/event_engine_plugin/include/eosio/event_engine_plugin/messages.hpp
+++ b/plugins/event_engine_plugin/include/eosio/event_engine_plugin/messages.hpp
@@ -61,12 +61,27 @@ namespace eosio {
 
            AcceptTrx,
            ApplyTrx,
+
+           GenesisData,
        };
 
        MsgType msg_type;
 
        BaseMessage(MsgType type = Unknown)
        : msg_type(type)
+       {}
+   };
+
+   struct GenesisDataMessage : public BaseMessage {
+       chain::name code;
+       chain::name name;
+       fc::variant data;
+
+       GenesisDataMessage(BaseMessage::MsgType msg_type, const chain::name code, const chain::name name, const fc::variant& data)
+       : BaseMessage(msg_type)
+       , code(code)
+       , name(name)
+       , data(data)
        {}
    };
 
@@ -143,8 +158,9 @@ FC_REFLECT(eosio::ActionData, (receiver)(code)(action)(data)(args)(events))
 FC_REFLECT(eosio::TrxMetadata, (id)(accepted)(implicit)(scheduled))
 FC_REFLECT(eosio::TrxReceipt, (id)(status)(cpu_usage_us)(net_usage_words))
 
-FC_REFLECT_ENUM(eosio::BaseMessage::MsgType, (Unknown)(AcceptBlock)(CommitBlock)(AcceptTrx)(ApplyTrx))
+FC_REFLECT_ENUM(eosio::BaseMessage::MsgType, (Unknown)(GenesisData)(AcceptBlock)(CommitBlock)(AcceptTrx)(ApplyTrx))
 FC_REFLECT(eosio::BaseMessage, (msg_type))
+FC_REFLECT_DERIVED(eosio::GenesisDataMessage, (eosio::BaseMessage), (code)(name)(data))
 FC_REFLECT_DERIVED(eosio::BlockMessage, (eosio::BaseMessage), (id)(block_num)(block_time)(validated)(in_current_chain))
 FC_REFLECT_DERIVED(eosio::AcceptedBlockMessage, (eosio::BlockMessage), (trxs)(events))
 FC_REFLECT_DERIVED(eosio::AcceptTrxMessage, (eosio::BaseMessage)(eosio::TrxMetadata), )

--- a/programs/create-genesis-ee/genesis_ee_builder.cpp
+++ b/programs/create-genesis-ee/genesis_ee_builder.cpp
@@ -1,6 +1,6 @@
 #include "genesis_ee_builder.hpp"
 #include "golos_operations.hpp"
-#include <cyberway/genesis/genesis_ee_container.hpp>
+#include <cyberway/genesis/ee_genesis_container.hpp>
 
 #define MEGABYTE 1024*1024
 
@@ -167,8 +167,8 @@ void genesis_ee_builder::build(const bfs::path& out_file) {
     out_.exceptions(std::ofstream::failbit | std::ofstream::badbit);
     out_.open(out_file, std::ios_base::binary);
 
-    genesis_ee_header hdr;
-    out_.write((const char*)&hdr, sizeof(genesis_ee_header));
+    ee_genesis_header hdr;
+    out_.write((const char*)&hdr, sizeof(ee_genesis_header));
 
     build_messages();
 }

--- a/programs/create-genesis/genesis_create.hpp
+++ b/programs/create-genesis/genesis_create.hpp
@@ -27,7 +27,7 @@ public:
     ~genesis_create();
 
     void read_state(const bfs::path& state_file);
-    void write_genesis(const bfs::path& out_file, const genesis_info&, const genesis_state&, const contracts_map&);
+    void write_genesis(const bfs::path& out_file, const bfs::path& ee_file, const genesis_info&, const genesis_state&, const contracts_map&);
 
 private:
     struct genesis_create_impl;

--- a/programs/create-genesis/main.cpp
+++ b/programs/create-genesis/main.cpp
@@ -45,6 +45,7 @@ struct config_reader {
 
     bfs::path info_file;
     bfs::path out_file;
+    bfs::path ee_file;
 
     genesis_info info;
     genesis_state genesis;
@@ -58,6 +59,8 @@ void config_reader::set_program_options(options_description& cli) {
             "the location of the genesis info file (absolute path or relative to the current directory).")
         ("output-file,o", bpo::value<bfs::path>(&out_file)->default_value("cyberway-genesis.dat"),
             "the file to write generic genesis data to (absolute or relative path).")
+        ("ee-output-file,o", bpo::value<bfs::path>(&ee_file)->default_value("events-genesis.dat"),
+            "the file to write Event-Engine genesis data to (absolute or relative path).")
         ("help,h", "Print this help message and exit.")
         ;
 }
@@ -147,7 +150,7 @@ int main(int argc, char** argv) {
 
         genesis_create builder{};
         builder.read_state(cr.info.state_file);
-        builder.write_genesis(cr.out_file, cr.info, cr.genesis, cr.contracts);
+        builder.write_genesis(cr.out_file, cr.ee_file, cr.info, cr.genesis, cr.contracts);
 
     } catch (const fc::exception& e) {
         elog("${e}", ("e", e.to_detail_string()));

--- a/programs/create-genesis/main.cpp
+++ b/programs/create-genesis/main.cpp
@@ -112,6 +112,7 @@ void config_reader::read_config(const variables_map& options) {
     ilog("Genesis: read config");
     make_absolute(info_file, "Info");
     make_absolute(out_file, "Output", false);
+    make_absolute(ee_file, "Events", false);
 
     info = fc::json::from_file(info_file).as<genesis_info>();
     make_absolute(info.state_file, "Golos state");

--- a/programs/create-genesis/main.cpp
+++ b/programs/create-genesis/main.cpp
@@ -59,7 +59,7 @@ void config_reader::set_program_options(options_description& cli) {
             "the location of the genesis info file (absolute path or relative to the current directory).")
         ("output-file,o", bpo::value<bfs::path>(&out_file)->default_value("cyberway-genesis.dat"),
             "the file to write generic genesis data to (absolute or relative path).")
-        ("ee-output-file,o", bpo::value<bfs::path>(&ee_file)->default_value("events-genesis.dat"),
+        ("ee-output-file,e", bpo::value<bfs::path>(&ee_file)->default_value("events-genesis.dat"),
             "the file to write Event-Engine genesis data to (absolute or relative path).")
         ("help,h", "Print this help message and exit.")
         ;


### PR DESCRIPTION
Resolves #544, partly implement #545
1. implement `ee_genesis_serializer` to write EE genesis data
2. add `GenesisDataMessage` for sending EE genesis data
3. event_engine_plugin send data from `event-engine-genesis` files. May be pointed several times.
4. `create-genesis` utility form EE genesis data with currency stats for `cyber.token` contract

On receiver side, GenesisDataMessage looks like:
```
{
    "msg_type": "GenesisData",
    "code": "cyber.token",
    "name": "stat",
    "data": {
        "supply": {
            "amount": 1742257220940,
            "decs": 4,
            "sym": "SYS"
        },
        "max_supply": {
            "amount": 10000000000000,
            "decs": 4,
            "sym": "SYS"
        },
        "issuer": "cyber"
    }
}
{
    "msg_type": "GenesisData",
    "code": "cyber.token",
    "name": "stat",
    "data": {
        "supply": {
            "amount": 174475149117,
            "decs": 3,
            "sym": "GOLOS"
        },
        "max_supply": {
            "amount": 1000000000000,
            "decs": 3,
            "sym": "GOLOS"
        },
        "issuer": "gls.issuer"
    }
}
```