### PR TITLE
Remove limit on update archive objects. #567

### DIFF
--- a/contracts/eosiolib/multi_index.hpp
+++ b/contracts/eosiolib/multi_index.hpp
@@ -984,7 +984,6 @@ public:
         auto& mobj = const_cast<T&>(obj);
         auto& itm = static_cast<item&>(mobj);
         chaindb_assert(is_same_multidx(itm), "object passed to modify is not in multi_index");
-        chaindb_assert(itm.service_.in_ram, "object passed to modify is in archive");
 
         auto pk = primary_key_extractor_type()(obj);
 

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -344,10 +344,6 @@ namespace cyberway { namespace chaindb {
             auto obj = object_value{{table, pk}, std::move(value)};
             auto orig_obj = object_by_pk(table, obj.pk());
 
-            CYBERWAY_ASSERT(orig_obj.service.in_ram, update_archive_object_exception,
-                "Can't update the archive object ${obj} from the table ${table}",
-                ("obj", orig_obj.value)("table", get_full_table_name(table)));
-
             auto delta = update(table, ram, obj, std::move(orig_obj));
             cache_.emplace(table, std::move(obj));
 
@@ -358,10 +354,6 @@ namespace cyberway { namespace chaindb {
         int update(cache_object& itm, variant value, const ram_payer_info& ram) {
             auto table = get_table(itm);
             auto obj = object_value{{table, itm.pk()}, std::move(value)};
-
-            CYBERWAY_ASSERT(itm.service().in_ram, update_archive_object_exception,
-                "Can't update the archive object ${obj} from the table ${table}",
-                ("obj", itm.object().value)("table", get_full_table_name(table)));
 
             auto delta = update(table, ram, obj, itm.object());
             itm.set_object(std::move(obj));

--- a/libraries/chain/include/cyberway/chaindb/exception.hpp
+++ b/libraries/chain/include/cyberway/chaindb/exception.hpp
@@ -158,7 +158,4 @@ namespace cyberway { namespace chaindb {
         FC_DECLARE_DERIVED_EXCEPTION(object_exception, chaindb_object_exception,
                                      3740003, "Object has reserved field name")
 
-        FC_DECLARE_DERIVED_EXCEPTION(update_archive_object_exception, chaindb_object_exception,
-                                     3740004, "Can't edit object in archive")
-
 } } // namespace cyberway::chaindb


### PR DESCRIPTION
Resolve #567 

There are no reasons to limit to update archive objects.
User can do `move_to_ram()`->`update()`->`move_to_archive()`
But the same can be done on node side by calculating bandwidth.