### PR TITLE
Add usernames to EventGenesis #560

### DIFF
--- a/programs/create-genesis/event_engine_genesis.cpp
+++ b/programs/create-genesis/event_engine_genesis.cpp
@@ -8,7 +8,24 @@ static abi_def create_usernames_abi() {
     abi_def abi;
     abi.version = ABI_VERSION;
 
+    abi.structs.emplace_back( struct_def {
+        "domain_info", "", {
+            {"owner", "name"},
+            {"linked_to", "name"},
+            {"name", "string"}
+        }
+    });
+
+    abi.structs.emplace_back( struct_def {
+        "username_info", "", {
+            {"creator", "name"},
+            {"owner", "name"},
+            {"name", "string"}
+        }
+    });
+
     return abi;
+
 }
 
 static abi_def create_balances_abi() {

--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -476,6 +476,7 @@ struct genesis_create::genesis_create_impl final {
 
         // add usernames
         db.start_section(config::system_account_name, N(domain), "domain_object", 1);
+        ee_genesis.usernames.start_section(config::system_account_name, N(domain), "domain_info", 1);
         const auto app = names[golos_account_name];
         db.emplace<domain_object>([&](auto& a) {
             a.owner = app;
@@ -483,8 +484,14 @@ struct genesis_create::genesis_create_impl final {
             a.creation_date = ts;
             a.name = golos_account_name;
         });
+        ee_genesis.usernames.insert(mvo
+            ("owner", app)
+            ("linked_to", app)
+            ("name", golos_account_name)
+        );
 
         db.start_section(config::system_account_name, N(username), "username_object", _visitor.auths.size());
+        ee_genesis.usernames.start_section(config::system_account_name, N(username), "username_info", _visitor.auths.size());
         for (const auto& auth : _visitor.auths) {                // loop through auths to preserve names order
             const auto& n = auth.account.value(_accs_map);
             db.emplace<username_object>([&](auto& u) {
@@ -492,6 +499,11 @@ struct genesis_create::genesis_create_impl final {
                 u.scope = app;
                 u.name = n;
             });
+            ee_genesis.usernames.insert(mvo
+                ("creator", app)
+                ("owner", names[n])
+                ("name", n)
+            );
         }
 
         _visitor.auths.clear();


### PR DESCRIPTION
Resolves #560 
- `create-genesis` utility creates file `usernames.dat` with info about domain and usernames
- `domain_info` structures combines data from `newdomain` and `linkdomain` actions
- `username_info` structures match `newusername` action