### PR TITLE
Allow create-genesis-ee dump only before specified block #594

### DIFF
--- a/programs/create-genesis-ee/genesis_ee_builder.hpp
+++ b/programs/create-genesis-ee/genesis_ee_builder.hpp
@@ -19,14 +19,14 @@ FC_DECLARE_EXCEPTION(genesis_exception, 9000000, "genesis create exception");
 class genesis_ee_builder final {
 public:
     genesis_ee_builder(const genesis_ee_builder&) = delete;
-    genesis_ee_builder(const std::string& shared_file);
+    genesis_ee_builder(const std::string& shared_file, uint32_t last_block);
     ~genesis_ee_builder();
 
     void read_operation_dump(const bfs::path& in_dump_dir);
     void build(const bfs::path& out_dir);
 private:
     golos_dump_header read_header(bfs::fstream& in);
-    operation_number read_op_num(bfs::fstream& in);
+    bool read_op_num(bfs::fstream& in, operation_number& op_num);
 
     void process_comments();
     void process_delete_comments();
@@ -41,6 +41,7 @@ private:
 
     bfs::path in_dump_dir_;
     event_engine_genesis out_;
+    uint32_t last_block_;
     chainbase::database maps_;
     uint32_t comment_count_;
 };

--- a/programs/create-genesis-ee/main.cpp
+++ b/programs/create-genesis-ee/main.cpp
@@ -32,6 +32,7 @@ int main(int argc, char** argv) {
 
     bfs::path input_dir;
     bfs::path output_dir;
+    uint32_t last_block;
 
     options_description cli("create-genesis-ee command line options");
     try {
@@ -41,6 +42,9 @@ int main(int argc, char** argv) {
         ) (
             "output-dir,e", bpo::value<bfs::path>(&output_dir)->default_value("events-genesis"),
             "the directory to write Event-Engine genesis data files to (absolute or relative path)."
+        ) (
+            "last-block,l", bpo::value<uint32_t>(&last_block)->default_value(UINT32_MAX),
+            "last block num to read operations from dump and write them to Event-Engine genesis."
         ) (
             "help,h",
             "Print this help message and exit."
@@ -59,7 +63,7 @@ int main(int argc, char** argv) {
 
         bfs::remove_all("shared_memory");
 
-        genesis_ee_builder builder("shared_memory");
+        genesis_ee_builder builder("shared_memory", last_block);
         builder.read_operation_dump(input_dir);
         builder.build(output_dir);
 


### PR DESCRIPTION
Resolves #594

In `create-genesis-ee` tool added option `--last-block` (or shorter `-l`).
If set, tool will read from dump and write to EE-genesis only operations not after this block.
Option is optional. Default is infinity (write all blocks which are present in dump).

Usage example:
```
./create-genesis-ee -i /root/golos.transit/build/programs/golosd/witness_node_data_dir/operation_dump -l 1000000
```