### PR TITLE
Link posting permission with contracts in genesis #540

### DIFF
--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -47,19 +47,19 @@ using plk_idx = uint32_t;       // lookup index in _plnk_map
 
 
 static constexpr uint64_t gls_issuer_account_name = N(gls.issuer);
-static constexpr uint64_t gls_ctrl_account_name  = N(gls.ctrl);
-static constexpr uint64_t gls_vest_account_name  = N(gls.vesting);
-static constexpr uint64_t gls_post_account_name  = N(gls.publish);
+static constexpr uint64_t gls_ctrl_account_name = N(gls.ctrl);
+static constexpr uint64_t gls_vest_account_name = N(gls.vesting);
+static constexpr uint64_t gls_post_account_name = N(gls.publish);
+static constexpr uint64_t gls_social_account_name = N(gls.social);
 
 constexpr auto GBG = SY(3,GBG);
 constexpr auto GLS = SY(3,GOLOS);
 constexpr auto GESTS = SY(6,GESTS);
 constexpr auto VESTS = SY(6,GOLOS);                 // Golos dApp vesting
 constexpr auto posting_auth_name = "posting";
-constexpr auto golos_account_name = "golos";
+constexpr auto golos_domain_name = "golos";
 constexpr auto issuer_account_name = gls_issuer_account_name;
 constexpr auto notify_account_name = gls_ctrl_account_name;
-constexpr auto posting_account_name = gls_post_account_name;
 
 constexpr auto withdraw_interval_seconds = 60*60*24*7;
 constexpr auto withdraw_intervals = 13;
@@ -497,20 +497,36 @@ struct genesis_create::genesis_create_impl final {
             // TODO: recovery ?
         }
 
+        // link posting permission with gls.publish and gls.social
+        db.start_section(config::system_account_name, N(permlink), "permission_link_object", _visitor.auths.size()*2);
+        auto insert_link = [&](name acc, name code) {
+            db.emplace<permission_link_object>([&](auto& link) {
+                link.account = acc;
+                link.code = code;
+                link.message_type = name();
+                link.required_permission = N(posting);
+            });
+        };
+        for (const auto a: _visitor.auths) {
+            const auto n = generate_name(a.account.value(_accs_map));
+            insert_link(n, gls_post_account_name);
+            insert_link(n, gls_social_account_name);
+        }
+
         // add usernames
         db.start_section(config::system_account_name, N(domain), "domain_object", 1);
         ee_genesis.usernames.start_section(config::system_account_name, N(domain), "domain_info", 1);
-        const auto app = names[golos_account_name];
+        const auto app = golos_domain_name;
         db.emplace<domain_object>([&](auto& a) {
             a.owner = app;
             a.linked_to = app;
             a.creation_date = ts;
-            a.name = golos_account_name;
+            a.name = golos_domain_name;
         });
         ee_genesis.usernames.insert(mvo
             ("owner", app)
             ("linked_to", app)
-            ("name", golos_account_name)
+            ("name", golos_domain_name)
         );
 
         db.start_section(config::system_account_name, N(username), "username_object", _visitor.auths.size());
@@ -818,11 +834,6 @@ struct genesis_create::genesis_create_impl final {
         );
 
         // funds
-        auto balance_obj = [](const asset& x) {
-            return mvo
-                ("balance", x)
-                ("payments", asset(0, x.get_symbol()));
-        };
         const auto n_balances = 3 + 2*data.gbg.size();
         db.start_section(config::token_account_name, N(accounts), "account", n_balances);
         ee_genesis.balances.start_section(config::token_account_name, N(balance), "balance_event", n_balances);

--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -516,7 +516,7 @@ struct genesis_create::genesis_create_impl final {
         // add usernames
         db.start_section(config::system_account_name, N(domain), "domain_object", 1);
         ee_genesis.usernames.start_section(config::system_account_name, N(domain), "domain_info", 1);
-        const auto app = golos_domain_name;
+        const auto app = gls_issuer_account_name;
         db.emplace<domain_object>([&](auto& a) {
             a.owner = app;
             a.linked_to = app;

--- a/programs/create-genesis/serializer.hpp
+++ b/programs/create-genesis/serializer.hpp
@@ -5,6 +5,7 @@
 #include <cyberway/genesis/genesis_container.hpp>
 #include <eosio/chain/controller.hpp>
 #include <eosio/chain/authorization_manager.hpp>
+#include <eosio/chain/permission_link_object.hpp>
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/resource_limits_private.hpp>  // public interface is not enough
 #include <eosio/chain/abi_serializer.hpp>
@@ -26,6 +27,7 @@ template<> type_name get_type_name<permission_object>()         { return "permis
 template<> type_name get_type_name<permission_usage_object>()   { return "permission_usage_object"; }
 template<> type_name get_type_name<account_object>()            { return "account_object"; }
 template<> type_name get_type_name<account_sequence_object>()   { return "account_sequence_object"; }
+template<> type_name get_type_name<permission_link_object>()    { return "permission_link_object"; }
 template<> type_name get_type_name<resource_usage_object>()     { return "resource_usage_object"; }
 template<> type_name get_type_name<domain_object>()             { return "domain_object"; }
 template<> type_name get_type_name<username_object>()           { return "username_object"; }
@@ -37,6 +39,7 @@ template<> type_name get_type_name<stake_stat_object>()         { return "stake_
 
 enum class stored_contract_tables: int {
     domains,        usernames,
+    permissionlink,
     token_stats,    vesting_stats,
     token_balance,  vesting_balance,
     delegation,     rdelegation,


### PR DESCRIPTION
+ `posting` permission now linked with `gls.publish` and `gls.social` contracts' actions
+ changed "golos" domain owner to golos issuer account (TODO: `gls` account)
