### PR TITLE
Change ram state #479

### DIFF
--- a/contracts/eosiolib/chaindb.h
+++ b/contracts/eosiolib/chaindb.h
@@ -34,12 +34,15 @@ primary_key_t chaindb_prev(account_name_t code, cursor_t);
 
 int32_t chaindb_datasize(account_name_t code, cursor_t);
 primary_key_t chaindb_data(account_name_t code, cursor_t, void* data, const size_t size);
+int32_t chaindb_service(account_name_t code, cursor_t, void* data, const size_t size);
 
 primary_key_t chaindb_available_primary_key(account_name_t code, scope_t scope, table_name_t table);
 
-primary_key_t chaindb_insert(account_name_t code, scope_t scope, account_name_t payer, table_name_t, primary_key_t, void* data, size_t);
-primary_key_t chaindb_update(account_name_t code, scope_t scope, account_name_t payer, table_name_t, primary_key_t, void* data, size_t);
-primary_key_t chaindb_delete(account_name_t code, scope_t scope, table_name_t, primary_key_t);
+int32_t chaindb_insert(account_name_t code, scope_t scope, account_name_t payer, table_name_t, primary_key_t, void* data, size_t);
+int32_t chaindb_update(account_name_t code, scope_t scope, account_name_t payer, table_name_t, primary_key_t, void* data, size_t);
+int32_t chaindb_delete(account_name_t code, scope_t scope, table_name_t, primary_key_t);
+
+int32_t chaindb_ram_state(account_name_t code, scope_t scope, table_name_t, primary_key_t, bool);
 
 #ifdef __cplusplus
 }

--- a/contracts/eosiolib/multi_index.hpp
+++ b/contracts/eosiolib/multi_index.hpp
@@ -513,14 +513,14 @@ private:
             return static_cast<const T*>(item_.get());
         }
         primary_key_t pk() const {
-            lazy_load_object();
+            lazy_open();
             return primary_key_;
         }
         int size() const {
             lazy_load_object();
             return item_->service_.size;
         }
-        eosio::name payer() const {
+        const eosio::name& payer() const {
             lazy_load_object();
             return item_->service_.payer;
         }

--- a/contracts/eosiolib/multi_index.hpp
+++ b/contracts/eosiolib/multi_index.hpp
@@ -300,6 +300,12 @@ struct key_converter<std::tuple<Indices...>> {
     }
 }; // struct key_converter
 
