### PR TITLE
Write CYBER & GOLOS balances into EE genesis #545 #546

### DIFF
--- a/libraries/chain/include/cyberway/genesis/ee_genesis_container.hpp
+++ b/libraries/chain/include/cyberway/genesis/ee_genesis_container.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <eosio/chain/types.hpp>
+#include <eosio/chain/asset.hpp>
 #include <eosio/chain/abi_def.hpp>
 #include <fc/reflect/reflect.hpp>
 

--- a/libraries/chain/include/cyberway/genesis/ee_genesis_serializer.hpp
+++ b/libraries/chain/include/cyberway/genesis/ee_genesis_serializer.hpp
@@ -9,6 +9,8 @@ namespace cyberway { namespace genesis {
 using namespace chaindb;
 namespace bfs = boost::filesystem;
 
+FC_DECLARE_EXCEPTION(ee_genesis_exception, 10000000, "event engine genesis create exception");
+
 //const fc::microseconds abi_serializer_max_time = fc::seconds(10);
 
 struct ee_genesis_serializer {
@@ -48,7 +50,7 @@ public:
     }
 
     void finish_section() {
-        EOS_ASSERT(_row_count == 0, genesis_exception, "Section contains wrong number of rows",
+        EOS_ASSERT(_row_count == 0, ee_genesis_exception, "Section contains wrong number of rows",
             ("section",_section)("diff",_row_count));
     }
 

--- a/programs/create-genesis/CMakeLists.txt
+++ b/programs/create-genesis/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(create-genesis main.cpp genesis_create.cpp)
+add_executable(create-genesis main.cpp genesis_create.cpp event_engine_genesis.cpp)
 
 if(UNIX AND NOT APPLE)
   set(rt_library rt)

--- a/programs/create-genesis/event_engine_genesis.cpp
+++ b/programs/create-genesis/event_engine_genesis.cpp
@@ -1,0 +1,51 @@
+#include "event_engine_genesis.hpp"
+
+namespace cyberway { namespace genesis {
+
+#define ABI_VERSION "cyberway::abi/1.0"
+
+static abi_def create_usernames_abi() {
+    abi_def abi;
+    abi.version = ABI_VERSION;
+
+    return abi;
+}
+
+static abi_def create_balances_abi() {
+    abi_def abi;
+    abi.version = ABI_VERSION;
+
+    abi.structs.emplace_back( struct_def {
+        "currency_stats", "", {
+            {"supply", "asset"},
+            {"max_supply", "asset"},
+            {"issuer", "name"}
+        }
+    });
+
+    abi.structs.emplace_back( struct_def {
+        "balance_event", "", {
+            {"account", "name"},
+            {"balance", "asset"},
+            {"payments", "asset"}
+        }
+    });
+
+    return abi;
+}
+
+event_engine_genesis::event_engine_genesis() {}
+event_engine_genesis::~event_engine_genesis() {}
+
+void event_engine_genesis::start(const bfp::path& ee_directory, const fc::sha256& hash) {
+    usernames.start(ee_directory / "usernames.dat", hash, create_usernames_abi());
+    balances.start(ee_directory / "balances.dat", hash, create_balances_abi());
+}
+
+void event_engine_genesis::finalize() {
+    usernames.finalize();
+    balances.finalize();
+}
+
+
+}} // cyberway::genesis

--- a/programs/create-genesis/event_engine_genesis.hpp
+++ b/programs/create-genesis/event_engine_genesis.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <boost/filesystem.hpp>
+#include <fc/crypto/sha256.hpp>
+#include <cyberway/genesis/ee_genesis_serializer.hpp>
+
+namespace cyberway { namespace genesis {
+
+using namespace eosio::chain;
+namespace bfp = boost::filesystem;
+
+class event_engine_genesis final {
+public:
+    event_engine_genesis(const event_engine_genesis&) = delete;
+    event_engine_genesis();
+    
+    void start(const bfp::path& ee_directory, const fc::sha256& hash);
+    void finalize();
+
+    ~event_engine_genesis();
+
+public:
+    ee_genesis_serializer usernames;
+    ee_genesis_serializer balances;
+};
+
+
+}} // cyberway::genesis

--- a/programs/create-genesis/genesis_create.hpp
+++ b/programs/create-genesis/genesis_create.hpp
@@ -27,7 +27,7 @@ public:
     ~genesis_create();
 
     void read_state(const bfs::path& state_file);
-    void write_genesis(const bfs::path& out_file, const bfs::path& ee_file, const genesis_info&, const genesis_state&, const contracts_map&);
+    void write_genesis(const bfs::path& out_file, const bfs::path& ee_directory, const genesis_info&, const genesis_state&, const contracts_map&);
 
 private:
     struct genesis_create_impl;


### PR DESCRIPTION
Resolves #545 and #546 

1. Convert Event Engine genesis into directory with different files in `create-genesis` utility
2. Implement `insert_balance_record` function to save balance into DB and ee-genesis
3. Balance & currency records in ee-genesis match cyber.token events