### PR TITLE
Import transfers to EE genesis #577

### DIFF
--- a/libraries/chain/include/cyberway/genesis/ee_genesis_container.hpp
+++ b/libraries/chain/include/cyberway/genesis/ee_genesis_container.hpp
@@ -24,7 +24,7 @@ struct ee_table_header {
     account_name code;
     table_name   name;
     type_name    abi_type;
-    uint32_t     count;
+    uint32_t     count = 0;
 };
 
 }} // cyberway::genesis

--- a/programs/create-genesis-ee/event_engine_genesis.cpp
+++ b/programs/create-genesis-ee/event_engine_genesis.cpp
@@ -46,12 +46,30 @@ static abi_def create_messages_abi() {
     return abi;
 }
 
+static abi_def create_transfers_abi() {
+    abi_def abi;
+    abi.version = ABI_VERSION;
+
+    abi.structs.emplace_back( struct_def {
+        "transfer", "", {
+            {"from", "name"},
+            {"to", "name"},
+            {"quantity", "asset"},
+            {"memo", "string"},
+        }
+    });
+
+    return abi;
+}
+
 void event_engine_genesis::start(const bfs::path& ee_directory, const fc::sha256& hash) {
     messages.start(ee_directory / "messages.dat", hash, create_messages_abi());
+    transfers.start(ee_directory / "transfers.dat", hash, create_transfers_abi());
 }
 
 void event_engine_genesis::finalize() {
     messages.finalize();
+    transfers.finalize();
 }
 
 } } // cyberway::genesis

--- a/programs/create-genesis-ee/event_engine_genesis.hpp
+++ b/programs/create-genesis-ee/event_engine_genesis.hpp
@@ -18,6 +18,7 @@ public:
     void finalize();
 public:
     ee_genesis_serializer messages;
+    ee_genesis_serializer transfers;
 };
 
 } } // cyberway::genesis

--- a/programs/create-genesis-ee/genesis_ee_builder.cpp
+++ b/programs/create-genesis-ee/genesis_ee_builder.cpp
@@ -314,7 +314,7 @@ void genesis_ee_builder::build_messages() {
 
         auto reblogs = build_reblogs(comment_itr->hash, comment_itr->last_delete_op, dump_reblogs);
 
-        auto msg = mvo
+        out_.messages.insert(mvo
             ("parent_author", generate_name(std::string(cop.parent_author)))
             ("parent_permlink", cop.parent_permlink)
             ("author", generate_name(std::string(cop.author)))
@@ -327,10 +327,37 @@ void genesis_ee_builder::build_messages() {
             ("benefactor_reward", asset(comment_itr->benefactor_reward, symbol(GLS)))
             ("curator_reward", asset(comment_itr->curator_reward, symbol(GLS)))
             ("votes", votes)
-            ("reblogs", reblogs);
-
-        out_.messages.insert(msg);
+            ("reblogs", reblogs)
+        );
     }
+}
+
+void genesis_ee_builder::build_transfers() {
+    std::cout << "-> Writing transfers..." << std::endl;
+
+    out_.transfers.start_section(config::token_account_name, N(transfer), "transfer", 0);
+
+    uint32_t transfer_count = 0;
+
+    bfs::fstream in(in_dump_dir_ / "transfers");
+    read_header(in);
+
+    operation_header op;
+    while (read_op_header(in, op)) {
+        cyberway::golos::transfer_operation top;
+        fc::raw::unpack(in, top);
+
+        transfer_count++;
+
+        out_.transfers.insert(mvo
+            ("from", generate_name(std::string(top.from)))
+            ("to", generate_name(std::string(top.to)))
+            ("quantity", top.amount)
+            ("memo", top.memo)
+        );
+    }
+
+    out_.transfers.finish_section(transfer_count);
 }
 
 void genesis_ee_builder::build(const bfs::path& out_dir) {
@@ -339,6 +366,7 @@ void genesis_ee_builder::build(const bfs::path& out_dir) {
     out_.start(out_dir, fc::sha256());
 
     build_messages();
+    build_transfers();
 
     out_.finalize();
 }

--- a/programs/create-genesis-ee/genesis_ee_builder.hpp
+++ b/programs/create-genesis-ee/genesis_ee_builder.hpp
@@ -38,6 +38,7 @@ private:
     variants build_votes(uint64_t msg_hash, operation_number msg_created);
     variants build_reblogs(uint64_t msg_hash, operation_number msg_created, bfs::fstream& dump_reblogs);
     void build_messages();
+    void build_transfers();
 
     bfs::path in_dump_dir_;
     event_engine_genesis out_;


### PR DESCRIPTION
Resolves #577 

Introduced event is similar to `transfer` action from `cyber.token` contract, but `memo` can take size up to 2048 bytes: https://github.com/GolosChain/golos/blob/golos-v0.20.0/libraries/protocol/include/golos/protocol/config.hpp#L298