+struct service_info {
+    account_name_t payer;
+    int  size   = 0;
+    bool in_ram = false;
+}; // struct service_info
+
 template<typename T, typename MultiIndex>
 struct multi_index_item: public T {
     template<typename Constructor>
@@ -311,6 +317,7 @@ struct multi_index_item: public T {
 
     const account_name_t code_;
     const scope_t scope_ = 0;
+    service_info  service_;
 
     bool deleted_ = false;
     int ref_cnt_ = 0;
@@ -504,6 +511,18 @@ private:
         const T* operator->() const {
             lazy_load_object();
             return static_cast<const T*>(item_.get());
+        }
+        primary_key_t pk() const {
+            lazy_load_object();
+            return primary_key_;
+        }
+        int size() const {
+            lazy_load_object();
+            return item_->service_.size;
+        }
+        eosio::name payer() const {
+            lazy_load_object();
+            return item_->service_.payer;
         }
 
         const_iterator_impl operator++(int) {
@@ -828,7 +847,7 @@ private:
 
         auto size = chaindb_datasize(get_code(), cursor);
 
-        safe_allocate(size, "invalid unpack object size", [&](auto& data, auto& datasize) {
+        safe_allocate(size, "object doesn't exist", [&](auto& data, auto& datasize) {
             auto dpk = chaindb_data(get_code(), cursor, data, datasize);
             chaindb_assert(dpk == pk, "invalid packet object");
             ptr = item_ptr(new item(*this, [&](auto& itm) {
@@ -839,6 +858,12 @@ private:
 
         auto ptr_pk = primary_key_extractor_type()(*ptr);
         chaindb_assert(ptr_pk == pk, "invalid primary key of object");
+
+        safe_allocate(sizeof(service_info), "object doesn't exist", [&](auto& data, auto& datasize) {
+            chaindb_service(get_code(), cursor, data, datasize);
+            unpack_object(ptr->service_, data, datasize);
+        });
+
         add_object_to_cache(ptr);
         return ptr;
     }
@@ -931,7 +956,10 @@ public:
 
         safe_allocate(pack_size(obj), "invalid size of object", [&](auto& data, auto& size) {
             pack_object(obj, data, size);
-            chaindb_insert(get_code(), get_scope(), table_name(), payer, pk, data, size);
+            auto delta = chaindb_insert(get_code(), get_scope(), table_name(), payer, pk, data, size);
+            ptr->service_.size   = delta;
+            ptr->service_.in_ram = true;
+            ptr->service_.payer  = payer;
         });
 
         add_object_to_cache(ptr);
@@ -953,12 +981,13 @@ public:
             static_cast<uint64_t>(get_code()) == current_receiver(),
             "cannot modify objects in table of another contract");
 
-        const auto& itm = static_cast<const item&>(obj);
+        auto& mobj = const_cast<T&>(obj);
+        auto& itm = static_cast<item&>(mobj);
         chaindb_assert(is_same_multidx(itm), "object passed to modify is not in multi_index");
+        chaindb_assert(itm.service_.in_ram, "object passed to modify is in archive");
 
         auto pk = primary_key_extractor_type()(obj);
 
-        auto& mobj = const_cast<T&>(obj);
         updater(mobj);
 
         auto mpk = primary_key_extractor_type()(obj);
@@ -966,8 +995,9 @@ public:
 
         safe_allocate(pack_size(obj), "invalid size of object", [&](auto& data, auto& size) {
             pack_object(obj, data, size);
-            auto upk = chaindb_update(get_code(), get_scope(), table_name(), payer, pk, data, size);
-            chaindb_assert(upk == pk, "unable to update object");
+            auto delta = chaindb_update(get_code(), get_scope(), table_name(), payer, pk, data, size);
+            itm.service_.payer = payer;
+            itm.service_.size += delta;
         });
     }
 
@@ -1005,8 +1035,36 @@ public:
 
         auto pk = primary_key_extractor_type()(obj);
         remove_object_from_cache(pk);
-        auto dpk = chaindb_delete(get_code(), get_scope(), table_name(), pk);
-        chaindb_assert(dpk == pk, "unable to delete object");
+        chaindb_delete(get_code(), get_scope(), table_name(), pk);
     }
+
+    void move_to_ram(const T& obj) const {
+        auto& itm = static_cast<item&>(const_cast<T&>(obj));
+
+        CHAINDB_ANOTHER_CONTRACT_PROTECT(
+            static_cast<uint64_t>(get_code()) == current_receiver(),
+            "cannot move objects from table of another contract");
+
+        chaindb_assert(is_same_multidx(itm), "object passed to move_to_ram is not in multi_index");
+        chaindb_assert(!itm.service_.in_ram, "object passed to move_to_ram is already in RAM");
+        auto pk = primary_key_extractor_type()(obj);
+        chaindb_ram_state(get_code(), get_scope(), table_name(), pk, true);
+        itm.service_.in_ram = true;
+    }
+
+    void move_to_archive(const T& obj) const {
+        auto& itm = static_cast<item&>(const_cast<T&>(obj));
+
+        CHAINDB_ANOTHER_CONTRACT_PROTECT(
+            static_cast<uint64_t>(get_code()) == current_receiver(),
+            "cannot move objects from table of another contract");
+
+        chaindb_assert(is_same_multidx(itm), "object passed to move_to_archive is not in multi_index");
+        chaindb_assert(itm.service_.in_ram,  "object passed to move_to_archive is already in archive");
+        auto pk = primary_key_extractor_type()(obj);
+        chaindb_ram_state(get_code(), get_scope(), table_name(), pk, false);
+        itm.service_.in_ram = false;
+    }
+
 }; // class multi_index
 }  // namespace eosio

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -556,9 +556,9 @@ cyberway::chaindb::ram_payer_info apply_context::get_ram_payer( account_name ram
 
 void apply_context::add_ram_usage( const account_name& payer, const int64_t delta ) {
    if( delta > 0 ) {
-      if( !(privileged || payer == account_name(receiver)) ) {
-         EOS_ASSERT( control.is_ram_billing_in_notify_allowed() || (receiver == act.account),
-                     subjective_block_production_exception, "Cannot charge RAM to other accounts during notify." );
+      if( !(privileged || payer == receiver) ) {
+         EOS_ASSERT( (receiver == act.account), subjective_block_production_exception,
+             "Cannot charge RAM to other accounts during notify." );
          require_authorization( payer );
       }
    }

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -179,6 +179,15 @@ void apply_context::require_authorization( const account_name& account ) {
    EOS_ASSERT( false, missing_auth_exception, "missing authority of ${account}", ("account",account));
 }
 
+bool apply_context::weak_require_authorization( const account_name& account ) {
+    for( uint32_t i=0; i < act.authorization.size(); i++ ) {
+        if( act.authorization[i].actor == account ) {
+            used_authorizations[i] = true;
+            return true;
+        }
+    }
+}
+
 bool apply_context::has_authorization( const account_name& account )const {
    for( const auto& auth : act.authorization )
      if( auth.actor == account )
@@ -197,6 +206,18 @@ void apply_context::require_authorization(const account_name& account,
      }
   EOS_ASSERT( false, missing_auth_exception, "missing authority of ${account}/${permission}",
               ("account",account)("permission",permission) );
+}
+
+bool apply_context::weak_require_authorization(const account_name& account,
+                                               const permission_name& permission) {
+    for( uint32_t i=0; i < act.authorization.size(); i++ )
+        if( act.authorization[i].actor == account ) {
+            if( act.authorization[i].permission == permission ) {
+                used_authorizations[i] = true;
+                return true;
+            }
+        }
+    return false;
 }
 
 bool apply_context::has_recipient( account_name code )const {

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -186,6 +186,7 @@ bool apply_context::weak_require_authorization( const account_name& account ) {
             return true;
         }
     }
+    return false;
 }
 
 bool apply_context::has_authorization( const account_name& account )const {

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -424,7 +424,7 @@ bool apply_context::cancel_deferred_transaction( const uint128_t& sender_id, acc
    if ( gto ) {
 // TODO: Removed by CyberWay
 //      add_ram_usage( gto->payer, -(config::billable_size_v<generated_transaction_object> + gto->packed_trx.size()) );
-      trx_table.erase(*gto, {*this});
+      trx_table.erase(*gto, get_ram_payer());
    }
    return gto;
 }
@@ -516,8 +516,12 @@ bytes apply_context::get_packed_transaction() {
    return r;
 }
 
-cyberway::chaindb::ram_payer_info apply_context::get_ram_payer( const account_name& ram_owner, const account_name& ram_payer ) {
-   return {*this, trx_context.get_ram_provider(ram_payer), ram_owner};
+cyberway::chaindb::ram_payer_info apply_context::get_ram_payer( account_name ram_owner, account_name ram_payer ) {
+   if (ram_payer.empty()) {
+       ram_payer = ram_owner;
+   }
+
+   return {*this, ram_owner, trx_context.get_ram_provider(ram_payer)};
 }
 
 void apply_context::add_ram_usage( const account_name& payer, const int64_t delta ) {

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -363,6 +363,16 @@ namespace cyberway { namespace chaindb {
         }
     }
 
+    void cache_object::set_service(service_state service) {
+        assert(is_valid_table(service));
+
+        object_.service = std::move(service);
+        if (!object_.service.ram && table_cache_map_) {
+            table_cache_map_->remove_cache_indicies(std::move(indicies_));
+            table_cache_map_->remove_cache_object(*this);
+        }
+    }
+
     void cache_object::mark_deleted() {
         assert(table_cache_map_);
 

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -367,7 +367,7 @@ namespace cyberway { namespace chaindb {
         assert(is_valid_table(service));
 
         object_.service = std::move(service);
-        if (!object_.service.ram && table_cache_map_) {
+        if (!object_.service.in_ram && table_cache_map_) {
             table_cache_map_->remove_cache_indicies(std::move(indicies_));
             table_cache_map_->remove_cache_object(*this);
         }

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -196,41 +196,28 @@ namespace cyberway { namespace chaindb {
         }
 
         cache_object_ptr emplace(object_value obj) {
-            auto& cache_service = get_cache_service(obj);
-            auto  cache_ptr     = cache_object_ptr(find(obj.service));
+            bool in_ram    = obj.service.in_ram;
+            auto cache_ptr = cache_object_ptr(find(obj.service));
+            cache_service_info* cache_service = nullptr;
 
-            if (!cache_ptr) {
-                cache_ptr = cache_object_ptr(new cache_object(*this, std::move(obj)));
-
-                // self incrementing of ref counter allows to use object w/o an additional storage
-                //   self decrementing happens in remove()
-                intrusive_ptr_add_ref(cache_ptr.get());
-
-
-                cache_object_tree_.insert(*cache_ptr.get());
-                cache_service.cache_object_cnt++;
+            if (in_ram) {
+                cache_service = emplace_in_ram(cache_ptr, std::move(obj));
             } else {
-                // updating of an exist cache item
-                cache_ptr->set_object(std::move(obj));
-
-                auto lru_itr = lru_list_.iterator_to(*cache_ptr.get());
-                lru_list_.erase(lru_itr);
-            }
-
-            lru_list_.push_back(*cache_ptr.get());
-
-            // emplace happens in three cases:
-            //   1. create object for interchain tables ->  object().is_null()
-            //   2. loading object from chaindb         -> !object().is_null()
-            //   3. restore from undo state             -> !object().is_null()
-            if (cache_service.converter && !cache_ptr->object().is_null()) {
-                cache_service.converter->convert_variant(*cache_ptr.get());
+                cache_service = emplace_in_archive(cache_ptr, std::move(obj));
             }
 
             // TODO: cache size should be configurable
             if (lru_list_.size() > 100'000) {
                 auto& cache = lru_list_.front();
                 cache.mark_deleted();
+            }
+
+            // emplace happens in three cases:
+            //   1. create object for interchain tables ->  object().is_null()
+            //   2. loading object from chaindb         -> !object().is_null()
+            //   3. restore from undo state             -> !object().is_null()
+            if (cache_service && cache_service->converter && !cache_ptr->object().is_null()) {
+                cache_service->converter->convert_variant(*cache_ptr.get());
             }
 
             return cache_ptr;
@@ -341,13 +328,54 @@ namespace cyberway { namespace chaindb {
             }
             return nullptr;
         }
+
+        cache_service_info* emplace_in_ram(cache_object_ptr& cache_ptr, object_value obj) {
+            auto& cache_service = get_cache_service(obj);
+
+            if (!cache_ptr) {
+                cache_ptr = cache_object_ptr(new cache_object(this, std::move(obj)));
+
+                // self incrementing of ref counter allows to use object w/o an additional storage
+                //   self decrementing happens in remove()
+                intrusive_ptr_add_ref(cache_ptr.get());
+
+                cache_object_tree_.insert(*cache_ptr.get());
+                cache_service.cache_object_cnt++;
+            } else {
+                // updating of an exist cache item
+                cache_ptr->set_object(std::move(obj));
+
+                auto lru_itr = lru_list_.iterator_to(*cache_ptr.get());
+                lru_list_.erase(lru_itr);
+            }
+
+            lru_list_.push_back(*cache_ptr.get());
+
+            return &cache_service;
+        }
+
+        cache_service_info* emplace_in_archive(cache_object_ptr& cache_ptr, object_value obj) {
+            auto cache_service = find_cache_service(obj);
+
+            if (!cache_ptr) {
+                cache_ptr = cache_object_ptr(new cache_object(nullptr, std::move(obj)));
+            } else {
+                // updating of an exist cache item
+                cache_ptr->set_object(std::move(obj));
+                cache_ptr->mark_deleted();
+            }
+
+            return cache_service;
+        }
     }; // struct table_cache_map
 
     //--------------
 
-    cache_object::cache_object(table_cache_map& map, object_value obj)
-    : table_cache_map_(&map), object_(std::move(obj)) {
-        table_cache_map_->build_cache_indicies(*this, indicies_);
+    cache_object::cache_object(table_cache_map* map, object_value obj)
+    : table_cache_map_(map), object_(std::move(obj)) {
+        if (table_cache_map_) {
+            table_cache_map_->build_cache_indicies(*this, indicies_);
+        }
     }
 
     void cache_object::set_object(object_value obj) {

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -360,6 +360,15 @@ namespace cyberway { namespace chaindb {
             return delta;
         }
 
+        void recalc_ram_usage(cache_object& itm, const ram_payer_info& ram_payer) {
+            auto table = get_table(itm);
+            auto obj = itm.object();
+
+            obj.service.ram = ram_payer.in_ram;
+            update(table, ram_payer, obj);
+            itm.set_service(std::move(obj.service));
+        }
+
         // From contracts
         int64_t remove(const table_request& request, const ram_payer_info& ram, const primary_key_t pk) {
             auto table = get_table(request);
@@ -832,6 +841,10 @@ namespace cyberway { namespace chaindb {
 
     int64_t chaindb_controller::remove(cache_object& itm, const ram_payer_info& ram) {
         return impl_->remove(itm, ram);
+    }
+
+    void chaindb_controller::recalc_ram_usage(cache_object& itm, const ram_payer_info& ram) {
+        impl_->recalc_ram_usage(itm, ram);
     }
 
     variant chaindb_controller::value_by_pk(const table_request& request, primary_key_t pk) {

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -579,7 +579,12 @@ namespace cyberway { namespace chaindb {
             obj.service.revision = undo_.revision();
             obj.service.size     = calc_ram_usage(ram, table, obj);
             obj.service.payer    = ram.payer;
-            obj.service.owner    = ram.owner;
+
+            if (ram.owner.empty()) {
+                obj.service.owner = ram.payer;
+            } else {
+                obj.service.owner = ram.owner;
+            }
 
             // charge the payer
             auto delta = static_cast<int64_t>(obj.service.size);

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -211,7 +211,7 @@ namespace cyberway { namespace chaindb {
             return current(cursor);
         }
 
-        const cursor_info& lower_bound(const index_request& request, const primary_key_t pk) const {
+        const cursor_info& lower_bound(const table_request& request, const primary_key_t pk) const {
             auto  index  = get_pk_index(request);
             auto  value  = _detail::get_pk_value(index, pk);
             auto  cache  = cache_.find(index, pk);
@@ -236,7 +236,7 @@ namespace cyberway { namespace chaindb {
             return current(driver_.upper_bound(std::move(index), std::move(value)));
         }
 
-        const cursor_info& upper_bound(const index_request& request, const primary_key_t pk) const {
+        const cursor_info& upper_bound(const table_request& request, const primary_key_t pk) const {
             auto index = get_pk_index(request);
             auto value = _detail::get_pk_value(index, pk);
             return current(driver_.upper_bound(std::move(index), std::move(value)));
@@ -717,7 +717,7 @@ namespace cyberway { namespace chaindb {
         return {info.id, info.pk};
     }
 
-    find_info chaindb_controller::lower_bound(const index_request& request, const primary_key_t pk) const {
+    find_info chaindb_controller::lower_bound(const table_request& request, const primary_key_t pk) const {
         const auto& info = impl_->lower_bound(request, pk);
         return {info.id, info.pk};
     }
@@ -732,7 +732,7 @@ namespace cyberway { namespace chaindb {
         return {info.id, info.pk};
     }
 
-    find_info chaindb_controller::upper_bound(const index_request& request, const primary_key_t pk) const {
+    find_info chaindb_controller::upper_bound(const table_request& request, const primary_key_t pk) const {
         const auto& info = impl_->upper_bound(request, pk);
         return {info.id, info.pk};
     }

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -364,7 +364,7 @@ namespace cyberway { namespace chaindb {
             auto table = get_table(itm);
             auto obj = itm.object();
 
-            obj.service.ram = ram_payer.in_ram;
+            obj.service.in_ram = ram_payer.in_ram;
             update(table, ram_payer, obj);
             itm.set_service(std::move(obj.service));
         }

--- a/libraries/chain/chaindb/mongo_driver_utils.cpp
+++ b/libraries/chain/chaindb/mongo_driver_utils.cpp
@@ -203,13 +203,13 @@ namespace cyberway { namespace chaindb {
             ("pk", table.pk_order->field)("row", to_json(row))("table", get_full_table_name(table)));
     }
 
-    void validate_field_name(const bool test, const document_view& doc, const element& itm) {
+    static inline void validate_field_name(const bool test, const document_view& doc, const element& itm) {
         CYBERWAY_ASSERT(test, driver_wrong_field_name_exception,
             "Wrong field name ${name} in the row '${row}",
             ("name", itm.key().to_string())("row", to_json(doc)));
     }
 
-    void validate_field_type(const bool test, const document_view& doc, const element& itm) {
+    static inline void validate_field_type(const bool test, const document_view& doc, const element& itm) {
         CYBERWAY_ASSERT(test, driver_wrong_field_type_exception,
             "Wrong type for the field ${name} in the document '${row}",
             ("name", itm.key().to_string())("row", to_json(doc)));
@@ -226,6 +226,12 @@ namespace cyberway { namespace chaindb {
         bool has_payer = false;
         bool has_owner = false;
         bool has_scope = false;
+
+        // The number of RAM objects is less then the number of archive objects.
+        //   so, the RAM field is false by default
+        state.ram      = false;
+        state.undo_ram = false;
+
         for (auto& itm: src) try {
             auto key = itm.key().to_string();
             auto key_type = itm.type();
@@ -248,20 +254,20 @@ namespace cyberway { namespace chaindb {
                     break;
                 }
                 case 's': {
-                    if (key == names::scope_field) {
-                        validate_field_type(type::k_utf8 == key_type, src, itm);
-                        state.scope = account_name(itm.get_utf8().value.to_string());
-                        has_scope = true;
-                    } else if (key == names::size_field) {
-                        validate_field_type(type::k_int32 == key_type, src, itm);
-                        state.size = itm.get_int32().value;
-                        has_size = true;
+                    if (names::scope_field == key) {
+                       validate_field_type(type::k_utf8 == key_type, src, itm);
+                       state.scope = account_name(itm.get_utf8().value.to_string());
+                       has_scope = true;
                     } else {
-                        validate_field_name(false, src, itm);
+                       validate_field_name(names::size_field == key, src, itm);
+                       validate_field_type(type::k_int32 == key_type, src, itm);
+                       state.size = itm.get_int32().value;
+                       has_size = true;
                     }
                     break;
                 }
                 case 'o': {
+                    validate_field_name(names::owner_field == key, src, itm);
                     validate_field_type(type::k_utf8 == key_type, src, itm);
                     state.owner = account_name(itm.get_utf8().value.to_string());
                     has_owner = true;
@@ -271,12 +277,11 @@ namespace cyberway { namespace chaindb {
                     if (key == names::pk_field) {
                         validate_field_type(type::k_decimal128 == key_type, src, itm);
                         state.pk = from_decimal128(itm.get_decimal128());
-                    } else if (key == names::payer_field) {
+                    } else {
+                        validate_field_name(names::payer_field == key, src, itm);
                         validate_field_type(type::k_utf8 == key_type, src, itm);
                         state.payer = account_name(itm.get_utf8().value.to_string());
                         has_payer = true;
-                    } else {
-                        validate_field_name(false, src, itm);
                     }
                     break;
                 }
@@ -284,33 +289,58 @@ namespace cyberway { namespace chaindb {
                     if (key == names::revision_field) {
                         validate_field_type(type::k_int64 == key_type, src, itm);
                         state.revision = itm.get_int64().value;
-                    } else if (key == names::undo_rec_field) {
-                        validate_field_type(type::k_utf8 == key_type, src, itm);
-                        state.undo_rec = fc::reflector<undo_record>::from_string(itm.get_utf8().value.data());
                     } else {
-                        validate_field_name(false, src, itm);
+                        validate_field_name(names::ram_field == key, src, itm);
+                        validate_field_type(type::k_bool == key_type, src, itm);
+                        state.ram = itm.get_bool().value;
+                        // for archive records it should absent
+                        validate_field_type(state.ram, src, itm);
                     }
                     break;
                 }
                 case 'u': {
-                    if (key == names::undo_pk_field) {
-                        validate_field_type(type::k_decimal128 == key_type, src, itm);
-                        state.undo_pk = from_decimal128(itm.get_decimal128());
-                    } else if (key == names::undo_payer_field) {
-                        validate_field_type(type::k_utf8 == key_type, src, itm);
-                        state.undo_payer = account_name(itm.get_utf8().value.to_string());
-                    } else if (key == names::undo_owner_field) {
-                        validate_field_type(type::k_utf8 == key_type, src, itm);
-                        state.undo_owner = account_name(itm.get_utf8().value.to_string());
-                    } else if (key == names::undo_size_field) {
-                        validate_field_type(type::k_int32 == key_type, src, itm);
-                        state.undo_size = itm.get_int32().value;
+                    switch (key[1]) {
+                        case 'p': {
+                            validate_field_name(names::undo_pk_field == key, src, itm);
+                            validate_field_type(type::k_decimal128 == key_type, src, itm);
+                            state.undo_pk = from_decimal128(itm.get_decimal128());
+                            break;
+                        }
+                        case 'y': {
+                            validate_field_name(names::undo_payer_field == key, src, itm);
+                            validate_field_type(type::k_utf8 == key_type, src, itm);
+                            state.undo_payer = account_name(itm.get_utf8().value.to_string());
+                            break;
+                        }
+                        case 'o': {
+                            validate_field_name(names::undo_owner_field == key, src, itm);
+                            validate_field_type(type::k_utf8 == key_type, src, itm);
+                            state.undo_owner = account_name(itm.get_utf8().value.to_string());
+                            break;
+                        }
+                        case 's': {
+                            validate_field_name(names::undo_size_field == key, src, itm);
+                            validate_field_type(type::k_int32 == key_type, src, itm);
+                            state.undo_size = itm.get_int32().value;
+                            break;
+                        }
+                        case 'c': {
+                            validate_field_name(names::undo_rec_field == key, src, itm);
+                            validate_field_type(type::k_utf8 == key_type, src, itm);
+                            state.undo_rec = fc::reflector<undo_record>::from_string(itm.get_utf8().value.data());
+                            break;
+                        }
+                        default: {
+                            validate_field_name(names::undo_ram_field == key, src, itm);
+                            validate_field_type(type::k_bool == key_type, src, itm);
+                            state.undo_ram = itm.get_bool().value;
+                            // for archive records it should absent
+                            validate_field_type(state.undo_ram, src, itm);
+                            break;
+                        }
                     }
                     break;
                 }
-                default:
-                    validate_field_name(false, src, itm);
-                    break;
             }
         } catch(const driver_wrong_field_name_exception&) {
             throw;
@@ -551,6 +581,13 @@ namespace cyberway { namespace chaindb {
         return build_document(dst, obj.value.get_object());
     }
 
+    static inline void append_ram_field(sub_document& doc, const string& name, const bool value) {
+        if (value) {
+            // for archive records it should absent
+            doc.append(kvp(name, true));
+        }
+    }
+
     sub_document& build_service_document(sub_document& doc, const table_info& table, const object_value& obj) {
         doc.append(kvp(names::service_field, [&](sub_document serv_doc) {
             serv_doc.append(kvp(names::scope_field, get_scope_name(table)));
@@ -558,6 +595,7 @@ namespace cyberway { namespace chaindb {
             serv_doc.append(kvp(names::payer_field, get_payer_name(obj.service.payer)));
             serv_doc.append(kvp(names::owner_field, get_owner_name(obj.service.owner)));
             serv_doc.append(kvp(names::size_field, static_cast<int32_t>(obj.service.size)));
+            append_ram_field(serv_doc, names::ram_field, obj.service.ram);
         }));
         return doc;
     }
@@ -577,6 +615,8 @@ namespace cyberway { namespace chaindb {
             serv_doc.append(kvp(names::payer_field, get_payer_name(obj.service.payer)));
             serv_doc.append(kvp(names::owner_field, get_owner_name(obj.service.owner)));
             serv_doc.append(kvp(names::size_field, static_cast<int32_t>(obj.service.size)));
+            append_ram_field(serv_doc, names::ram_field, obj.service.ram);
+            append_ram_field(serv_doc, names::undo_ram_field, obj.service.undo_ram);
         }));
         return doc;
     }

--- a/libraries/chain/chaindb/mongo_driver_utils.cpp
+++ b/libraries/chain/chaindb/mongo_driver_utils.cpp
@@ -229,8 +229,8 @@ namespace cyberway { namespace chaindb {
 
         // The number of RAM objects is less then the number of archive objects.
         //   so, the RAM field is false by default
-        state.ram      = false;
-        state.undo_ram = false;
+        state.in_ram      = false;
+        state.undo_in_ram = false;
 
         for (auto& itm: src) try {
             auto key = itm.key().to_string();
@@ -292,9 +292,9 @@ namespace cyberway { namespace chaindb {
                     } else {
                         validate_field_name(names::ram_field == key, src, itm);
                         validate_field_type(type::k_bool == key_type, src, itm);
-                        state.ram = itm.get_bool().value;
+                        state.in_ram = itm.get_bool().value;
                         // for archive records it should absent
-                        validate_field_type(state.ram, src, itm);
+                        validate_field_type(state.in_ram, src, itm);
                     }
                     break;
                 }
@@ -333,9 +333,9 @@ namespace cyberway { namespace chaindb {
                         default: {
                             validate_field_name(names::undo_ram_field == key, src, itm);
                             validate_field_type(type::k_bool == key_type, src, itm);
-                            state.undo_ram = itm.get_bool().value;
+                            state.undo_in_ram = itm.get_bool().value;
                             // for archive records it should absent
-                            validate_field_type(state.undo_ram, src, itm);
+                            validate_field_type(state.undo_in_ram, src, itm);
                             break;
                         }
                     }
@@ -595,7 +595,7 @@ namespace cyberway { namespace chaindb {
             serv_doc.append(kvp(names::payer_field, get_payer_name(obj.service.payer)));
             serv_doc.append(kvp(names::owner_field, get_owner_name(obj.service.owner)));
             serv_doc.append(kvp(names::size_field, static_cast<int32_t>(obj.service.size)));
-            append_ram_field(serv_doc, names::ram_field, obj.service.ram);
+            append_ram_field(serv_doc, names::ram_field, obj.service.in_ram);
         }));
         return doc;
     }
@@ -615,8 +615,8 @@ namespace cyberway { namespace chaindb {
             serv_doc.append(kvp(names::payer_field, get_payer_name(obj.service.payer)));
             serv_doc.append(kvp(names::owner_field, get_owner_name(obj.service.owner)));
             serv_doc.append(kvp(names::size_field, static_cast<int32_t>(obj.service.size)));
-            append_ram_field(serv_doc, names::ram_field, obj.service.ram);
-            append_ram_field(serv_doc, names::undo_ram_field, obj.service.undo_ram);
+            append_ram_field(serv_doc, names::ram_field, obj.service.in_ram);
+            append_ram_field(serv_doc, names::undo_ram_field, obj.service.undo_in_ram);
         }));
         return doc;
     }

--- a/libraries/chain/chaindb/names.cpp
+++ b/libraries/chain/chaindb/names.cpp
@@ -75,15 +75,17 @@ namespace cyberway { namespace chaindb {
 
     const string names::next_pk_field    = "npk";
     const string names::undo_pk_field    = "upk";
-    const string names::undo_payer_field = "upr";
+    const string names::undo_payer_field = "uyr";
     const string names::undo_owner_field = "uow";
     const string names::undo_size_field  = "usz";
-    const string names::undo_rec_field   = "rec";
+    const string names::undo_ram_field   = "urm";
+    const string names::undo_rec_field   = "uct";
     const string names::revision_field   = "rev";
 
     const string names::payer_field      = "payer";
     const string names::owner_field      = "owner";
     const string names::size_field       = "size";
+    const string names::ram_field        = "ram";
 
     const string names::scope_path       = string(names::service_field).append(".").append(names::scope_field);
     const string names::undo_pk_path     = string(names::service_field).append(".").append(names::undo_pk_field);

--- a/libraries/chain/chaindb/ram_calculator.cpp
+++ b/libraries/chain/chaindb/ram_calculator.cpp
@@ -110,8 +110,8 @@ namespace cyberway { namespace chaindb {
     }
 
     uint calc_ram_usage(const eosio::chain::table_def& table, const variant& var) {
-        constexpr static uint base_size = 64; /* "_SERVICE_":{"scope":,"rev":,"payer":,"size":} */
-        constexpr static uint index_size = 12 /* scope */ + 12; /* primary key */
+        constexpr static uint base_size = 128; /* "_SERVICE_":{"scope":,"rev":,"payer":,"owner":,"size":,"ram":} */
+        constexpr static uint index_size = 12 + 8 /* scope:pk */ + 8; /* pk */
 
         uint size = base_size + index_size * table.indexes.size();
         if (table.indexes.size() > 1) {

--- a/libraries/chain/chaindb/undo_state.cpp
+++ b/libraries/chain/chaindb/undo_state.cpp
@@ -535,7 +535,7 @@ namespace cyberway { namespace chaindb {
             obj.service.payer    = obj.service.undo_payer;
             obj.service.owner    = obj.service.undo_owner;
             obj.service.size     = obj.service.undo_size;
-            obj.service.ram      = obj.service.undo_ram;
+            obj.service.in_ram   = obj.service.undo_in_ram;
         }
 
         void undo(table_undo_stack& table, const revision_t undo_rev, const revision_t test_rev) {
@@ -867,10 +867,10 @@ namespace cyberway { namespace chaindb {
         }
 
         void copy_undo_object(object_value& dst, const object_value& src) {
-            dst.service.payer = src.service.payer;
-            dst.service.owner = src.service.owner;
-            dst.service.size  = src.service.size;
-            dst.service.ram   = src.service.ram;
+            dst.service.payer  = src.service.payer;
+            dst.service.owner  = src.service.owner;
+            dst.service.size   = src.service.size;
+            dst.service.in_ram = src.service.in_ram;
         }
 
         void copy_undo_object(object_value& dst, const object_value& src, const undo_record rec) {
@@ -883,7 +883,7 @@ namespace cyberway { namespace chaindb {
             dst.service.undo_payer    = dst.service.payer;
             dst.service.undo_owner    = dst.service.owner;
             dst.service.undo_size     = dst.service.size;
-            dst.service.undo_ram      = dst.service.ram;
+            dst.service.undo_in_ram   = dst.service.in_ram;
 
             dst.service.revision      = revision_;
             dst.service.undo_pk       = generate_undo_pk();

--- a/libraries/chain/chaindb/undo_state.cpp
+++ b/libraries/chain/chaindb/undo_state.cpp
@@ -535,6 +535,7 @@ namespace cyberway { namespace chaindb {
             obj.service.payer    = obj.service.undo_payer;
             obj.service.owner    = obj.service.undo_owner;
             obj.service.size     = obj.service.undo_size;
+            obj.service.ram      = obj.service.undo_ram;
         }
 
         void undo(table_undo_stack& table, const revision_t undo_rev, const revision_t test_rev) {
@@ -869,6 +870,7 @@ namespace cyberway { namespace chaindb {
             dst.service.payer = src.service.payer;
             dst.service.owner = src.service.owner;
             dst.service.size  = src.service.size;
+            dst.service.ram   = src.service.ram;
         }
 
         void copy_undo_object(object_value& dst, const object_value& src, const undo_record rec) {
@@ -881,6 +883,7 @@ namespace cyberway { namespace chaindb {
             dst.service.undo_payer    = dst.service.payer;
             dst.service.undo_owner    = dst.service.owner;
             dst.service.undo_size     = dst.service.size;
+            dst.service.undo_ram      = dst.service.ram;
 
             dst.service.revision      = revision_;
             dst.service.undo_pk       = generate_undo_pk();

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -268,6 +268,7 @@ struct controller_impl {
     SET_CYBER_DOMAIN_HANDLER(unlinkdomain);
 
    SET_CYBER_HANDLER(cyber, cyber, setrampayer);
+   SET_CYBER_HANDLER(cyber, cyber, setramstate);
 
    fork_db.irreversible.connect( [&]( auto b ) {
                                  on_irreversible(b);

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -267,6 +267,8 @@ struct controller_impl {
     SET_CYBER_DOMAIN_HANDLER(linkdomain);
     SET_CYBER_DOMAIN_HANDLER(unlinkdomain);
 
+   SET_CYBER_HANDLER(cyber, cyber, setrampayer);
+
    fork_db.irreversible.connect( [&]( auto b ) {
                                  on_irreversible(b);
                                  });

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -781,7 +781,7 @@ struct controller_impl {
 //      );
       // No need to verify_account_ram_usage since we are only reducing memory
 
-      chaindb.erase( gto, {resource_limits} );
+      chaindb.erase( gto, resource_limits.get_ram_payer() );
    }
 
    bool failure_is_subjective( const fc::exception& e ) const {

--- a/libraries/chain/cyberway/cyberway_contract.cpp
+++ b/libraries/chain/cyberway/cyberway_contract.cpp
@@ -157,7 +157,7 @@ void apply_cyber_setramstate(apply_context& context) {
             context.require_authorization(owner);
         }
 
-        EOS_ASSERT(op.in_ram != cache->service().ram, eosio::chain::object_ram_state_exception,
+        EOS_ASSERT(op.in_ram != cache->service().in_ram, eosio::chain::object_ram_state_exception,
             "Object with the primary key ${scope}:${pk} in the table ${table} already has RAM state = ${state}",
             ("pk", op.pk)("scope", chaindb::get_scope_name(op.scope))("table", chaindb::get_full_table_name(op))
             ("state", op.in_ram));

--- a/libraries/chain/cyberway/cyberway_contract.cpp
+++ b/libraries/chain/cyberway/cyberway_contract.cpp
@@ -137,7 +137,7 @@ void apply_cyber_setrampayer(apply_context& context) {
         auto owner = cache->service().owner;
         context.require_authorization(owner);
 
-        EOS_ASSERT(op.new_payer != cache->service().payer, eosio::chain::object_payer_exception,
+        EOS_ASSERT(op.new_payer != cache->service().payer, eosio::chain::object_ram_payer_exception,
             "Object with the primary key ${scope}:${pk} in the table ${table} already has the ram payer ${payer}",
             ("pk", op.pk)("scope", chaindb::get_scope_name(op.scope))("table", chaindb::get_full_table_name(op))
             ("payer", op.new_payer));

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -662,6 +662,16 @@ abi_def eosio_contract_abi(abi_def eos_abi)
       }
    });
 
+   eos_abi.structs.emplace_back( struct_def {
+      "set_ram_state", "", {
+         {"code",        "account_name"},
+         {"scope",       "account_name"},
+         {"table",       "name"},
+         {"primary_key", "uint64"},
+         {"in_ram",      "bool"}
+      }
+   });
+
    eos_abi.actions.push_back( action_def{name("newaccount"), "newaccount"} );
    eos_abi.actions.push_back( action_def{name("setcode"), "setcode"} );
    eos_abi.actions.push_back( action_def{name("setabi"), "setabi"} );
@@ -678,6 +688,7 @@ abi_def eosio_contract_abi(abi_def eos_abi)
    eos_abi.actions.push_back( action_def{name("onblock"), "onblock"} );
 
    eos_abi.actions.push_back( action_def{name("setrampayer"), "set_ram_payer"} );
+   eos_abi.actions.push_back( action_def{name("setramstate"), "set_ram_state"} );
 
    return eos_abi;
 }

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -640,17 +640,26 @@ abi_def eosio_contract_abi(abi_def eos_abi)
    });
 
    eos_abi.structs.emplace_back( struct_def {
-         "onerror", "", {
-            {"sender_id", "uint128"},
-            {"sent_trx",  "bytes"}
+      "onerror", "", {
+         {"sender_id", "uint128"},
+         {"sent_trx",  "bytes"}
       }
    });
 
    eos_abi.structs.emplace_back( struct_def {
-         "onblock", "", {
-            {"header", "block_header"}
+      "onblock", "", {
+         {"header", "block_header"}
       }
    });
+
+   eos_abi.structs.emplace_back( struct_def {
+      "set_ram_payer", "", {
+         {"code",        "account_name"},
+         {"scope",       "account_name"},
+         {"table",       "name"},
+         {"primary_key", "uint64"},
+      }
+    });
 
    eos_abi.actions.push_back( action_def{name("newaccount"), "newaccount"} );
    eos_abi.actions.push_back( action_def{name("setcode"), "setcode"} );
@@ -666,6 +675,8 @@ abi_def eosio_contract_abi(abi_def eos_abi)
    eos_abi.actions.push_back( action_def{name("canceldelay"), "canceldelay"} );
    eos_abi.actions.push_back( action_def{name("onerror"), "onerror"} );
    eos_abi.actions.push_back( action_def{name("onblock"), "onblock"} );
+
+   eos_abi.actions.push_back( action_def{name("setrampayer"), "set_ram_payer"} );
 
    return eos_abi;
 }

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -658,8 +658,9 @@ abi_def eosio_contract_abi(abi_def eos_abi)
          {"scope",       "account_name"},
          {"table",       "name"},
          {"primary_key", "uint64"},
+         {"new_payer",   "account_name"},
       }
-    });
+   });
 
    eos_abi.actions.push_back( action_def{name("newaccount"), "newaccount"} );
    eos_abi.actions.push_back( action_def{name("setcode"), "setcode"} );

--- a/libraries/chain/include/cyberway/chain/cyberway_contract.hpp
+++ b/libraries/chain/include/cyberway/chain/cyberway_contract.hpp
@@ -7,8 +7,13 @@ namespace eosio { namespace chain {
     class apply_context;
 } } // namespace eosio::chain
 
+namespace cyberway { namespace chaindb {
+    struct service_state;
+} } // namespace cyberway::chaindb
+
 namespace cyberway { namespace chain {
     using eosio::chain::apply_context;
+    using cyberway::chaindb::service_state;
 
     struct set_ram_state;
 
@@ -37,6 +42,6 @@ namespace cyberway { namespace chain {
     void apply_cyber_setrampayer(apply_context&);
     void apply_cyber_setramstate(apply_context&);
 
-    void change_ram_state(apply_context&, const set_ram_state&);
+    void apply_set_ram_state(apply_context&, const set_ram_state&, const std::function<void(const service_state&)>&);
 
 } } // namespace cyberway::chain

--- a/libraries/chain/include/cyberway/chain/cyberway_contract.hpp
+++ b/libraries/chain/include/cyberway/chain/cyberway_contract.hpp
@@ -32,4 +32,6 @@ namespace cyberway { namespace chain {
     void apply_cyber_vetorecovery(apply_context&);
     */
 
+    void apply_cyber_setrampayer(apply_context&);
+
 } } // namespace cyberway::chain

--- a/libraries/chain/include/cyberway/chain/cyberway_contract.hpp
+++ b/libraries/chain/include/cyberway/chain/cyberway_contract.hpp
@@ -10,6 +10,8 @@ namespace eosio { namespace chain {
 namespace cyberway { namespace chain {
     using eosio::chain::apply_context;
 
+    struct set_ram_state;
+
     /**
      * @defgroup native_action_handlers Native Action Handlers
      */
@@ -34,5 +36,7 @@ namespace cyberway { namespace chain {
 
     void apply_cyber_setrampayer(apply_context&);
     void apply_cyber_setramstate(apply_context&);
+
+    void change_ram_state(apply_context&, const set_ram_state&);
 
 } } // namespace cyberway::chain

--- a/libraries/chain/include/cyberway/chain/cyberway_contract.hpp
+++ b/libraries/chain/include/cyberway/chain/cyberway_contract.hpp
@@ -33,5 +33,6 @@ namespace cyberway { namespace chain {
     */
 
     void apply_cyber_setrampayer(apply_context&);
+    void apply_cyber_setramstate(apply_context&);
 
 } } // namespace cyberway::chain

--- a/libraries/chain/include/cyberway/chain/cyberway_contract_types.hpp
+++ b/libraries/chain/include/cyberway/chain/cyberway_contract_types.hpp
@@ -5,10 +5,13 @@
 #include <eosio/chain/config.hpp>
 #include <eosio/chain/types.hpp>
 
+#include <cyberway/chaindb/common.hpp>
+
 namespace cyberway { namespace chain {
 
     using eosio::chain::account_name;
     using eosio::chain::action_name;
+    using eosio::chain::table_name;
 
     struct providebw final {
         account_name    provider;
@@ -121,16 +124,39 @@ namespace cyberway { namespace chain {
 #undef SYS_ACTION_STRUCT
 #undef SYS_ACTION_STRUCT_END
 
+    using chaindb::primary_key_t;
+
+    struct set_ram_payer final {
+        account_name  code;
+        account_name  scope;
+        table_name    table;
+        primary_key_t pk;
+
+        account_name  new_payer;
+
+        static account_name get_account() {
+            return eosio::chain::config::system_account_name;
+        }
+
+        static action_name get_name() {
+            return N(setrampayer);
+        }
+    };
+
+
 } } // namespace cyberway::chain
 
-FC_REFLECT(cyberway::chain::providebw                        , (provider)(account))
+FC_REFLECT(cyberway::chain::providebw,     (provider)(account))
 //TODO: requestbw
-//FC_REFLECT(cyberway::chain::requestbw                        , (provider)(account))
-//FC_REFLECT(cyberway::chain::approvebw                        , (account) )
-FC_REFLECT(cyberway::chain::provideram                       , (provider)(account))
+//FC_REFLECT(cyberway::chain::requestbw,   (provider)(account))
+//FC_REFLECT(cyberway::chain::approvebw,   (account))
+FC_REFLECT(cyberway::chain::provideram,    (provider)(account))
 
-FC_REFLECT(cyberway::chain::newdomain,    (creator)(name))
-FC_REFLECT(cyberway::chain::passdomain,   (from)(to)(name))
-FC_REFLECT(cyberway::chain::linkdomain,   (owner)(to)(name))
-FC_REFLECT(cyberway::chain::unlinkdomain, (owner)(name))
-FC_REFLECT(cyberway::chain::newusername,  (creator)(owner)(name))
+FC_REFLECT(cyberway::chain::newdomain,     (creator)(name))
+FC_REFLECT(cyberway::chain::passdomain,    (from)(to)(name))
+FC_REFLECT(cyberway::chain::linkdomain,    (owner)(to)(name))
+FC_REFLECT(cyberway::chain::unlinkdomain,  (owner)(name))
+FC_REFLECT(cyberway::chain::newusername,   (creator)(owner)(name))
+
+FC_REFLECT(cyberway::chain::set_ram_payer, (code)(scope)(table)(pk)(new_payer))
+

--- a/libraries/chain/include/cyberway/chain/cyberway_contract_types.hpp
+++ b/libraries/chain/include/cyberway/chain/cyberway_contract_types.hpp
@@ -143,6 +143,23 @@ namespace cyberway { namespace chain {
         }
     };
 
+    struct set_ram_state final {
+        account_name  code;
+        account_name  scope;
+        table_name    table;
+        primary_key_t pk;
+
+        bool          in_ram;
+
+        static account_name get_account() {
+            return eosio::chain::config::system_account_name;
+        }
+
+        static action_name get_name() {
+            return N(setramstate);
+        }
+    };
+
 
 } } // namespace cyberway::chain
 
@@ -159,4 +176,4 @@ FC_REFLECT(cyberway::chain::unlinkdomain,  (owner)(name))
 FC_REFLECT(cyberway::chain::newusername,   (creator)(owner)(name))
 
 FC_REFLECT(cyberway::chain::set_ram_payer, (code)(scope)(table)(pk)(new_payer))
-
+FC_REFLECT(cyberway::chain::set_ram_state, (code)(scope)(table)(pk)(in_ram))

--- a/libraries/chain/include/cyberway/chaindb/cache_item.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_item.hpp
@@ -65,7 +65,7 @@ namespace cyberway { namespace chaindb {
         bytes            blob_;
 
     public:
-        cache_object(table_cache_map&, object_value);
+        cache_object(table_cache_map*, object_value);
         cache_object(cache_object&&) = default;
 
         ~cache_object() = default;

--- a/libraries/chain/include/cyberway/chaindb/cache_item.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_item.hpp
@@ -83,8 +83,8 @@ namespace cyberway { namespace chaindb {
         }
 
         void mark_deleted();
-
         void set_object(object_value);
+        void set_service(service_state service);
 
         void set_revision(const revision_t rev) {
             object_.service.revision = rev;

--- a/libraries/chain/include/cyberway/chaindb/common.hpp
+++ b/libraries/chain/include/cyberway/chaindb/common.hpp
@@ -33,18 +33,22 @@ namespace cyberway { namespace chaindb {
     using index_name_t = index_name::value_type;
     using account_name_t = account_name::value_type;
 
-    struct index_request final {
-        const account_name code;
-        const account_name scope;
-        const table_name_t table;
-        const index_name_t index;
-    }; // struct index_request
-
     struct table_request final {
         const account_name code;
         const account_name scope;
         const table_name_t table;
     }; // struct table_request
+
+    struct index_request final {
+        const account_name code;
+        const account_name scope;
+        const table_name_t table;
+        const index_name_t index;
+
+        operator table_request() const {
+            return {code, scope, table};
+        }
+    }; // struct index_request
 
     struct cursor_request final {
         const account_name code;

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -150,11 +150,11 @@ namespace cyberway { namespace chaindb {
         void set_revision(uint64_t revision);
 
         find_info lower_bound(const index_request&, const char* key, size_t) const;
-        find_info lower_bound(const index_request&, primary_key_t) const;
+        find_info lower_bound(const table_request&, primary_key_t) const;
         find_info lower_bound(const index_request& request, const variant&) const;
 
         find_info upper_bound(const index_request&, const char* key, size_t) const;
-        find_info upper_bound(const index_request&, primary_key_t) const;
+        find_info upper_bound(const table_request&, primary_key_t) const;
         find_info upper_bound(const index_request& request, const variant&) const;
 
         find_info locate_to(const index_request&, const char* key, size_t, primary_key_t);

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -176,15 +176,15 @@ namespace cyberway { namespace chaindb {
 
         primary_key_t available_pk(const table_request&);
 
-        int64_t insert(const table_request&, const ram_payer_info&, primary_key_t, const char*, size_t);
-        int64_t update(const table_request&, const ram_payer_info&, primary_key_t, const char*, size_t);
-        int64_t remove(const table_request&, const ram_payer_info&, primary_key_t);
+        int insert(const table_request&, const ram_payer_info&, primary_key_t, const char*, size_t);
+        int update(const table_request&, const ram_payer_info&, primary_key_t, const char*, size_t);
+        int remove(const table_request&, const ram_payer_info&, primary_key_t);
 
-        int64_t insert(const table_request&, primary_key_t, variant, const ram_payer_info&);
+        int insert(const table_request&, primary_key_t, variant, const ram_payer_info&);
 
-        int64_t insert(cache_object&, variant, const ram_payer_info&);
-        int64_t update(cache_object&, variant, const ram_payer_info&);
-        int64_t remove(cache_object&, const ram_payer_info&);
+        int insert(cache_object&, variant, const ram_payer_info&);
+        int update(cache_object&, variant, const ram_payer_info&);
+        int remove(cache_object&, const ram_payer_info&);
 
         void recalc_ram_usage(cache_object&, const ram_payer_info&);
 

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -186,6 +186,8 @@ namespace cyberway { namespace chaindb {
         int64_t update(cache_object&, variant, const ram_payer_info&);
         int64_t remove(cache_object&, const ram_payer_info&);
 
+        void recalc_ram_usage(cache_object&, const ram_payer_info&);
+
         variant value_by_pk(const table_request& request, primary_key_t pk);
         variant value_at_cursor(const cursor_request& request);
         object_value object_at_cursor(const cursor_request& request) const;

--- a/libraries/chain/include/cyberway/chaindb/cursor_cache.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cursor_cache.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cyberway/chaindb/cache_item.hpp>
+
+namespace cyberway { namespace chaindb {
+
+    struct chaindb_cursor_cache final {
+        account_name_t   cache_code   = 0;
+        cursor_t         cache_cursor = invalid_cursor;
+
+        cache_object_ptr cache;
+
+        void reset() {
+            cache_code   = 0;
+            cache_cursor = invalid_cursor;
+            cache.reset();
+        }
+    }; // struct chaindb_cursor_cache
+
+} } //namespace cyberway::chaindb

--- a/libraries/chain/include/cyberway/chaindb/exception.hpp
+++ b/libraries/chain/include/cyberway/chaindb/exception.hpp
@@ -143,6 +143,9 @@ namespace cyberway { namespace chaindb {
         FC_DECLARE_DERIVED_EXCEPTION(invalid_data_size_exception, chaindb_contract_exception,
                                      3730001, "Requested data with wrong size")
 
+        FC_DECLARE_DERIVED_EXCEPTION(invalid_data_exception, chaindb_contract_exception,
+                                     3730002, "Requested data is invalid")
+
     FC_DECLARE_DERIVED_EXCEPTION(chaindb_object_exception, chaindb_exception,
                                  3740000, "ChainDB object exception")
 
@@ -154,5 +157,8 @@ namespace cyberway { namespace chaindb {
 
         FC_DECLARE_DERIVED_EXCEPTION(object_exception, chaindb_object_exception,
                                      3740003, "Object has reserved field name")
+
+        FC_DECLARE_DERIVED_EXCEPTION(update_archive_object_exception, chaindb_object_exception,
+                                     3740004, "Can't edit object in archive")
 
 } } // namespace cyberway::chaindb

--- a/libraries/chain/include/cyberway/chaindb/multi_index.hpp
+++ b/libraries/chain/include/cyberway/chaindb/multi_index.hpp
@@ -345,7 +345,7 @@ private:
             return &item_data::get_T(item_);
         }
         const primary_key_t pk() const {
-            lazy_load_object();
+            lazy_open();
             return primary_key_;
         }
         const service_state& service() const {

--- a/libraries/chain/include/cyberway/chaindb/multi_index.hpp
+++ b/libraries/chain/include/cyberway/chaindb/multi_index.hpp
@@ -111,7 +111,7 @@ template<bool IsPrimaryIndex> struct lower_bound final {
 }; // struct lower_bound
 
 template<> struct lower_bound<true /*IsPrimaryIndex*/> final {
-    find_info operator()(chaindb_controller& chaindb, const index_request& request, const primary_key_t pk) const {
+    find_info operator()(chaindb_controller& chaindb, const table_request& request, const primary_key_t pk) const {
         return chaindb.lower_bound(request, pk);
     }
 }; // struct lower_bound
@@ -129,7 +129,7 @@ template<bool IsPrimaryIndex> struct upper_bound final {
 }; // struct upper_bound
 
 template<> struct upper_bound<true /*IsPrimaryIndex*/> final {
-    find_info operator()(chaindb_controller& chaindb, const index_request& request, const primary_key_t pk) const {
+    find_info operator()(chaindb_controller& chaindb, const table_request& request, const primary_key_t pk) const {
         return chaindb.upper_bound(request, pk);
     }
 }; // struct upper_bound

--- a/libraries/chain/include/cyberway/chaindb/multi_index.hpp
+++ b/libraries/chain/include/cyberway/chaindb/multi_index.hpp
@@ -352,6 +352,9 @@ private:
             lazy_load_object();
             return item_->service();
         }
+        bool in_ram() const {
+            return service().in_ram;
+        }
 
         const_iterator_impl operator++(int) {
             const_iterator_impl result(*this);
@@ -657,7 +660,7 @@ public:
         }
 
         template<typename Lambda>
-        int64_t modify(const T& obj, const ram_payer_info& ram, Lambda&& updater) const {
+        int modify(const T& obj, const ram_payer_info& ram, Lambda&& updater) const {
             auto& itm = item_data::get_cache(obj);
             CYBERWAY_ASSERT(itm.is_valid_table(get_table_request()), chaindb_midx_logic_exception,
                 "Object ${obj} passed to modify is not from the index ${index}",
@@ -679,11 +682,11 @@ public:
         }
 
         template<typename Lambda>
-        int64_t modify(const T& obj, Lambda&& updater) const {
+        int modify(const T& obj, Lambda&& updater) const {
             return modify(obj, {}, std::forward<Lambda>(updater));
         }
 
-        int64_t erase(const T& obj, const ram_payer_info& ram = {}) const {
+        int erase(const T& obj, const ram_payer_info& ram = {}) const {
             auto& itm = item_data::get_cache(obj);
             CYBERWAY_ASSERT(itm.is_valid_table(get_table_request()), chaindb_midx_logic_exception,
                 "Object ${obj} passed to erase is not from the index ${index}",

--- a/libraries/chain/include/cyberway/chaindb/names.hpp
+++ b/libraries/chain/include/cyberway/chaindb/names.hpp
@@ -24,11 +24,13 @@ namespace cyberway { namespace chaindb {
         static const string undo_payer_field;
         static const string undo_owner_field;
         static const string undo_size_field;
+        static const string undo_ram_field;
         static const string revision_field;
 
         static const string payer_field;
         static const string owner_field;
         static const string size_field;
+        static const string ram_field;
 
         static const string scope_path;
         static const string undo_pk_path;

--- a/libraries/chain/include/cyberway/chaindb/object_value.hpp
+++ b/libraries/chain/include/cyberway/chaindb/object_value.hpp
@@ -17,7 +17,7 @@ namespace cyberway { namespace chaindb {
         account_name  payer;
         account_name  owner;
         size_t        size     = 0;
-        bool          ram      = true;
+        bool          in_ram   = true;
 
         account_name  code;
         account_name  scope;
@@ -32,7 +32,7 @@ namespace cyberway { namespace chaindb {
         account_name  undo_payer;
         account_name  undo_owner;
         size_t        undo_size     = 0;
-        bool          undo_ram      = true;
+        bool          undo_in_ram   = true;
 
         service_state(const table_info& table, primary_key_t pk)
         : pk(pk), code(table.code), scope(table.scope), table(table.table->name) {

--- a/libraries/chain/include/cyberway/chaindb/object_value.hpp
+++ b/libraries/chain/include/cyberway/chaindb/object_value.hpp
@@ -16,7 +16,7 @@ namespace cyberway { namespace chaindb {
         primary_key_t pk       = unset_primary_key;
         account_name  payer;
         account_name  owner;
-        size_t        size     = 0;
+        int           size     = 0;
         bool          in_ram   = true;
 
         account_name  code;
@@ -82,3 +82,4 @@ namespace cyberway { namespace chaindb {
 } } // namespace cyberway::chaindb
 
 FC_REFLECT_ENUM(cyberway::chaindb::undo_record, (Unknown)(OldValue)(RemovedValue)(NewValue)(NextPk))
+FC_REFLECT(cyberway::chaindb::service_state, (owner)(size)(in_ram))

--- a/libraries/chain/include/cyberway/chaindb/object_value.hpp
+++ b/libraries/chain/include/cyberway/chaindb/object_value.hpp
@@ -17,6 +17,7 @@ namespace cyberway { namespace chaindb {
         account_name  payer;
         account_name  owner;
         size_t        size     = 0;
+        bool          ram      = true;
 
         account_name  code;
         account_name  scope;
@@ -31,6 +32,7 @@ namespace cyberway { namespace chaindb {
         account_name  undo_payer;
         account_name  undo_owner;
         size_t        undo_size     = 0;
+        bool          undo_ram      = true;
 
         service_state(const table_info& table, primary_key_t pk)
         : pk(pk), code(table.code), scope(table.scope), table(table.table->name) {

--- a/libraries/chain/include/cyberway/chaindb/ram_payer_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/ram_payer_info.hpp
@@ -23,32 +23,23 @@ namespace cyberway { namespace chaindb {
 
         const account_name   owner;
         const account_name   payer;
-        const size_t         precalc_size = 0;
+        size_t               precalc_size = 0;
 
         ram_payer_info() = default;
 
-        ram_payer_info(apply_context& c, account_name p = {}, account_name o = {}, const size_t s = 0)
-        : apply_ctx(&c), owner(select_owner(p, o)), payer(std::move(p)), precalc_size(s) {
+        ram_payer_info(apply_context& c, account_name o, account_name p, const size_t s = 0)
+        : apply_ctx(&c), owner(std::move(o)), payer(std::move(p)), precalc_size(s) {
         }
         
-        ram_payer_info(resource_manager& r, account_name p = {}, account_name o = {}, const size_t s = 0)
-        : resource_mng(&r), owner(select_owner(p, o)), payer(std::move(p)), precalc_size(s) {
+        ram_payer_info(resource_manager& r, account_name o)
+        : resource_mng(&r), owner(std::move(o)) {
         }
 
-        ram_payer_info(transaction_context& t, account_name p = {}, account_name o = {}, const size_t s = 0)
-        : transaction_ctx(&t), owner(select_owner(p, o)), payer(std::move(p)), precalc_size(s) {
+        ram_payer_info(transaction_context& t, account_name o, account_name p, const size_t s = 0)
+        : transaction_ctx(&t), owner(std::move(o)), payer(std::move(p)), precalc_size(s) {
         }
 
         void add_usage(const account_name, const int64_t delta) const;
-
-    private:
-        static account_name select_owner(account_name p, account_name o) {
-            if (o.empty()) {
-                return p;
-            } else {
-                return o;
-            }
-        }
     }; // struct ram_payer_info
 
 } } // namespace cyberway::chaindb

--- a/libraries/chain/include/cyberway/chaindb/ram_payer_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/ram_payer_info.hpp
@@ -24,6 +24,7 @@ namespace cyberway { namespace chaindb {
         const account_name   owner;
         const account_name   payer;
         size_t               precalc_size = 0;
+        bool                 in_ram = true;
 
         ram_payer_info() = default;
 

--- a/libraries/chain/include/cyberway/genesis/genesis_container.hpp
+++ b/libraries/chain/include/cyberway/genesis/genesis_container.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <eosio/chain/types.hpp>
+#include <eosio/chain/resource_limits.hpp>
 #include <cyberway/chaindb/controller.hpp>
 #include <fc/reflect/reflect.hpp>
 
@@ -53,7 +54,7 @@ struct sys_table_row {
     }
     ram_payer_info payer() const {
         if (resource_mng) {
-            return {*resource_mng, ram_payer};
+            return resource_mng->get_ram_payer(ram_payer);
         } else {
             return {};
         }

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -5,7 +5,6 @@
 #pragma once
 #include <eosio/chain/controller.hpp>
 #include <eosio/chain/transaction.hpp>
-#include <eosio/chain/contract_table_objects.hpp>
 #include <fc/utility.hpp>
 #include <sstream>
 #include <algorithm>
@@ -14,13 +13,15 @@
 namespace cyberway { namespace chaindb {
     class chaindb_controller;
     struct ram_payer_info;
-}}
+    struct chaindb_cursor_cache;
+} }
 
 namespace chainbase { class database; }
 
 namespace eosio { namespace chain {
 
 using cyberway::chaindb::chaindb_controller;
+using cyberway::chaindb::chaindb_cursor_cache;
 
 class controller;
 class transaction_context;
@@ -616,7 +617,7 @@ class apply_context {
       uint64_t next_recv_sequence( account_name receiver );
       uint64_t next_auth_sequence( account_name actor );
 
-      cyberway::chaindb::ram_payer_info get_ram_payer( const account_name& ram_owner = account_name(), const account_name& ram_payer = account_name() );
+      cyberway::chaindb::ram_payer_info get_ram_payer( account_name ram_owner = account_name(), account_name ram_payer = account_name() );
       void add_ram_usage( const account_name& account, int64_t ram_delta );
       void finalize_trace( action_trace& trace, const fc::time_point& start );
 
@@ -627,6 +628,7 @@ class apply_context {
 // TODO: Removed by CyberWay
 //      chainbase::database&          db;
       chaindb_controller&           chaindb; ///< database where state is stored
+      chaindb_cursor_cache*         chaindb_cache = nullptr;
       transaction_context&          trx_context; ///< transaction context in which the action is running
       const action&                 act; ///< message being applied
       account_name                  receiver; ///< the code that is currently running

--- a/libraries/chain/include/eosio/chain/apply_context.hpp
+++ b/libraries/chain/include/eosio/chain/apply_context.hpp
@@ -510,8 +510,10 @@ class apply_context {
        * @throws missing_auth_exception If no sufficient permission was found
        */
       void require_authorization(const account_name& account);
+      bool weak_require_authorization(const account_name& account);
       bool has_authorization(const account_name& account) const;
       void require_authorization(const account_name& account, const permission_name& permission);
+      bool weak_require_authorization(const account_name& account, const permission_name& permission);
 
       /**
        * @return true if account exists, false if it does not

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -240,6 +240,9 @@ namespace eosio { namespace chain {
         FC_DECLARE_DERIVED_EXCEPTION(username_query_exception, database_exception, 3060007, "Username Query Exception")
         FC_DECLARE_DERIVED_EXCEPTION(username_exists_exception,database_exception, 3060008, "Username already exists")
 
+        FC_DECLARE_DERIVED_EXCEPTION(object_query_exception,   database_exception, 3060009, "Object doesn't exist")
+        FC_DECLARE_DERIVED_EXCEPTION(object_payer_exception,   database_exception, 3060010, "Wrong RAM payer")
+
 
    FC_DECLARE_DERIVED_EXCEPTION( guard_exception, database_exception,
                                  3060100, "Guard Exception" )

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -240,8 +240,8 @@ namespace eosio { namespace chain {
         FC_DECLARE_DERIVED_EXCEPTION(username_query_exception, database_exception, 3060007, "Username Query Exception")
         FC_DECLARE_DERIVED_EXCEPTION(username_exists_exception,database_exception, 3060008, "Username already exists")
 
-        FC_DECLARE_DERIVED_EXCEPTION(object_query_exception,   database_exception, 3060009, "Object doesn't exist")
-        FC_DECLARE_DERIVED_EXCEPTION(object_payer_exception,   database_exception, 3060010, "Wrong RAM payer")
+        FC_DECLARE_DERIVED_EXCEPTION(object_query_exception,     database_exception, 3060009, "Object doesn't exist")
+        FC_DECLARE_DERIVED_EXCEPTION(object_ram_payer_exception, database_exception, 3060010, "Wrong RAM payer")
 
 
    FC_DECLARE_DERIVED_EXCEPTION( guard_exception, database_exception,

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -242,6 +242,7 @@ namespace eosio { namespace chain {
 
         FC_DECLARE_DERIVED_EXCEPTION(object_query_exception,     database_exception, 3060009, "Object doesn't exist")
         FC_DECLARE_DERIVED_EXCEPTION(object_ram_payer_exception, database_exception, 3060010, "Wrong RAM payer")
+        FC_DECLARE_DERIVED_EXCEPTION(object_ram_state_exception, database_exception, 3060011, "Wrong RAM state")
 
 
    FC_DECLARE_DERIVED_EXCEPTION( guard_exception, database_exception,

--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -72,6 +72,8 @@ namespace resource_limits {
          void add_to_snapshot( const snapshot_writer_ptr& snapshot ) const;
          void read_from_snapshot( const snapshot_reader_ptr& snapshot );
 
+         cyberway::chaindb::ram_payer_info get_ram_payer(const account_name& owner = account_name());
+
          void initialize_account( const account_name& account, const cyberway::chaindb::ram_payer_info& );
          void set_block_parameters( const elastic_limit_parameters& cpu_limit_parameters, const elastic_limit_parameters& net_limit_parameters );
 

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -75,6 +75,10 @@ void resource_limits_manager::read_from_snapshot( const snapshot_reader_ptr& sna
    // TODO: Removed by CyberWay
 }
 
+cyberway::chaindb::ram_payer_info resource_limits_manager::get_ram_payer(const account_name& owner) {
+    return {*this, owner};
+}
+
 void resource_limits_manager::initialize_account(const account_name& account, const cyberway::chaindb::ram_payer_info& ram_payer) {
    _chaindb.emplace<resource_usage_object>(ram_payer, [&]( resource_usage_object& bu ) {
       bu.owner = account;
@@ -292,7 +296,7 @@ account_balance resource_limits_manager::get_account_balance(int64_t now, const 
     uint64_t staked = 0;
     auto agent = agents_idx.find(agent_key(token_code, account));
     if (agent != agents_idx.end()) {
-        update_proxied(_chaindb, {*this}, now, token_code, account, param->frame_length, false);
+        update_proxied(_chaindb, get_ram_payer(), now, token_code, account, param->frame_length, false);
 
         auto total_funds = agent->get_total_funds();
         EOS_ASSERT(total_funds >= 0, chain_exception, "SYSTEM: incorrect total_funds value");

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -696,7 +696,7 @@ namespace bacc = boost::accumulators;
    }
 
    cyberway::chaindb::ram_payer_info transaction_context::get_ram_payer(const account_name& ram_owner) {
-      return {*this, get_ram_provider(ram_owner), ram_owner};
+      return {*this, ram_owner, get_ram_provider(ram_owner)};
    }
 
     void transaction_context::available_resources_t::init(resource_limits_manager& rl, const flat_set<account_name>& accounts, fc::time_point now) {

--- a/libraries/chain/wasm_chaindb_interface.ipp
+++ b/libraries/chain/wasm_chaindb_interface.ipp
@@ -234,7 +234,13 @@ namespace eosio { namespace chain {
             op.pk     = pk;
             op.in_ram = in_ram;
 
-            cyberway::chain::change_ram_state(context, op);
+            cyberway::chain::apply_set_ram_state(context, op, [&](const cyberway::chaindb::service_state& service) {
+                if (context.privileged || (service.owner == context.receiver && service.payer == context.receiver)) {
+                    return;
+                } else if (service.owner == service.payer || !context.weak_require_authorization(service.payer)) {
+                    context.require_authorization(service.owner);
+                }
+            });
         }
 
     }; // class chaindb_api

--- a/libraries/chain/wasm_chaindb_interface.ipp
+++ b/libraries/chain/wasm_chaindb_interface.ipp
@@ -1,4 +1,13 @@
 #include <cyberway/chaindb/controller.hpp>
+#include <cyberway/chaindb/cursor_cache.hpp>
+
+#include <cyberway/chain/cyberway_contract_types.hpp>
+#include <cyberway/chain/cyberway_contract.hpp>
+
+#include <assert.h>
+
+#include <fc/io/json.hpp>
+#include <cyberway/chaindb/names.hpp>
 
 namespace eosio { namespace chain {
 
@@ -93,12 +102,21 @@ namespace eosio { namespace chain {
         int32_t chaindb_datasize(account_name_t code, cursor_t cursor) {
             // cursor is already opened -> no reason to check ABI for it
 
-            auto cache = context.chaindb.get_cache_object({code, cursor}, true);
-            if (cache) {
-                auto& blob = cache->blob();
+            assert(context.chaindb_cache);
+            auto& chaindb_cache = *context.chaindb_cache;
+
+            chaindb_cache.cache_code   = code;
+            chaindb_cache.cache_cursor = cursor;
+
+            chaindb_cache.cache = context.chaindb.get_cache_object({code, cursor}, true);
+
+            if (chaindb_cache.cache) {
+                auto& blob = chaindb_cache.cache->blob();
                 CYBERWAY_ASSERT(blob.size() < 1024 * 1024, cyberway::chaindb::invalid_data_size_exception,
                     "Wrong data size ${data_size}", ("object_size", blob.size()));
                 return static_cast<int32_t>(blob.size());
+            } else {
+                chaindb_cache.reset();
             }
             return 0;
         }
@@ -106,24 +124,56 @@ namespace eosio { namespace chain {
         primary_key_t chaindb_data(account_name_t code, cursor_t cursor, array_ptr<char> data, size_t size) {
             // cursor is already opened -> no reason to check ABI for it
 
-            auto   cache = context.chaindb.get_cache_object({code, cursor}, false);
-            size_t blob_size = 0;
+            assert(context.chaindb_cache);
+            auto& chaindb_cache = *context.chaindb_cache;
 
-            if (cache) {
-                blob_size = cache->blob().size();
-            }
+            CYBERWAY_ASSERT(chaindb_cache.cache_code == code && chaindb_cache.cache_cursor == cursor,
+                cyberway::chaindb::invalid_data_exception,
+                "Data is requested for the wrong cursor ${code}.${cursor}",
+                ("code", account_name(code))("cursor", cursor));
+
+            auto blob_size = chaindb_cache.cache->blob().size();
 
             CYBERWAY_ASSERT(blob_size == size, cyberway::chaindb::invalid_data_size_exception,
-                "Wrong data size (${data_size} != ${object_size})",
-                ("data_size", size)("object_size", blob_size));
+                "Wrong data size (${data_size} != ${object_size}) for the cursor ${code}.${cursor}",
+                ("data_size", size)("object_size", blob_size)("code", account_name(code))("cursor", cursor));
 
-            if (cache) {
-                auto& blob = cache->blob();
-                std::memcpy(data.value, blob.data(), blob.size());
-                return cache->pk();
+            auto& blob = chaindb_cache.cache->blob();
+            std::memcpy(data.value, blob.data(), blob.size());
+            return chaindb_cache.cache->pk();
+        }
+
+        int32_t chaindb_service(account_name_t code, cursor_t cursor, array_ptr<char> data, size_t size) {
+            // cursor is already opened -> no reason to check ABI for it
+
+            assert(context.chaindb_cache);
+            auto& chaindb_cache = *context.chaindb_cache;
+
+            CYBERWAY_ASSERT(chaindb_cache.cache_code == code && chaindb_cache.cache_cursor == cursor,
+                cyberway::chaindb::invalid_data_exception,
+                "Service is requested for the wrong cursor ${code}.${cursor}",
+                 ("code", account_name(code))("cursor", cursor));
+
+            auto service = context.chaindb_cache->cache->service();
+            auto s = fc::raw::pack_size(service);
+            if (size == 0) {
+                return s;
             }
 
-            return cyberway::chaindb::end_primary_key;
+            chaindb_cache.reset();
+
+            // allow to extend structure in the future
+
+            vector<char> pack_buffer;
+            pack_buffer.resize(size);
+            datastream<char*> ds(pack_buffer.data(), s);
+            fc::raw::pack(ds, service);
+
+            s = std::min(s, size);
+            std::memset(data, size, 0);
+            std::memcpy(data, pack_buffer.data(), s);
+
+            return s;
         }
 
         primary_key_t chaindb_available_primary_key(account_name_t code, account_name_t scope, table_name_t table) {
@@ -136,7 +186,7 @@ namespace eosio { namespace chain {
                 table_access_violation, "db access violation");
         }
 
-        primary_key_t chaindb_insert(
+        int32_t chaindb_insert(
             account_name_t code, account_name_t scope, table_name_t table,
             account_name_t payer, primary_key_t pk, array_ptr<const char> data, size_t size
         ) {
@@ -144,27 +194,47 @@ namespace eosio { namespace chain {
                 "must specify a valid account to pay for new record");
             validate_db_access_violation(code);
             context.lazy_init_chaindb_abi(code);
-            context.chaindb.insert({code, scope, table}, context.get_ram_payer(payer), pk, data, size);
-            return pk;
+            auto delta = context.chaindb.insert({code, scope, table}, context.get_ram_payer(payer), pk, data, size);
+            return static_cast<int32_t>(delta);
         }
 
-        primary_key_t chaindb_update(
+        int32_t chaindb_update(
             account_name_t code, account_name_t scope, table_name_t table,
             account_name_t payer, primary_key_t pk, array_ptr<const char> data, size_t size
         ) {
             validate_db_access_violation(code);
             context.lazy_init_chaindb_abi(code);
-            context.chaindb.update({code, scope, table}, context.get_ram_payer(payer), pk, data, size);
-            return pk;
+            auto delta = context.chaindb.update({code, scope, table}, context.get_ram_payer(payer), pk, data, size);
+            return static_cast<int32_t>(delta);
         }
 
-        primary_key_t chaindb_delete(
+        int32_t chaindb_delete(
             account_name_t code, account_name_t scope, table_name_t table, primary_key_t pk
         ) {
             validate_db_access_violation(code);
             context.lazy_init_chaindb_abi(code);
-            context.chaindb.remove({code, scope, table}, context.get_ram_payer(), pk);
-            return pk;
+            auto delta = context.chaindb.remove({code, scope, table}, context.get_ram_payer(), pk);
+            return static_cast<int32_t>(delta);
+        }
+
+        void chaindb_ram_state(
+            account_name_t code, account_name_t scope, table_name_t table, primary_key_t pk, bool in_ram
+        ) {
+            // This realization doesn't allow to call handler in system contract,
+            //   but as result it works faster - is it good or not?
+            // As an alternative, the account contract can send inline action by itself ...
+
+            validate_db_access_violation(code);
+            context.lazy_init_chaindb_abi(code);
+
+            cyberway::chain::set_ram_state op;
+            op.code   = code;
+            op.scope  = scope;
+            op.table  = table;
+            op.pk     = pk;
+            op.in_ram = in_ram;
+
+            cyberway::chain::change_ram_state(context, op);
         }
 
     }; // class chaindb_api
@@ -189,12 +259,15 @@ namespace eosio { namespace chain {
 
         (chaindb_datasize,    int(int64_t, int)               )
         (chaindb_data,        int64_t(int64_t, int, int, int) )
+        (chaindb_service,     int(int64_t, int, int, int)     )
 
         (chaindb_available_primary_key, int64_t(int64_t, int64_t, int64_t) )
 
-        (chaindb_insert,      int64_t(int64_t, int64_t, int64_t, int64_t, int64_t, int, int) )
-        (chaindb_update,      int64_t(int64_t, int64_t, int64_t, int64_t, int64_t, int, int) )
-        (chaindb_delete,      int64_t(int64_t, int64_t, int64_t, int64_t)                    )
+        (chaindb_insert,      int(int64_t, int64_t, int64_t, int64_t, int64_t, int, int) )
+        (chaindb_update,      int(int64_t, int64_t, int64_t, int64_t, int64_t, int, int) )
+        (chaindb_delete,      int(int64_t, int64_t, int64_t, int64_t)                    )
+
+        (chaindb_ram_state,   void(int64_t, int64_t, int64_t, int64_t, int) )
     );
 
 } } /// eosio::chain

--- a/libraries/chain/wasm_chaindb_interface.ipp
+++ b/libraries/chain/wasm_chaindb_interface.ipp
@@ -34,7 +34,7 @@ namespace eosio { namespace chain {
             account_name_t code, account_name_t scope, table_name_t table, primary_key_t pk
         ) {
             context.lazy_init_chaindb_abi(code);
-            return context.chaindb.lower_bound({code, scope, table, 0}, pk).cursor;
+            return context.chaindb.lower_bound({code, scope, table}, pk).cursor;
         }
 
         cursor_t chaindb_upper_bound(
@@ -49,7 +49,7 @@ namespace eosio { namespace chain {
             account_name_t code, account_name_t scope, table_name_t table, primary_key_t pk
         ) {
             context.lazy_init_chaindb_abi(code);
-            return context.chaindb.upper_bound({code, scope, table, 0}, pk).cursor;
+            return context.chaindb.upper_bound({code, scope, table}, pk).cursor;
         }
 
         cursor_t chaindb_locate_to(

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -129,15 +129,15 @@ class privileged_api : public context_aware_api {
       void activate_feature( int64_t feature_name ) {
          EOS_ASSERT( false, unsupported_feature, "Unsupported Hardfork Detected" );
       }
-      
+
       void update_stake_proxied(uint64_t token_code_raw, account_name account, int64_t frame_length, int force) {
           int64_t now = context.control.pending_block_time().sec_since_epoch();
-          stake::update_proxied(context.chaindb, {context}, now, symbol_code{token_code_raw}, account, frame_length, static_cast<bool>(force));
+          stake::update_proxied(context.chaindb, context.get_ram_payer(), now, symbol_code{token_code_raw}, account, frame_length, static_cast<bool>(force));
       }
 
       void recall_stake_proxied(uint64_t token_code_raw, account_name grantor_name, account_name agent_name, int32_t pct) {
           int64_t now = context.control.pending_block_time().sec_since_epoch();
-          stake::recall_proxied(context.chaindb, {context}, now, symbol_code{token_code_raw}, grantor_name, agent_name, pct);
+          stake::recall_proxied(context.chaindb, context.get_ram_payer(), now, symbol_code{token_code_raw}, grantor_name, agent_name, pct);
       }
 
       int64_t set_proposed_producers( array_ptr<char> packed_producer_schedule, size_t datalen) {

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -850,13 +850,22 @@ class authorization_api : public context_aware_api {
       context.require_authorization( account );
    }
 
+   bool weak_require_authorization( const account_name& account ) {
+      return context.weak_require_authorization( account );
+   }
+
    bool has_authorization( const account_name& account )const {
       return context.has_authorization( account );
    }
 
    void require_authorization(const account_name& account,
-                                                 const permission_name& permission) {
+                              const permission_name& permission) {
       context.require_authorization( account, permission );
+   }
+
+   bool weak_require_authorization(const account_name& account,
+                                   const permission_name& permission) {
+      return context.weak_require_authorization( account, permission );
    }
 
    void require_recipient( account_name recipient ) {
@@ -1846,6 +1855,8 @@ REGISTER_INTRINSICS(authorization_api,
    (require_recipient,     void(int64_t)          )
    (require_authorization, void(int64_t), "require_auth", void(authorization_api::*)(const account_name&) )
    (require_authorization, void(int64_t, int64_t), "require_auth2", void(authorization_api::*)(const account_name&, const permission_name& permission) )
+   (weak_require_authorization, int(int64_t), "weak_require_auth", bool(authorization_api::*)(const account_name&) )
+   (weak_require_authorization, int(int64_t, int64_t), "weak_require_auth2", bool(authorization_api::*)(const account_name&, const permission_name& permission) )
    (has_authorization,     int(int64_t), "has_auth", bool(authorization_api::*)(const account_name&)const )
    (is_account,            int(int64_t)           )
 );

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -420,8 +420,8 @@ get_table_rows_result chain_api_plugin_impl::get_table_rows( const get_table_row
        // TODO: implement rbegin end rend methods in mongo driver https://github.com/GolosChain/cyberway/issues/446
        EOS_THROW(cyberway::chaindb::driver_unsupported_operation_exception, "Backward iteration through table not supported yet");
    } else {
-       auto begin = p.lower_bound == fc::variant() ? chaindb.begin(request) : chaindb.lower_bound(request, p.lower_bound);
-       const auto end_pk = p.upper_bound == fc::variant() ? cyberway::chaindb::end_primary_key : chaindb.upper_bound(request, p.upper_bound).pk;
+       auto begin = p.lower_bound.is_null() ? chaindb.begin(request) : chaindb.lower_bound(request, p.lower_bound);
+       const auto end_pk = p.upper_bound.is_null() ? cyberway::chaindb::end_primary_key : chaindb.upper_bound(request, p.upper_bound).pk;
        return walk_table_row_range(p, begin, end_pk);
    }
 
@@ -443,10 +443,12 @@ get_table_rows_result chain_api_plugin_impl::walk_table_row_range(const get_tabl
         if (p.show_payer && *p.show_payer) {
             const auto object = chaindb.object_at_cursor(cursor);
             auto value = fc::mutable_variant_object()
-                ("data",  object.value)
-                ("payer", object.service.payer)
-                ("owner", object.service.owner)
-                ("size",  object.service.size);
+                ("data",    object.value)
+                ("scope",   object.service.scope)
+                ("primary", object.service.pk)
+                ("payer",   object.service.payer)
+                ("owner",   object.service.owner)
+                ("size",    object.service.size);
             result.rows.push_back(std::move(value));
         } else {
             result.rows.push_back(chaindb.value_at_cursor(cursor));

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2149,6 +2149,8 @@ CLI::callback_t header_opt_callback = [](CLI::results_t res) {
    return true;
 };
 
+#include "set_ram_subcommand.hpp"
+
 int main( int argc, char** argv ) {
    setlocale(LC_ALL, "");
    bindtextdomain(locale_domain, locale_path);
@@ -2758,6 +2760,9 @@ int main( int argc, char** argv ) {
                      // ->required();
    contractSubcommand->add_option("wasm-file", wasmPath, localized("The file containing the contract WASM relative to contract-dir"));
 //                     ->check(CLI::ExistingFile);
+
+   auto ramSubcommand = set_ram_subcommand(setSubcommand);
+
    auto abi = contractSubcommand->add_option("abi-file,-a,--abi", abiPath, localized("The ABI for the contract relative to contract-dir"));
 //                                ->check(CLI::ExistingFile);
    contractSubcommand->add_flag( "-c,--clear", contract_clear, localized("Rmove contract on an account"));

--- a/programs/cleos/set_ram_subcommand.hpp
+++ b/programs/cleos/set_ram_subcommand.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cyberway/chain/cyberway_contract_types.hpp>
+
+struct base_ram_subcommand {
+    using account_name = eosio::chain::account_name;
+    using name = eosio::chain::name;
+    using primary_key_t = cyberway::chaindb::primary_key_t;
+
+    account_name  code;
+    string        scope;
+    name          table;
+    primary_key_t pk;
+
+    CLI::App*     command;
+
+    base_ram_subcommand(CLI::App* root, string name, string description) {
+        command = root->add_subcommand(name, description);
+        command->add_option("code",    code,  localized("The account who owns the table"))->required();
+        command->add_option("scope",   scope, localized("The scope within the contract in which the table is found") )->required();
+        command->add_option("table",   table, localized("The name of the table as specified by the contract abi") )->required();
+        command->add_option("primary", pk,    localized("The primary key of the object in the table") )->required();
+    }
+};
+
+struct set_ram_payer_subcommand final: protected base_ram_subcommand {
+    eosio::chain::account_name payer;
+
+    set_ram_payer_subcommand(CLI::App* root)
+    : base_ram_subcommand(root, "payer", localized("Set the RAM payer of the object")) {
+        command->add_option("payer", payer, localized("The new RAM payer for the table object") )->required();
+        add_standard_transaction_options(command, "payer@active");
+
+        command->set_callback([this] {
+            cyberway::chain::set_ram_payer action;
+            action.code      = code;
+            action.scope     = scope;
+            action.table     = table;
+            action.pk        = pk;
+            action.new_payer = payer;
+
+            auto payer_perms = get_account_permissions(tx_permission, {payer, config::active_name});
+            send_actions({ eosio::chain::action(payer_perms, action) });
+        });
+    }
+};
+
+struct set_ram_subcommand final {
+    CLI::App* command;
+    set_ram_payer_subcommand payer;
+
+    set_ram_subcommand(CLI::App* root)
+    : command(root->add_subcommand("ram", localized("Change RAM state of the object"))),
+      payer(command) {
+        command->require_subcommand();
+    }
+};


### PR DESCRIPTION
Resolve #479 - add system contract action to change RAM payer.
Resolve #482 - add system contract action to move objects from RAM to archive
Resolve #483 - allows to move objects from archive to RAM.

As additional changes the intrinsic `weak_require_auth()` is added.
Different with `require_auth()` - doesn't throw exception if fail, only returns bad-result.
Different with `has_auth()` - set flag of usage.

This PR doesn't support calculation of archive usages. 
It will be implemented in other 