### PR TITLE
Genesis: add deferred txs to close messages #583

### DIFF
--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -1110,7 +1110,6 @@ struct genesis_create::genesis_create_impl final {
         const auto expiration_time = fc::hours(48);
         for (const auto& cp : _visitor.comments) {
             const auto& c = cp.second;
-            const auto cashout = c.active.cashout_time;
             db.emplace<generated_transaction_object>([&](auto& t){
                 std::pair<name,string> data{get_name(c.author), c.permlink.value(_plnk_map)};
                 tx.actions[0].data = fc::raw::pack(data);

--- a/programs/create-genesis/serializer.hpp
+++ b/programs/create-genesis/serializer.hpp
@@ -4,11 +4,12 @@
 #include <cyberway/chaindb/common.hpp>
 #include <cyberway/genesis/genesis_container.hpp>
 #include <eosio/chain/controller.hpp>
+#include <eosio/chain/abi_serializer.hpp>
 #include <eosio/chain/authorization_manager.hpp>
 #include <eosio/chain/permission_link_object.hpp>
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/resource_limits_private.hpp>  // public interface is not enough
-#include <eosio/chain/abi_serializer.hpp>
+#include <eosio/chain/generated_transaction_object.hpp>
 
 
 #define IGNORE_SYSTEM_ABI
@@ -35,6 +36,7 @@ template<> type_name get_type_name<stake_agent_object>()        { return "stake_
 template<> type_name get_type_name<stake_grant_object>()        { return "stake_grant_object"; }
 template<> type_name get_type_name<stake_param_object>()        { return "stake_param_object"; }
 template<> type_name get_type_name<stake_stat_object>()         { return "stake_stat_object"; }
+template<> type_name get_type_name<generated_transaction_object>()  { return "generated_transaction_object"; }
 
 
 enum class stored_contract_tables: int {
@@ -46,6 +48,7 @@ enum class stored_contract_tables: int {
     withdrawal,
     witness_vote,   witness_info,
     reward_pool,    // post_limits,
+    gtransaction,
     messages,       permlinks,
     votes,
     // the following are system tables, but it's simpler to have them here


### PR DESCRIPTION
Note: `delay_until` extended if it's earlier than genesis initial timestamp so each tx have enough time before expiration
