### PR TITLE
Add common hash to reading dumped operations #601

### DIFF
--- a/programs/create-genesis-ee/genesis_ee_builder.hpp
+++ b/programs/create-genesis-ee/genesis_ee_builder.hpp
@@ -26,7 +26,7 @@ public:
     void build(const bfs::path& out_dir);
 private:
     golos_dump_header read_header(bfs::fstream& in);
-    bool read_op_num(bfs::fstream& in, operation_number& op_num);
+    bool read_op_header(bfs::fstream& in, operation_header& op);
 
     void process_comments();
     void process_delete_comments();

--- a/programs/create-genesis-ee/golos_dump_container.hpp
+++ b/programs/create-genesis-ee/golos_dump_container.hpp
@@ -2,10 +2,9 @@
 
 #include <cstdint>
 #include <utility>
+#include <fc/reflect/reflect.hpp>
 
 namespace cyberway { namespace genesis {
-
-using operation_number = std::pair<uint32_t, uint16_t>;
 
 struct golos_dump_header {
     char magic[13] = "";
@@ -15,4 +14,13 @@ struct golos_dump_header {
     static constexpr uint32_t expected_version = 1;
 };
 
+using operation_number = std::pair<uint32_t, uint16_t>;
+
+struct operation_header {
+	operation_number num;
+	uint64_t hash = 0;
+};
+
 } } // cyberway::genesis
+
+FC_REFLECT(cyberway::genesis::operation_header, (num)(hash))

--- a/programs/create-genesis-ee/golos_operations.hpp
+++ b/programs/create-genesis-ee/golos_operations.hpp
@@ -5,7 +5,6 @@
 namespace cyberway { namespace golos {
 
 struct comment_operation {
-    uint64_t hash = 0;
     account_name_type parent_author;
     string parent_permlink;
 
@@ -17,12 +16,7 @@ struct comment_operation {
     flat_set<string> tags;
 };
 
-struct delete_comment_operation {
-    uint64_t hash = 0;
-};
-
 struct vote_operation {
-    uint64_t hash = 0;
     account_name_type voter;
     account_name_type author;
     string permlink;
@@ -31,7 +25,6 @@ struct vote_operation {
 };
 
 struct reblog_operation {
-    uint64_t hash = 0;
     account_name_type account;
     account_name_type author;
     string permlink;
@@ -41,7 +34,6 @@ struct reblog_operation {
 };
 
 struct delete_reblog_operation {
-    uint64_t hash = 0;
     account_name_type account;
 };
 
@@ -86,7 +78,6 @@ struct auction_window_reward_operation {
 };
 
 struct total_comment_reward_operation {
-    uint64_t hash = 0;
     account_name_type author;
     string permlink;
     asset author_reward;
@@ -97,11 +88,10 @@ struct total_comment_reward_operation {
 
 } } // cyberway::golos
 
-FC_REFLECT(cyberway::golos::comment_operation, (hash)(parent_author)(parent_permlink)(author)(permlink)(title)(body)(tags))
-FC_REFLECT(cyberway::golos::delete_comment_operation, (hash))
-FC_REFLECT(cyberway::golos::vote_operation, (hash)(voter)(author)(permlink)(weight)(timestamp))
-FC_REFLECT(cyberway::golos::reblog_operation, (hash)(account)(author)(permlink)(title)(body)(timestamp))
-FC_REFLECT(cyberway::golos::delete_reblog_operation, (hash)(account))
+FC_REFLECT(cyberway::golos::comment_operation, (parent_author)(parent_permlink)(author)(permlink)(title)(body)(tags))
+FC_REFLECT(cyberway::golos::vote_operation, (voter)(author)(permlink)(weight)(timestamp))
+FC_REFLECT(cyberway::golos::reblog_operation, (account)(author)(permlink)(title)(body)(timestamp))
+FC_REFLECT(cyberway::golos::delete_reblog_operation, (account))
 FC_REFLECT(cyberway::golos::transfer_operation, (from)(to)(amount)(memo))
 
 FC_REFLECT(cyberway::golos::author_reward_operation, (author)(permlink)(sbd_payout)(steem_payout)(vesting_payout))


### PR DESCRIPTION
Resolves #601 

In actual merged version, each of dump's operation was having its own hash field. Such things are complicating work on code. It caused the bug: `total_comment_reward_operation` was missing field in FC_REFLECT.

It's better to add hash in header of each operation.
If operation cannot be hashed, we can write it as 0.

Another bug (or potential bug) was `fc::raw::unpack`-ing operation number without initializing it with zeros.