### PR TITLE
Rebuild caches #615

### DIFF
--- a/CMakeModules/ChaindbMongo.cmake
+++ b/CMakeModules/ChaindbMongo.cmake
@@ -4,6 +4,7 @@ set(CHAINDB_LIBS "")
 set(CHAINDB_SRCS "")
 
 if (BUILD_CYBERWAY_CHAINDB_MONGO)
+    message("chaindb with MongoDB support is selected and will be builded.")
 
     find_package(libmongoc-1.0 1.8)
 

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -508,7 +508,7 @@ namespace cyberway { namespace chaindb {
         impl_->set_revision(obj.service, rev);
     }
 
-    void cache_map::clear() {
+    void cache_map::clear() const {
         impl_->clear();
     }
 

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -6,6 +6,15 @@
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/resource_limits_private.hpp>
 
+/** Cache exception is a critical errors and it doesn't handle by chain */
+#define CYBERWAY_CACHE_ASSERT(expr, FORMAT, ...)                      \
+    FC_MULTILINE_MACRO_BEGIN                                          \
+        if (BOOST_UNLIKELY( !(expr) )) {                              \
+            elog(FORMAT, __VA_ARGS__);                                \
+            FC_THROW_EXCEPTION(cache_exception, FORMAT, __VA_ARGS__); \
+        }                                                             \
+    FC_MULTILINE_MACRO_END
+
 namespace cyberway { namespace chaindb {
 
     struct cache_object_compare {
@@ -52,27 +61,46 @@ namespace cyberway { namespace chaindb {
         cache_service_key(const table_info& tab)
         : code(tab.code), table(tab.table->name) {
         }
-
-        friend bool operator<(const cache_service_key& l, const cache_service_key& r) {
-            if (l.code < r.code) return true;
-            if (l.code > r.code) return false;
-            return l.table < r.table;
-        }
     }; // cache_service_key
+
+    bool operator<(const cache_service_key& l, const cache_service_key& r) {
+        if (l.code < r.code) return true;
+        if (l.code > r.code) return false;
+        return l.table < r.table;
+    }
 
     //---------------------------------------
 
-    struct cache_index_key final {
-        const index_info& info;
-        const char*       data;
-        const size_t      size;
-    }; // struct cache_index_key
+    struct cache_service_info final {
+        int cache_object_cnt = 0;
+        primary_key_t next_pk = unset_primary_key;
+        const cache_converter_interface* converter = nullptr; // exist only for interchain tables
 
-    cache_index_value::cache_index_value(index_name i, data_t d, const cache_object& c)
+        cache_service_info() = default;
+
+        cache_service_info(const cache_converter_interface& c)
+        : converter(&c) {
+        }
+
+        bool empty() const {
+            assert(cache_object_cnt >= 0);
+            return (!converter /* info for contacts tables */ && !cache_object_cnt);
+        }
+    }; // struct cache_service_info
+
+    //---------------------------------------
+
+    cache_index_value::cache_index_value(index_name i, bytes b, const cache_object& c)
     : index(std::move(i)),
-      data(std::move(d)),
+      blob(std::move(b)),
       object(&c) {
     }
+
+    struct cache_index_key final {
+        const index_info& info;
+        const char*       blob;
+        const size_t      size;
+    }; // struct cache_index_key
 
     struct cache_index_compare {
         const index_name&   index(const cache_index_value& v) const { return v.index;                   }
@@ -87,11 +115,11 @@ namespace cyberway { namespace chaindb {
         const account_name& scope(const cache_index_value& v) const { return v.object->service().scope; }
         const account_name& scope(const cache_index_key& v  ) const { return v.info.scope;              }
 
-        const size_t        size (const cache_index_value& v) const { return v.data.size();             }
+        const size_t        size (const cache_index_value& v) const { return v.blob.size();             }
         const size_t        size (const cache_index_key& v  ) const { return v.size;                    }
 
-        const char*         data (const cache_index_value& v) const { return v.data.data();             }
-        const char*         data (const cache_index_key& v  ) const { return v.data;                    }
+        const char*         data (const cache_index_value& v) const { return v.blob.data();             }
+        const char*         data (const cache_index_key& v  ) const { return v.blob;                    }
 
         template<typename LeftKey, typename RightKey>
         bool operator()(const LeftKey& l, const RightKey& r) const {
@@ -121,118 +149,478 @@ namespace cyberway { namespace chaindb {
 
     //---------------------------------------
 
-    struct cache_service_info final {
-        int cache_object_cnt = 0;
-        primary_key_t next_pk = unset_primary_key;
-        const cache_converter_interface* converter = nullptr; // exist only for interchain tables
+    struct pending_cache_object_state final: public cache_object_state {
+        using cache_object_state::cache_object_state;
 
-        cache_service_info() = default;
-
-        cache_service_info(const cache_converter_interface* c)
-        : converter(c) {
+        ~pending_cache_object_state() {
+            reset();
         }
 
-        bool empty() const {
-            assert(cache_object_cnt >= 0);
-            return (converter == nullptr /* info for contacts tables */) && (cache_object_cnt == 0);
-        }
-    }; // struct cache_service_info
-
-    //---------------------------------------
-
-    struct table_cache_map final {
-        table_cache_map(abi_map& map)
-        : abi_map_(map) {
-        }
-
-        ~table_cache_map() {
-            clear();
-        }
-
-        cache_object* find(const service_state& key) {
-            auto itr = cache_object_tree_.find(key, cache_object_compare());
-            if (cache_object_tree_.end() != itr) {
-                return &(*itr);
-            }
-
-            return nullptr;
-        }
-
-        cache_object* find(const cache_index_key& key) {
-            auto itr = cache_index_tree_.find(key, cache_index_compare());
-            if (cache_index_tree_.end() != itr) {
-                return const_cast<cache_object*>(itr->object);
+        static pending_cache_object_state* cast(cache_object_state* state) {
+            if (state && state->cell && cache_cell::Pending == state->cell->kind) {
+                return static_cast<pending_cache_object_state*>(state);
             }
             return nullptr;
         }
 
-        cache_object_ptr emplace(object_value obj) {
-            auto ram_limit = ram_limit_;
-
-            if (obj.service.in_ram) {
-                ram_limit += obj.service.size;
-            }
-
-            static constexpr int max_cleared_objs = 100;
-            for (int i = 0; i < max_cleared_objs && !lru_list_.empty() && ram_used_ >= ram_limit; ++i) {
-                lru_list_.front().mark_deleted();
-            }
-
-            if (obj.service.in_ram) {
-                return emplace_in_ram(std::move(obj));
-            } else {
-                return get_cache_object(std::move(obj));
-            }
+        static pending_cache_object_state& cast(cache_object_state& state) {
+            auto pending_ptr = cast(&state);
+            assert(pending_ptr);
+            return *pending_ptr;
         }
 
-        void remove_cache_object(cache_object& cache, cache_indicies& indicies) {
-            // self decrementing of ref counter, see emplace_in_ram()
-            auto cache_ptr = cache_object_ptr(&cache, false);
-            auto tree_itr  = cache_object_tree_.iterator_to(cache);
-
-            if (cache.service().size) {
-                auto list_itr = lru_list_.iterator_to(cache);
-                lru_list_.erase(list_itr);
-                add_ram_usage(-cache.service().size);
-            }
-
-            remove_cache_indicies(indicies);
-            cache_object_tree_.erase(tree_itr);
-
-            auto service_itr = service_tree_.find(cache.object());
-            if (service_tree_.end() == service_itr) {
+        void reset() {
+            if (!object_ptr) {
                 return;
             }
 
-            service_itr->second.cache_object_cnt--;
-            if (service_itr->second.empty()) {
-                service_tree_.erase(service_itr);
+            auto tmp_obj_ptr = std::move(object_ptr);
+
+            auto tmp_prev_state = prev_state;
+            prev_state = nullptr;
+
+            if (!tmp_obj_ptr->is_same_cell(*cell)) {
+                return;
+            }
+
+            if (!tmp_prev_state) {
+                tmp_obj_ptr->release();
+                return;
+            }
+
+            tmp_obj_ptr->swap_state(*tmp_prev_state);
+
+            auto pending_prev_state = cast(tmp_prev_state);
+            if (pending_prev_state) {
+                pending_prev_state->is_deleted = is_deleted;
+            }
+
+            prev_state = nullptr;
+        }
+
+        void commit() {
+            if (!object_ptr) {
+                return;
+            }
+
+            while (prev_state) {
+                prev_state->object_ptr.reset();
+
+                auto pending_prev_state = cast(prev_state);
+                if (pending_prev_state) {
+                    prev_state = pending_prev_state->prev_state;
+                } else {
+                    prev_state = nullptr;
+                }
+            }
+
+            if (is_deleted) {
+                object_ptr->release();
+                object_ptr.reset();
+            }
+        }
+
+        cache_object_state* prev_state = nullptr;
+        bool is_deleted = false;
+    }; // struct pending_cache_object_state
+
+    struct pending_cache_cell final: public cache_cell {
+        pending_cache_cell(cache_map_impl& m, const revision_t r)
+        : cache_cell(m, cache_cell::Pending),
+          revision(r) {
+        }
+
+        void emplace(cache_object_ptr obj_ptr, const bool is_deleted) {
+            size += obj_ptr->service().size;
+
+            state_list.emplace_back(*this, std::move(obj_ptr));
+
+            auto& state = state_list.back();
+            auto  prev_state = state.object_ptr->swap_state(state);
+
+            state.prev_state = prev_state;
+            state.is_deleted = is_deleted;
+        }
+
+        void emplace(cache_object_ptr obj_ptr, const bool is_deleted, cache_object_state* prev_state) {
+            emplace(std::move(obj_ptr), is_deleted);
+            state_list.back().prev_state = prev_state;
+        }
+
+        revision_t revision = impossible_revision;
+        std::deque<pending_cache_object_state> state_list; // Expansion of a std::deque is cheaper than the expansion of a std::vector
+    }; // struct pending_cache_cell
+
+    //---------------------------------------
+
+    struct lru_cache_object_state final: public cache_object_state {
+        using cache_object_state::cache_object_state;
+
+        ~lru_cache_object_state() {
+            reset();
+        }
+
+        static lru_cache_object_state* cast(cache_object_state* state) {
+            if (state && state->cell && cache_cell::LRU == state->cell->kind) {
+                return static_cast<lru_cache_object_state*>(state);
+            }
+            return nullptr;
+        }
+
+        static lru_cache_object_state& cast(cache_object_state& state) {
+            auto lru_ptr = cast(&state);
+            assert(lru_ptr);
+            return *lru_ptr;
+        }
+
+        void reset() {
+            if (!object_ptr) {
+                return;
+            }
+
+            if (object_ptr->has_cell()) {
+                object_ptr->mark_deleted();
+            }
+            object_ptr.reset();
+        }
+    }; // struct lru_cache_object_state
+
+    struct lru_cache_cell final: public cache_cell {
+        lru_cache_cell(cache_map_impl& m)
+        : cache_cell(m, cache_cell::LRU) {
+        }
+
+        ~lru_cache_cell() {
+            clear();
+        }
+
+        void clear() {
+            for (auto& state: state_list) if (state.object_ptr) {
+                state.reset();
+            }
+            state_list.clear();
+        }
+
+        void emplace(cache_object_ptr obj_ptr) {
+            state_list.emplace_back(*this, std::move(obj_ptr));
+
+            auto& state = state_list.back();
+            auto* prev_state = state.object_ptr->swap_state(state);
+
+            if (prev_state) {
+                prev_state->reset();
+            }
+        }
+
+        std::deque<lru_cache_object_state> state_list; // Expansion of a std::deque is cheaper than the expansion of a std::vector
+    }; // struct lru_cache_cell
+
+    //---------------------------------------
+
+    struct system_cache_object_state final: public cache_object_state {
+        using cache_object_state::cache_object_state;
+
+        ~system_cache_object_state() {
+            reset();
+        }
+
+        static system_cache_object_state* cast(cache_object_state* state) {
+            if (state && state->cell && cache_cell::System == state->cell->kind) {
+                return static_cast<system_cache_object_state*>(state);
+            }
+            return nullptr;
+        }
+
+        static system_cache_object_state& cast(cache_object_state& state) {
+            auto* system_ptr = cast(&state);
+            assert(system_ptr);
+            return *system_ptr;
+        }
+
+        void reset();
+
+        std::list<system_cache_object_state>::iterator itr;
+    }; // struct pending_cache_object_state
+
+    struct system_cache_cell final: public cache_cell {
+        system_cache_cell(cache_map_impl& m)
+        : cache_cell(m, cache_cell::System) {
+        }
+
+        ~system_cache_cell() {
+            clear();
+        }
+
+        void clear() {
+            for (auto& state: state_list) if (state.object_ptr) {
+                assert(state.object_ptr->is_same_cell(*this));
+                state.itr = state_list.end();
+                state.object_ptr->mark_deleted();
+            }
+
+            state_list.clear();
+        }
+
+        void emplace(cache_object_ptr obj_ptr) {
+            size += obj_ptr->service().size;
+
+            state_list.emplace_back(*this, std::move(obj_ptr));
+
+            auto& state = state_list.back();
+            auto* prev_state = state.object_ptr->swap_state(state);
+            assert(!prev_state);
+
+            state.itr = --state_list.end();
+        }
+
+        std::list<system_cache_object_state> state_list;
+    }; // struct system_cache_cell
+
+    void system_cache_object_state::reset() {
+        if (!object_ptr) {
+            return;
+        }
+
+        assert(!object_ptr->has_cell());
+
+        auto system_cell = static_cast<system_cache_cell*>(cell);
+        auto system_itr  = itr;
+
+        object_ptr.reset();
+
+        if (system_cell->state_list.end() != system_itr) {
+            itr = system_cell->state_list.end();
+            system_cell->state_list.erase(system_itr);
+        }
+    }
+
+    //---------------------------------------
+
+    void cache_object_state::reset() {
+        switch (cell->kind) {
+            case cache_cell::System:
+                system_cache_object_state::cast(*this).reset();
+                break;
+
+            case cache_cell::Pending:
+                pending_cache_object_state::cast(*this).reset();
+                break;
+
+            case cache_cell::LRU: {
+                lru_cache_object_state::cast(*this).reset();
+                break;
+            }
+
+            case cache_cell::Unknown:
+            default:
+                assert(false);
+        }
+    }
+
+    //---------------------------------------
+
+    class cache_map_impl final {
+    public:
+        cache_map_impl(abi_map& map)
+        : abi_map_(map),
+          system_cell_(*this) {
+        }
+
+        ~cache_map_impl() {
+            system_cell_.clear();
+            clear();
+        }
+
+        cache_object_ptr find(const service_state& key) {
+            auto obj_ptr = find_in_cache(key);
+            if (obj_ptr) {
+                add_pending_object(obj_ptr);
+            }
+            return obj_ptr;
+        }
+
+        cache_object_ptr find(const cache_index_key& key) {
+            cache_object_ptr obj_ptr;
+            auto itr = cache_index_tree_.find(key, cache_index_compare());
+            if (cache_index_tree_.end() != itr) {
+                obj_ptr = cache_object_ptr(const_cast<cache_object*>(itr->object));
+                add_pending_object(obj_ptr);
+            }
+            return obj_ptr;
+        }
+
+        cache_object_ptr emplace(object_value value) {
+            if (!value.service.in_ram) {
+                return create_cache_object(std::move(value));
+            } else {
+                return emplace_in_ram(std::move(value));
             }
         }
 
         void remove_cache_object(const service_state& key) {
-            auto ptr = find(key);
-            if (ptr) {
-                ptr->mark_deleted();
+            auto obj_ptr = find(key);
+            if (obj_ptr) {
+                obj_ptr->mark_deleted();
             }
         }
 
-        void change_cache_object(cache_object& cache_obj, const int old_size, const int new_size, cache_indicies& indicies) {
-            add_ram_usage(new_size - old_size);
+        void set_revision(const service_state& key, const revision_t rev) {
+            auto obj_ptr = find(key);
+            if (obj_ptr) {
+                obj_ptr->set_revision(rev);
+            }
+        }
 
-            if (old_size > 0) {
-                auto list_itr = lru_list_.iterator_to(cache_obj);
-                lru_list_.erase(list_itr);
+        primary_key_t get_next_pk(const table_info& table) {
+            auto service_ptr = find_cache_service(table);
+            if (service_ptr && unset_primary_key != service_ptr->next_pk) {
+                return service_ptr->next_pk++;
+            }
+            return unset_primary_key;
+        }
+
+        void set_next_pk(const table_info& table, const primary_key_t pk) {
+            auto service_ptr = find_cache_service(table);
+            if (service_ptr) {
+                service_ptr->next_pk = pk;
+            }
+        }
+
+        void set_cache_converter(cache_service_key key, const cache_converter_interface& converter) {
+            auto res = service_tree_.emplace(std::move(key), cache_service_info(converter));
+            assert(res.second);
+        }
+
+        void clear() {
+            CYBERWAY_CACHE_ASSERT(!has_pending_cell(), "Clearing of cache with pending changes");
+
+            lru_cell_list_.clear();
+
+            cache_index_tree_.clear();
+            cache_object_tree_.clear();
+
+            service_tree_type tmp_tree;
+            tmp_tree.swap(service_tree_);
+            service_tree_.reserve(tmp_tree.size());
+            for (auto service: tmp_tree) if (service.second.converter) {
+                set_cache_converter(service.first, *service.second.converter);
+            }
+        }
+
+        void start_session(const revision_t revision) {
+            pending_cell_list_.emplace_back(*this, revision);
+            auto& pending = pending_cell_list_.back();
+            if (!lru_cell_list_.empty()) {
+                auto& lru = lru_cell_list_.back();
+                pending.pos = lru.pos + lru.size;
+            }
+        }
+
+        void push_session(const revision_t revision) {
+            CYBERWAY_CACHE_ASSERT(pending_cell_list_.size() == 1, "Push session for not-empty pending caches");
+            auto& pending = get_pending_cell(revision);
+
+            lru_cell_list_.emplace_back(*this);
+            auto& lru = lru_cell_list_.back();
+            lru.pos = pending.pos;
+
+            for (auto& state: pending.state_list) {
+                state.commit();
+                if (!state.is_deleted) {
+                    add_lru_object(std::move(state.object_ptr));
+                }
             }
 
-            if (new_size > 0) {
-                lru_list_.push_back(cache_obj);
+            pending_cell_list_.pop_back();
+            if (!lru.size) {
+                lru_cell_list_.pop_back();
             }
 
-            using state_object = eosio::chain::resource_limits::resource_limits_state_object;
-            if (is_system_code(cache_obj.service().code)) {
-                if (cache_obj.has_data() && cache_obj.service().table == chaindb::tag<state_object>::get_code()) {
-                    ram_limit_ = multi_index_item_data<state_object>::get_T(cache_obj).virtual_ram_limit;
+            CYBERWAY_CACHE_ASSERT(deleted_object_tree_.empty(), "Tree with deleted object still has items");
+
+            clear_overused_ram();
+        }
+
+        void squash_session(const revision_t revision) {
+            CYBERWAY_CACHE_ASSERT(pending_cell_list_.size() >= 2, "Squash session for less then 2 pending caches");
+
+            auto itr = pending_cell_list_.end();
+            --itr; auto& src_cell =*itr;
+            CYBERWAY_CACHE_ASSERT(revision == src_cell.revision, "Wrong revision of top pending caches");
+            --itr; auto& dst_cell =*itr;
+            CYBERWAY_CACHE_ASSERT(revision - 1 == dst_cell.revision, "Wrong revision of pending caches");
+            
+            if (pending_cell_list_.size() == 2 && dst_cell.state_list.empty()) {
+                assert(pending_cell_list_.front().revision == revision -1);
+                src_cell.revision = dst_cell.revision;
+                pending_cell_list_.pop_front();
+                return;
+            } 
+                
+            for (auto& src_state: src_cell.state_list) {
+                if (!src_state.prev_state && src_state.is_deleted) {
+                    // undo it
+                } else if (!src_state.prev_state || src_state.prev_state->cell != &dst_cell) {
+                    dst_cell.emplace(std::move(src_state.object_ptr), src_state.is_deleted, src_state.prev_state);
+                }
+            }
+
+            pending_cell_list_.pop_back();
+        }
+
+        void undo_session(const revision_t revision) {
+            if (!has_pending_cell()) {
+                // pop_block()
+                return;
+            }
+
+            auto& pending = get_pending_cell(revision);
+            pending_cell_list_.pop_back();
+            CYBERWAY_CACHE_ASSERT(!pending_cell_list_.empty() || deleted_object_tree_.empty(),
+                "Tree with deleted object still has items");
+        }
+
+        void release_cache_object(cache_object& obj, cache_indicies& indicies, const bool is_deleted) {
+            if (is_deleted) {
+                auto itr = deleted_object_tree_.iterator_to(obj);
+                deleted_object_tree_.erase(itr);
+            } else {
+                auto tree_itr = cache_object_tree_.iterator_to(obj);
+                cache_object_tree_.erase(tree_itr);
+                delete_cache_indicies(indicies);
+
+                auto service_itr = service_tree_.find(obj.object());
+                CYBERWAY_CACHE_ASSERT(service_tree_.end() != service_itr, "No service info on release object");
+
+                service_itr->second.cache_object_cnt--;
+                if (service_itr->second.empty()) {
+                    service_tree_.erase(service_itr);
+                }
+
+                add_ram_usage(obj.cell(), -obj.service().size);
+            }
+        }
+
+        bool delete_cache_object(cache_object& obj, cache_indicies& indicies) {
+            release_cache_object(obj, indicies, false);
+
+            if (!has_pending_cell() || obj.cell().kind == cache_cell::System) {
+                return true;
+            }
+
+            add_pending_object(cache_object_ptr(&obj), true);
+            deleted_object_tree_.insert(obj); // to save position in LRU
+            return false;
+        }
+
+        void change_cache_object(cache_object& obj, const int delta, cache_indicies& indicies) {
+            add_ram_usage(obj.cell(), delta);
+
+            if (is_system_code(obj.service().code)) {
+                using state_object = eosio::chain::resource_limits::resource_limits_state_object;
+                if (obj.has_data() && obj.service().table == chaindb::tag<state_object>::get_code()) {
+                    auto& state = multi_index_item_data<state_object>::get_T(obj);
+                    ram_limit_ = get_ram_limit(state.virtual_ram_limit, state.reserved_ram_size);
                 }
 
                 // don't rebuild indicies for interchain objects
@@ -241,89 +629,146 @@ namespace cyberway { namespace chaindb {
                 }
             }
 
-            remove_cache_indicies(indicies);
-            build_cache_indicies(cache_obj, indicies);
-        }
-
-        void set_revision(const service_state& key, const revision_t rev) {
-            auto ptr = find(key);
-            if (ptr) {
-                ptr->set_revision(rev);
-            }
-        }
-
-        primary_key_t get_next_pk(const table_info& table) {
-            auto ptr = find_cache_service(table);
-            if (ptr && unset_primary_key != ptr->next_pk) {
-                return ptr->next_pk++;
-            }
-            return unset_primary_key;
-        }
-
-        void set_next_pk(const table_info& table, const primary_key_t pk) {
-            auto ptr = find_cache_service(table);
-            if (ptr) {
-                ptr->next_pk = pk;
-            }
-        }
-
-        void set_cache_converter(const table_info& table, const cache_converter_interface& converter) {
-            get_cache_service(table).converter = &converter;
-        }
-
-        void clear() {
-            lru_list_.clear();
-            cache_index_tree_.clear();
-
-            while (!cache_object_tree_.empty()) {
-                auto itr = cache_object_tree_.begin();
-                // self decrementing of ref counter, see emplace()
-                auto cache_ptr = cache_object_ptr(&*itr, false);
-                cache_object_tree_.erase(itr);
-            }
-
-            service_tree_type tmp_tree;
-            tmp_tree.reserve(service_tree_.size());
-            for (auto service: service_tree_) if (service.second.converter) {
-                tmp_tree.emplace(service.first, cache_service_info(service.second.converter));
-            }
-            service_tree_.swap(tmp_tree);
+            delete_cache_indicies(indicies);
+            build_cache_indicies(obj, indicies);
         }
 
     private:
         using cache_object_tree_type = boost::intrusive::set<cache_object>;
         using cache_index_tree_type  = boost::intrusive::set<cache_index_value>;
-        using lru_list_type     = boost::intrusive::list<cache_object>;
-        using service_tree_type = fc::flat_map<cache_service_key, cache_service_info>;
+        using lru_cell_list_type     = std::deque<lru_cache_cell>;
+        using pending_cell_list_type = std::deque<pending_cache_cell>;
+        using service_tree_type      = fc::flat_map<cache_service_key, cache_service_info>;
 
         abi_map&               abi_map_;
+
         cache_object_tree_type cache_object_tree_;
+        cache_object_tree_type deleted_object_tree_;
         cache_index_tree_type  cache_index_tree_;
-        lru_list_type          lru_list_;
         service_tree_type      service_tree_;
 
-        uint64_t               ram_limit_ = eosio::chain::config::default_virtual_ram_limit;
+        pending_cell_list_type pending_cell_list_;
+        lru_cell_list_type     lru_cell_list_;
+        system_cache_cell      system_cell_;
+
+        uint64_t               ram_limit_ = get_ram_limit();
         uint64_t               ram_used_  = 0;
 
-        template <typename Table>
-        cache_service_info& get_cache_service(const Table& table) {
+        static uint64_t get_ram_limit(
+            const uint64_t limit   = eosio::chain::config::default_virtual_ram_limit,
+            const uint64_t reserve = eosio::chain::config::default_reserved_ram_size
+        ) {
+            // reserve for system objects (transactions, blocks, abi cache, ...)
+            //     and for pending caches (pending_cell_list_, ...)
+            return limit - reserve;
+        }
+
+        void clear_overused_ram() {
+            while (ram_limit_ < ram_used_) {
+                assert(!lru_cell_list_.empty());
+                auto& lru = lru_cell_list_.front();
+                add_ram_usage(lru, -lru.size);
+                lru_cell_list_.pop_front();
+            }
+        }
+
+        void add_system_object(cache_object_ptr obj_ptr) {
+            assert(obj_ptr && obj_ptr->service().payer.empty());
+            system_cell_.emplace(std::move(obj_ptr));
+        }
+
+        void add_lru_object(cache_object_ptr obj_ptr) {
+            assert(obj_ptr);
+            auto& lru = lru_cell_list_.back();
+            add_ram_usage(lru, obj_ptr->service().size);
+            lru.emplace(std::move(obj_ptr));
+        }
+
+        void add_pending_object(cache_object_ptr obj_ptr) {
+            assert(obj_ptr);
+
+            auto pending_ptr = find_pending_cell();
+            if (!pending_ptr) {
+                return;
+            }
+
+            if (!obj_ptr->has_cell() || cache_cell::LRU == obj_ptr->cell().kind) {
+                pending_ptr->emplace(std::move(obj_ptr), false);
+            }
+        }
+
+        void add_pending_object(cache_object_ptr obj_ptr, const bool is_deleted) {
+            assert(obj_ptr);
+
+            auto pending_ptr = find_pending_cell();
+            if (!pending_ptr) {
+                return;
+            }
+
+            if (obj_ptr->has_cell()) switch(obj_ptr->cell().kind) {
+                case cache_cell::System:
+                    return;
+
+                case cache_cell::Pending: {
+                    auto& state = pending_cache_object_state::cast(obj_ptr->state());
+                    if (state.is_deleted == is_deleted) {
+                        return;
+                    }
+                    if (state.cell == pending_ptr) {
+                        // the same cell -> only change state
+                        state.is_deleted = is_deleted;
+                        return;
+                    }
+                    break;
+                }
+
+                case cache_cell::LRU:
+                    break;
+
+                case cache_cell::Unknown:
+                default:
+                    assert(false);
+            }
+
+            pending_ptr->emplace(std::move(obj_ptr), is_deleted);
+        }
+
+        pending_cache_cell* find_pending_cell() {
+            if (pending_cell_list_.empty()) {
+                return nullptr;
+            }
+            return &pending_cell_list_.back();
+        }
+
+        bool has_pending_cell() const {
+            return !pending_cell_list_.empty();
+        }
+
+        pending_cache_cell& get_pending_cell(const revision_t revision) {
+            auto pending_ptr = find_pending_cell();
+            CYBERWAY_CACHE_ASSERT(pending_ptr && pending_ptr->revision == revision,
+                "Wrong pending revision ${pending_revision} != ${revision}",
+                ("pending_revision", pending_ptr ? pending_ptr->revision : impossible_revision)("revision", revision));
+            return *pending_ptr;
+        }
+
+        template <typename Table> cache_service_info& get_cache_service(const Table& table) {
             return service_tree_.emplace(cache_service_key(table), cache_service_info()).first->second;
         }
 
-        template <typename Table>
-        cache_service_info* find_cache_service(const Table& table) {
-            auto itr = service_tree_.find({table});
+        template <typename Table> cache_service_info* find_cache_service(const Table& table) {
+            auto itr = service_tree_.find(cache_service_key(table));
             if (service_tree_.end() != itr) {
                 return &itr->second;
             }
             return nullptr;
         }
 
-        void build_cache_indicies(cache_object& cache, cache_indicies& indicies) {
-            auto& object  = cache.object();
+        void build_cache_indicies(cache_object& obj, cache_indicies& indicies) {
+            auto& object  = obj.object();
             if (object.is_null()) return;
 
-            auto& service = cache.service();
+            auto& service = obj.service();
             auto  ctr = abi_map_.find(service.code);
             if (abi_map_.end() == ctr) return;
 
@@ -338,14 +783,13 @@ namespace cyberway { namespace chaindb {
             for (auto& i: ttr->indexes) if (i.unique && i.name != names::primary_index) {
                 info.index = &i;
 
-                auto bytes = abi.to_bytes(info, object.value); // size of this object is 1 Mb
-                if (bytes.empty()) continue;
+                auto big_blob = abi.to_bytes(info, object.value); // size of this object is 1 Mb
+                if (big_blob.empty()) continue;
 
-                using data_t = cache_index_value::data_t;
-                auto  data  =  data_t(bytes.begin(), bytes.end()); // minize memory usage
-                indicies.emplace_back(i.name, std::move(data), cache);
+                auto blob = bytes(big_blob.begin(), big_blob.end()); // minize memory usage
+                indicies.emplace_back(i.name, std::move(blob), obj);
                 CYBERWAY_ASSERT(cache_index_tree_.end() == cache_index_tree_.find(indicies.back()),
-                    driver_duplicate_exception, "ChainDB cache duplicate unique records in the index ${index}",
+                    driver_duplicate_exception, "Cache duplicate unique records in the index ${index}",
                     ("index", get_full_index_name(info)));
             }
 
@@ -354,7 +798,7 @@ namespace cyberway { namespace chaindb {
             }
         }
 
-        void remove_cache_indicies(cache_indicies& indicies) {
+        void delete_cache_indicies(cache_indicies& indicies) {
             for (auto& cache: indicies) {
                 auto itr = cache_index_tree_.iterator_to(cache);
                 cache_index_tree_.erase(itr);
@@ -362,84 +806,173 @@ namespace cyberway { namespace chaindb {
             indicies.clear();
         }
 
-        cache_object_ptr emplace_in_ram(object_value obj) {
-            auto cache_ptr  = cache_object_ptr(find(obj.service));
-            bool is_new_ptr = !cache_ptr;
-
-            if (is_new_ptr) {
-                cache_ptr = cache_object_ptr(new cache_object(this));
+        cache_object_ptr find_in_cache(const service_state& key) {
+            cache_object_ptr obj_ptr;
+            auto itr = cache_object_tree_.find(key, cache_object_compare());
+            if (cache_object_tree_.end() != itr) {
+                obj_ptr = cache_object_ptr(&*itr);
             }
-
-            auto& cache_service = get_cache_service(obj);
-            set_cache_value(&cache_service, cache_ptr, std::move(obj));
-
-            if (is_new_ptr) {
-                cache_object_tree_.insert(*cache_ptr.get());
-                cache_service.cache_object_cnt++;
-
-                // self incrementing of ref counter allows to use object w/o an additional storage
-                //   self decrementing happens in remove()
-                intrusive_ptr_add_ref(cache_ptr.get());
-            }
-
-            return cache_ptr;
+            return obj_ptr;
         }
 
-        cache_object_ptr get_cache_object(object_value obj) {
-            auto cache_ptr = cache_object_ptr(find(obj.service));
-            bool is_new_ptr = !cache_ptr;
-
-            if (is_new_ptr) {
-                // create object, and don't add it to RAM
-                cache_ptr = cache_object_ptr(new cache_object(nullptr));
-            } else {
-                // find object in cache, and remove it from RAM
-                cache_ptr->mark_deleted();
+        cache_object_ptr find_in_deleted(const service_state& key) {
+            cache_object_ptr obj_ptr;
+            auto itr = deleted_object_tree_.find(key, cache_object_compare());
+            if (deleted_object_tree_.end() != itr) {
+                obj_ptr = cache_object_ptr(&*itr);
             }
-
-            set_cache_value(find_cache_service(obj), cache_ptr,  std::move(obj));
-            return cache_ptr;
+            return obj_ptr;
         }
 
-        void set_cache_value(cache_service_info* service, cache_object_ptr& ptr, object_value obj) const {
+        cache_object_ptr emplace_in_ram(object_value value) {
+            auto obj_ptr = find_in_cache(value.service);
+            bool is_new_ptr = false;
+            bool is_del_ptr = false;
+
+            if (!obj_ptr && has_pending_cell()) {
+                obj_ptr = find_in_deleted(value.service);
+                is_del_ptr = !!obj_ptr;
+            }
+
+            if (!obj_ptr) {
+                obj_ptr = cache_object_ptr(new cache_object());
+                is_new_ptr = true;
+            }
+
+            assert(!is_new_ptr || !is_del_ptr);
+
+            auto& service = get_cache_service(value);
+            set_cache_value(&service, *obj_ptr.get(), std::move(value));
+
+            if (is_del_ptr) {
+                auto itr = deleted_object_tree_.iterator_to(*obj_ptr.get());
+                deleted_object_tree_.erase(itr);
+                add_pending_object(obj_ptr, false);
+            } else if (is_new_ptr) {
+                if (value.service.payer.empty()) {
+                    add_system_object(obj_ptr);
+                } else if (has_pending_cell()) {
+                    add_pending_object(obj_ptr);
+                } else {
+                    add_lru_object(obj_ptr);
+                }
+            }
+
+            if (is_new_ptr || is_del_ptr) {
+                cache_object_tree_.insert(*obj_ptr.get());
+                service.cache_object_cnt++;
+            }
+
+            return obj_ptr;
+        }
+
+        cache_object_ptr create_cache_object(object_value value) {
+            auto obj_ptr = find_in_cache(value.service);
+            bool is_new_ptr = !obj_ptr;
+
+            if (!is_new_ptr) {
+                // find object in RAM, and delete it from RAM
+                obj_ptr->mark_deleted();
+            } else if (has_pending_cell()) {
+                // find object in pending deletes, and don't add it to RAM
+                obj_ptr = find_in_deleted(value.service);
+                is_new_ptr = !obj_ptr;
+            }
+
+            if (is_new_ptr) {
+                // create object, but don't add it to RAM
+                obj_ptr = cache_object_ptr(new cache_object());
+            }
+
+            auto service_ptr = find_cache_service(value);
+            set_cache_value(service_ptr, *obj_ptr.get(), std::move(value));
+            return obj_ptr;
+        }
+
+        void set_cache_value(cache_service_info* service_ptr, cache_object& obj, object_value value) const {
             // set_cache_value happens in three cases:
-            //   1. create object for interchain tables ->  object().is_null()
-            //   2. loading object from chaindb         -> !object().is_null()
-            //   3. restore from undo state             -> !object().is_null()
-            if (service && service->converter && !obj.is_null()) {
-                service->converter->convert_variant(*ptr.get(), obj);
+            //   1. create object for interchain tables ->  value.is_null()
+            //   2. loading object from chaindb         -> !value.is_null()
+            //   3. restore from undo state             -> !value.is_null()
+            if (service_ptr && service_ptr->converter && !value.is_null()) {
+                service_ptr->converter->convert_variant(obj, value);
             }
 
-            ptr->set_object(std::move(obj));
+            obj.set_object(std::move(value));
         }
 
-        void add_ram_usage(const int delta) {
-            if (!delta) {
+        void add_ram_usage(cache_cell& cell, const int64_t delta) {
+            if (!delta || cell.kind != cache_cell::LRU) {
                 return;
             }
 
-            CYBERWAY_ASSERT(delta <= 0 || UINT64_MAX - ram_used_ >= (uint64_t)delta, cache_usage_exception,
-                "Cache delta would overflow UINT64_MAX", ("delta", delta)("used", ram_used_));
-            CYBERWAY_ASSERT(delta >= 0 || ram_used_ >= (uint64_t)(-delta), cache_usage_exception,
-                "Cache delta would underflow UINT64_MAX", ("delta", delta)("used", ram_used_));
+            cell.size = add_ram_usage(cell.size, delta);
+            ram_used_ = add_ram_usage(ram_used_, delta);
+        }
 
-            ram_used_ += (int64_t)delta;
+        uint64_t add_ram_usage(uint64_t usage, const int64_t delta) {
+            CYBERWAY_CACHE_ASSERT(delta <= 0 || UINT64_MAX - usage >= (uint64_t)delta,
+                "Cache delta would overflow UINT64_MAX", ("delta", delta)("used", usage));
+            CYBERWAY_CACHE_ASSERT(delta >= 0 || usage >= (uint64_t)(-delta),
+                "Cache delta would underflow UINT64_MAX", ("delta", delta)("used", usage));
+
+            return usage + delta;
         }
     }; // struct table_cache_map
 
-    //--------------
+    //---------------------------------------
+
+    bool cache_object::is_valid_cell() const {
+        return !state_ || (state_->cell && state_->cell->map);
+    }
+
+    bool cache_object::has_cell() const {
+        assert(is_valid_cell());
+        return !!state_;
+    }
+
+    bool cache_object::is_same_cell(const cache_cell& cell) const {
+        assert(is_valid_cell());
+        return state_ && &cell == state_->cell;
+    }
+
+    cache_object_state& cache_object::state() {
+        assert(has_cell());
+        return *state_;
+    }
+
+    cache_cell& cache_object::cell() {
+        assert(has_cell());
+        return *state_->cell;
+    }
+
+    const cache_cell& cache_object::cell() const {
+        assert(has_cell());
+        return *state_->cell;
+    }
+
+    cache_map_impl& cache_object::map() {
+        assert(has_cell());
+        return *state_->cell->map;
+    }
+
+    cache_object_state* cache_object::swap_state(cache_object_state& state) {
+        assert(!is_same_cell(*state.cell));
+
+        auto tmp = state_;
+        state_ = &state;
+        return tmp;
+    }
 
     void cache_object::set_object(object_value obj) {
         assert(object_.service.empty() || is_valid_table(obj.service));
 
-        auto old_size = object_.service.size;
-        auto new_size = obj.service.size;
-
+        int delta = obj.service.size - object_.service.size;
         object_ = std::move(obj);
         blob_.clear();
 
-        if (table_cache_map_) {
-            table_cache_map_->change_cache_object(*this, old_size, new_size, indicies_);
+        if (has_cell()) {
+            map().change_cache_object(*this, delta, indicies_);
         }
     }
 
@@ -447,38 +980,63 @@ namespace cyberway { namespace chaindb {
         assert(is_valid_table(service));
 
         object_.service = std::move(service);
-        if (!object_.service.in_ram && table_cache_map_) {
-            table_cache_map_->remove_cache_object(*this, indicies_);
+        if (!object_.service.in_ram && has_cell()) {
+            mark_deleted();
         }
     }
 
     void cache_object::mark_deleted() {
-        assert(table_cache_map_);
+        assert(!is_deleted());
 
-        auto& map = *table_cache_map_;
-        table_cache_map_ = nullptr;
-
-        map.remove_cache_object(*this, indicies_);
+        auto is_released = map().delete_cache_object(*this, indicies_);
+        if (is_released) {
+            auto& tmp_state = *state_;
+            state_ = nullptr;
+            tmp_state.reset();
+        }
     }
 
-    //-----------------
+    void cache_object::release() {
+        auto& pending_state = pending_cache_object_state::cast(*state_);
+        pending_state.cell->map->release_cache_object(*this, indicies_, pending_state.is_deleted);
+        state_ = nullptr;
+    }
+
+    bool cache_object::is_deleted() const {
+        if (!has_cell()) {
+            return true;
+        }
+
+        auto pending_ptr = pending_cache_object_state::cast(state_);
+        if (pending_ptr) {
+            return pending_ptr->is_deleted;
+        }
+
+        return false;
+    }
+
+    //---------------------------------------
 
     cache_map::cache_map(abi_map& map)
-    : impl_(new table_cache_map(map)) {
+    : impl_(new cache_map_impl(map)) {
     }
 
     cache_map::~cache_map() = default;
 
     void cache_map::set_cache_converter(const table_info& table, const cache_converter_interface& converter) const  {
-        impl_->set_cache_converter(table, converter);
+        impl_->set_cache_converter(cache_service_key(table), converter);
     }
 
-    cache_object_ptr cache_map::create(const table_info& table) const {
+    cache_object_ptr cache_map::create(const table_info& table, const storage_payer_info& storage) const {
         auto pk = impl_->get_next_pk(table);
         if (BOOST_UNLIKELY(unset_primary_key == pk)) {
             return {};
         }
-        return impl_->emplace({{table, pk}, {}});
+        auto value   = service_state(table, pk);
+        value.payer  = storage.payer;
+        value.owner  = storage.owner;
+        value.in_ram = true;
+        return impl_->emplace({std::move(value), {}});
     }
 
     void cache_map::set_next_pk(const table_info& table, const primary_key_t pk) const {
@@ -486,11 +1044,11 @@ namespace cyberway { namespace chaindb {
     }
 
     cache_object_ptr cache_map::find(const table_info& table, const primary_key_t pk) const {
-        return cache_object_ptr(impl_->find({table, pk}));
+        return impl_->find({table, pk});
     }
 
     cache_object_ptr cache_map::find(const index_info& info, const char* value, const size_t size) const {
-        return cache_object_ptr(impl_->find({info, value, size}));
+        return impl_->find({info, value, size});
     }
 
     cache_object_ptr cache_map::emplace(const table_info& table, object_value obj) const {
@@ -506,6 +1064,22 @@ namespace cyberway { namespace chaindb {
     void cache_map::set_revision(const object_value& obj, const revision_t rev) const {
         assert(obj.pk() != unset_primary_key && impossible_revision != rev);
         impl_->set_revision(obj.service, rev);
+    }
+
+    void cache_map::start_session(const revision_t revision) const {
+        impl_->start_session(revision);
+    }
+
+    void cache_map::push_session(const revision_t revision) const {
+        impl_->push_session(revision);
+    }
+
+    void cache_map::squash_session(const revision_t revision) const {
+        impl_->squash_session(revision);
+    }
+
+    void cache_map::undo_session(const revision_t revision) const {
+        impl_->undo_session(revision);
     }
 
     void cache_map::clear() const {

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -127,10 +127,7 @@ namespace cyberway { namespace chaindb {
     }
 
     void storage_payer_info::add_usage() {
-        // TODO: is it a crutch?
-        if (BOOST_UNLIKELY(payer == eosio::chain::config::system_account_name)) {
-            // do nothing
-        } else if (BOOST_UNLIKELY(payer.empty() || (!delta && !size))) {
+        if (BOOST_UNLIKELY(payer.empty() || !delta)) {
             // do nothing
         } else if (BOOST_LIKELY(!!apply_ctx)) {
             apply_ctx->add_storage_usage(*this);
@@ -624,14 +621,14 @@ namespace cyberway { namespace chaindb {
             charge.in_ram = true;
             charge.delta  = charge.size;
 
-            // charge the payer
-            charge.add_usage();
-
             // insert object to storage
             charge.set_payer_in(obj);
             obj.service.revision = undo_.revision();
 
             undo_.insert(table, obj);
+
+            // charge the payer
+            charge.add_usage();
 
             return charge.delta;
         }

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -714,27 +714,27 @@ namespace cyberway { namespace chaindb {
 
     chaindb_controller::~chaindb_controller() = default;
 
-    void chaindb_controller::restore_db() {
+    void chaindb_controller::restore_db() const {
         impl_->restore_db();
     }
 
-    void chaindb_controller::drop_db() {
+    void chaindb_controller::drop_db() const {
         impl_->drop_db();
     }
 
-    void chaindb_controller::clear_cache() {
+    void chaindb_controller::clear_cache() const {
         impl_->cache_.clear();
     }
 
-    void chaindb_controller::add_abi(const account_name& code, abi_def abi) {
+    void chaindb_controller::add_abi(const account_name& code, abi_def abi) const {
         impl_->set_abi(code, std::move(abi));
     }
 
-    void chaindb_controller::remove_abi(const account_name& code) {
+    void chaindb_controller::remove_abi(const account_name& code) const {
         impl_->remove_abi(code);
     }
 
-    bool chaindb_controller::has_abi(const account_name& code) {
+    bool chaindb_controller::has_abi(const account_name& code) const {
         return impl_->has_abi(code);
     }
 
@@ -742,19 +742,19 @@ namespace cyberway { namespace chaindb {
         return impl_->get_abi_map();
     }
 
-    void chaindb_controller::close(const cursor_request& request) {
+    void chaindb_controller::close(const cursor_request& request) const {
         impl_->driver_.close(request);
     }
 
-    void chaindb_controller::close_code_cursors(const account_name& code) {
+    void chaindb_controller::close_code_cursors(const account_name& code) const {
         impl_->driver_.close_code_cursors(code);
     }
 
-    void chaindb_controller::apply_all_changes() {
+    void chaindb_controller::apply_all_changes() const {
         impl_->driver_.apply_all_changes();
     }
 
-    void chaindb_controller::apply_code_changes(const account_name& code) {
+    void chaindb_controller::apply_code_changes(const account_name& code) const {
         impl_->driver_.apply_code_changes(code);
     }
 
@@ -788,101 +788,107 @@ namespace cyberway { namespace chaindb {
         return {info.id, info.pk};
     }
 
-    find_info chaindb_controller::locate_to(const index_request& request, const char* key, size_t size, primary_key_t pk) {
+    find_info chaindb_controller::locate_to(
+        const index_request& request, const char* key, size_t size, primary_key_t pk
+    ) const {
         const auto& info = impl_->locate_to(request, key, size, pk);
         return {info.id, info.pk};
     }
 
-    find_info chaindb_controller::begin(const index_request& request) {
+    find_info chaindb_controller::begin(const index_request& request) const {
         const auto& info = impl_->begin(request);
         return {info.id, info.pk};
     }
 
-    find_info chaindb_controller::end(const index_request& request) {
+    find_info chaindb_controller::end(const index_request& request) const {
         const auto& info = impl_->end(request);
         return {info.id, info.pk};
     }
 
-    find_info chaindb_controller::clone(const cursor_request& request) {
+    find_info chaindb_controller::clone(const cursor_request& request) const {
         const auto& info = impl_->driver_.clone(request);
         return {info.id, info.pk};
     }
 
-    primary_key_t chaindb_controller::current(const cursor_request& request) {
+    primary_key_t chaindb_controller::current(const cursor_request& request) const {
         return impl_->current(request).pk;
     }
 
-    primary_key_t chaindb_controller::next(const cursor_request& request) {
+    primary_key_t chaindb_controller::next(const cursor_request& request) const {
         auto& driver = impl_->driver_;
         return driver.next(driver.cursor(request)).pk;
     }
 
-    primary_key_t chaindb_controller::prev(const cursor_request& request) {
+    primary_key_t chaindb_controller::prev(const cursor_request& request) const{
         auto& driver = impl_->driver_;
         return driver.prev(driver.cursor(request)).pk;
     }
 
-    void chaindb_controller::set_cache_converter(const table_request& table, const cache_converter_interface& conv) {
+    void chaindb_controller::set_cache_converter(
+        const table_request& table, const cache_converter_interface& conv
+    ) const {
         impl_->set_cache_converter(table, conv);
     }
 
-    cache_object_ptr chaindb_controller::create_cache_object(const table_request& table) {
+    cache_object_ptr chaindb_controller::create_cache_object(const table_request& table) const {
         return impl_->create_cache_object(table);
     }
 
-    cache_object_ptr chaindb_controller::get_cache_object(const cursor_request& cursor, const bool with_blob) {
+    cache_object_ptr chaindb_controller::get_cache_object(const cursor_request& cursor, const bool with_blob) const {
         return impl_->get_cache_object(cursor, with_blob);
     }
 
-    primary_key_t chaindb_controller::available_pk(const table_request& request) {
+    primary_key_t chaindb_controller::available_pk(const table_request& request) const {
         return impl_->available_pk(request);
     }
 
     int chaindb_controller::insert(
         const table_request& request, const storage_payer_info& storage,
         primary_key_t pk, const char* data, size_t size
-    ) {
+    ) const {
          return impl_->insert(request, storage, pk, data, size);
     }
 
     int chaindb_controller::update(
         const table_request& request, const storage_payer_info& storage,
         primary_key_t pk, const char* data, size_t size
-    ) {
+    ) const {
         return impl_->update(request, storage, pk, data, size);
     }
 
-    int chaindb_controller::remove(const table_request& request, const storage_payer_info& storage, primary_key_t pk) {
+    int chaindb_controller::remove(
+        const table_request& request, const storage_payer_info& storage, primary_key_t pk
+    ) const{
         return impl_->remove(request, storage, pk);
     }
 
     int chaindb_controller::insert(
         const table_request& request, primary_key_t pk, variant data, const storage_payer_info& storage
-    ) {
+    ) const {
          return impl_->insert(request, pk, std::move(data), storage);
     }
 
-    int chaindb_controller::insert(cache_object& itm, variant data, const storage_payer_info& storage) {
+    int chaindb_controller::insert(cache_object& itm, variant data, const storage_payer_info& storage) const {
         return impl_->insert(itm, std::move(data), storage);
     }
 
-    int chaindb_controller::update(cache_object& itm, variant data, const storage_payer_info& storage) {
+    int chaindb_controller::update(cache_object& itm, variant data, const storage_payer_info& storage) const {
         return impl_->update(itm, std::move(data), storage);
     }
 
-    int chaindb_controller::remove(cache_object& itm, const storage_payer_info& storage) {
+    int chaindb_controller::remove(cache_object& itm, const storage_payer_info& storage) const {
         return impl_->remove(itm, storage);
     }
 
-    void chaindb_controller::recalc_ram_usage(cache_object& itm, const storage_payer_info& storage) {
+    void chaindb_controller::recalc_ram_usage(cache_object& itm, const storage_payer_info& storage) const {
         impl_->recalc_ram_usage(itm, storage);
     }
 
-    variant chaindb_controller::value_by_pk(const table_request& request, primary_key_t pk) {
+    variant chaindb_controller::value_by_pk(const table_request& request, primary_key_t pk) const {
         return impl_->object_by_pk(request, pk).value;
     }
 
-    variant chaindb_controller::value_at_cursor(const cursor_request& request) {
+    variant chaindb_controller::value_at_cursor(const cursor_request& request) const {
         return impl_->object_at_cursor(request).value;
     }
 
@@ -894,19 +900,19 @@ namespace cyberway { namespace chaindb {
         return impl_->undo_.revision();
     }
 
-    void chaindb_controller::set_revision(revision_t revision) {
+    void chaindb_controller::set_revision(revision_t revision) const {
         return impl_->undo_.set_revision(revision);
     }
 
-    chaindb_session chaindb_controller::start_undo_session(bool enabled) {
+    chaindb_session chaindb_controller::start_undo_session(bool enabled) const {
         return impl_->start_undo_session(enabled);
     }
 
-    void chaindb_controller::undo_last_revision() {
+    void chaindb_controller::undo_last_revision() const {
         return impl_->undo_revision(revision());
     }
 
-    void chaindb_controller::commit_revision(const revision_t revision) {
+    void chaindb_controller::commit_revision(const revision_t revision) const {
         return impl_->commit_revision(revision);
     }
 

--- a/libraries/chain/chaindb/mongo_driver.cpp
+++ b/libraries/chain/chaindb/mongo_driver.cpp
@@ -894,84 +894,84 @@ namespace cyberway { namespace chaindb {
         impl_->drop_table(table);
     }
 
-    void mongodb_driver::drop_db() {
+    void mongodb_driver::drop_db() const {
         impl_->drop_db();
     }
 
-    const cursor_info& mongodb_driver::clone(const cursor_request& request) {
+    const cursor_info& mongodb_driver::clone(const cursor_request& request) const {
         return impl_->clone_cursor(request);
     }
 
-    void mongodb_driver::close(const cursor_request& request) {
+    void mongodb_driver::close(const cursor_request& request) const {
         impl_->close_cursor(request);
     }
 
-    void mongodb_driver::close_code_cursors(const account_name& code) {
+    void mongodb_driver::close_code_cursors(const account_name& code) const {
         impl_->close_code_cursors(code);
     }
 
-    void mongodb_driver::apply_code_changes(const account_name& code) {
+    void mongodb_driver::apply_code_changes(const account_name& code) const {
         impl_->apply_code_changes(code);
     }
 
-    void mongodb_driver::apply_all_changes() {
+    void mongodb_driver::apply_all_changes() const {
         impl_->apply_all_changes();
     }
 
-    cursor_info& mongodb_driver::lower_bound(index_info index, variant key) {
+    cursor_info& mongodb_driver::lower_bound(index_info index, variant key) const {
         return impl_->create_cursor(std::move(index))
             .open(direction::Forward, std::move(key), unset_primary_key);
     }
 
-    cursor_info& mongodb_driver::upper_bound(index_info index, variant key) {
+    cursor_info& mongodb_driver::upper_bound(index_info index, variant key) const {
         return impl_->create_cursor(std::move(index))
             .open(direction::Backward, std::move(key), unset_primary_key)
             .next();
     }
 
-    cursor_info& mongodb_driver::locate_to(index_info index, variant key, primary_key_t pk) {
+    cursor_info& mongodb_driver::locate_to(index_info index, variant key, primary_key_t pk) const {
         return impl_->create_cursor(std::move(index))
             .open(direction::Forward, std::move(key), pk);
     }
 
-    cursor_info& mongodb_driver::begin(index_info index) {
+    cursor_info& mongodb_driver::begin(index_info index) const {
         return impl_->create_cursor(std::move(index))
             .open(direction::Forward, {}, unset_primary_key);
     }
 
-    cursor_info& mongodb_driver::end(index_info index) {
+    cursor_info& mongodb_driver::end(index_info index) const {
         return impl_->create_cursor(std::move(index))
             .open(direction::Backward, {}, end_primary_key);
     }
 
-    cursor_info& mongodb_driver::cursor(const cursor_request& request) {
+    cursor_info& mongodb_driver::cursor(const cursor_request& request) const {
         return impl_->get_unapplied_cursor(request);
     }
 
-    cursor_info& mongodb_driver::current(const cursor_info& info) {
+    cursor_info& mongodb_driver::current(const cursor_info& info) const {
         return impl_->get_applied_cursor(info)
             .current();
     }
 
-    cursor_info& mongodb_driver::next(const cursor_info& info) {
+    cursor_info& mongodb_driver::next(const cursor_info& info) const {
         return impl_->get_applied_cursor(info)
             .next();
     }
 
-    cursor_info& mongodb_driver::prev(const cursor_info& info) {
+    cursor_info& mongodb_driver::prev(const cursor_info& info) const {
         return impl_->get_applied_cursor(info)
             .prev();
     }
 
-    primary_key_t mongodb_driver::available_pk(const table_info& table) {
+    primary_key_t mongodb_driver::available_pk(const table_info& table) const {
         return impl_->available_pk(table);
     }
 
-    object_value mongodb_driver::object_by_pk(const table_info& table, const primary_key_t pk) {
+    object_value mongodb_driver::object_by_pk(const table_info& table, const primary_key_t pk) const {
         return impl_->object_by_pk(table, pk);
     }
 
-    const object_value& mongodb_driver::object_at_cursor(const cursor_info& info) {
+    const object_value& mongodb_driver::object_at_cursor(const cursor_info& info) const {
         return impl_->get_applied_cursor(info)
             .get_object_value();
     }

--- a/libraries/chain/chaindb/mongo_fail_driver.cpp
+++ b/libraries/chain/chaindb/mongo_fail_driver.cpp
@@ -7,7 +7,7 @@ namespace cyberway { namespace chaindb {
     struct mongodb_driver::mongodb_impl_ {
     }; // struct mongodb_driver::mongodb_impl_
 
-    mongodb_driver::mongodb_driver(string, string) {
+    mongodb_driver::mongodb_driver(journal&, string, string) {
         NOT_SUPPORTED;
     }
 
@@ -29,79 +29,75 @@ namespace cyberway { namespace chaindb {
         NOT_SUPPORTED;
     }
 
-    const cursor_info& mongodb_driver::clone(const cursor_request&) {
+    void mongodb_driver::drop_db() const {
         NOT_SUPPORTED;
     }
 
-    void mongodb_driver::close(const cursor_request&) {
+    const cursor_info& mongodb_driver::clone(const cursor_request&) const {
         NOT_SUPPORTED;
     }
 
-    void mongodb_driver::close_all_cursors(const account_name&) {
+    void mongodb_driver::close(const cursor_request&) const {
         NOT_SUPPORTED;
     }
 
-    void mongodb_driver::apply_changes() {
+    void mongodb_driver::close_code_cursors(const account_name&) const {
         NOT_SUPPORTED;
     }
 
-    const cursor_info& mongodb_driver::lower_bound(index_info, variant) {
+    void mongodb_driver::apply_code_changes(const account_name&) const {
         NOT_SUPPORTED;
     }
 
-    const cursor_info& mongodb_driver::upper_bound(index_info, variant) {
+    void mongodb_driver::apply_all_changes() const {
         NOT_SUPPORTED;
     }
 
-    const cursor_info& mongodb_driver::find(index_info, primary_key_t, variant) {
+    cursor_info& mongodb_driver::lower_bound(index_info, variant) const {
         NOT_SUPPORTED;
     }
 
-    const cursor_info& mongodb_driver::begin(index_info) {
+    cursor_info& mongodb_driver::upper_bound(index_info, variant) const {
         NOT_SUPPORTED;
     }
 
-    const cursor_info& mongodb_driver::end(index_info) {
+    cursor_info& mongodb_driver::locate_to(index_info, variant, primary_key_t) const {
         NOT_SUPPORTED;
     }
 
-    const cursor_info& mongodb_driver::opt_find_by_pk(index_info, primary_key_t) {
+    cursor_info& mongodb_driver::begin(index_info) const {
         NOT_SUPPORTED;
     }
 
-    const cursor_info& mongodb_driver::current(const cursor_info&) {
+    cursor_info& mongodb_driver::end(index_info) const {
         NOT_SUPPORTED;
     }
 
-    const cursor_info& mongodb_driver::current(const cursor_request&) {
+    cursor_info& mongodb_driver::cursor(const cursor_request&) const {
         NOT_SUPPORTED;
     }
 
-    const cursor_info& mongodb_driver::next(const cursor_request&) {
+    cursor_info& mongodb_driver::current(const cursor_info&) const {
         NOT_SUPPORTED;
     }
 
-    const cursor_info& mongodb_driver::prev(const cursor_request&) {
+    cursor_info& mongodb_driver::next(const cursor_info&) const {
         NOT_SUPPORTED;
     }
 
-    variant mongodb_driver::object_by_pk(const table_info&, const primary_key_t) {
+    cursor_info& mongodb_driver::prev(const cursor_info&) const {
         NOT_SUPPORTED;
     }
 
-    const variant& mongodb_driver::object_at_cursor(const cursor_info&) {
+    primary_key_t mongodb_driver::available_pk(const table_info&) const {
         NOT_SUPPORTED;
     }
 
-    void mongodb_driver::set_blob(const cursor_info&, bytes) {
+    object_value mongodb_driver::object_by_pk(const table_info&, const primary_key_t) const {
         NOT_SUPPORTED;
     }
 
-    primary_key_t mongodb_driver::available_primary_key(const table_info&) {
-        NOT_SUPPORTED;
-    }
-
-    void write(const table_info&, primary_key_t, revision_t, write_value, write_value) {
+    const object_value& mongodb_driver::object_at_cursor(const cursor_info&) const {
         NOT_SUPPORTED;
     }
 

--- a/libraries/chain/chaindb/storage_calculator.cpp
+++ b/libraries/chain/chaindb/storage_calculator.cpp
@@ -110,7 +110,7 @@ namespace cyberway { namespace chaindb {
     }
 
     int calc_storage_usage(const eosio::chain::table_def& table, const variant& var) {
-        constexpr static int base_size = 128; /* "_SERVICE_":{"scope":,"rev":,"payer":,"owner":,"size":,"ram":} */
+        constexpr static int base_size  = 256; /* memory usage of structures in RAM */
         constexpr static int index_size = 12 + 8 /* scope:pk */ + 8; /* pk */
 
         int size = base_size + index_size * table.indexes.size();

--- a/libraries/chain/chaindb/undo_state.cpp
+++ b/libraries/chain/chaindb/undo_state.cpp
@@ -362,16 +362,13 @@ namespace cyberway { namespace chaindb {
             return false;
         }
 
-        void apply_changes(const revision_t apply_rev) {
-            CYBERWAY_SESSION_ASSERT(apply_rev == revision_, "Wrong push revision ${apply_revision} != ${revision}",
-                ("revision", revision_)("apply_revision", apply_rev));
-            driver_.apply_all_changes();
-        }
-
-        void undo(const revision_t undo_rev) {
+        void undo(const revision_t undo_revision) {
+            CYBERWAY_SESSION_ASSERT(revision_ == undo_revision,
+                "Wrong undo revision ${revision} != ${undo_revision}",
+                ("revision", revision_)("undo_revision", undo_revision));
             for_tables([&](auto& table){
                 if (!table.stack_empty()) {
-                    undo(table, undo_rev, revision_);
+                    undo(table, undo_revision);
                 }
             });
             --revision_;
@@ -380,10 +377,13 @@ namespace cyberway { namespace chaindb {
             }
         }
 
-        void squash(const revision_t squash_rev) {
+        void squash(const revision_t squash_revision) {
+            CYBERWAY_SESSION_ASSERT(revision_ == squash_revision,
+                "Wrong squash revision ${revision} != ${squash_revision}",
+                ("revision", revision_)("squash_revision", squash_revision));
             for_tables([&](auto& table){
                 if (!table.stack_empty()) {
-                    squash(table, squash_rev, revision_);
+                    squash(table, squash_revision);
                 }
             });
             --revision_;
@@ -392,22 +392,17 @@ namespace cyberway { namespace chaindb {
             }
         }
 
-        void commit(const revision_t commit_rev) {
+        void commit(const revision_t commit_revision) {
+            CYBERWAY_SESSION_ASSERT(tail_revision_ <= commit_revision,
+                "Wrong commit revision ${tail_revision} > ${commit_revision}",
+                ("tail_revision", tail_revision_)("commit_revision", commit_revision));
             for_tables([&](auto& table){
-                commit(table, commit_rev);
+                commit(table, commit_revision);
             });
-            tail_revision_ = commit_rev;
+            tail_revision_ = commit_revision;
             if (revision_ == tail_revision_) {
                 stage_ = undo_stage::Unknown;
             }
-        }
-
-        void undo_all() {
-            for_tables([&](auto& table) {
-                undo_all(table);
-            });
-            stage_ = undo_stage::Unknown;
-            revision_ = tail_revision_;
         }
 
         void insert(const table_info& table, object_value obj) {
@@ -538,7 +533,7 @@ namespace cyberway { namespace chaindb {
             obj.service.in_ram   = obj.service.undo_in_ram;
         }
 
-        void undo(table_undo_stack& table, const revision_t undo_rev, const revision_t test_rev) {
+        void undo(table_undo_stack& table, const revision_t undo_rev) {
             if (undo_rev > table.head_revision()) {
                 table.undo();
                 return;
@@ -546,10 +541,9 @@ namespace cyberway { namespace chaindb {
 
             auto& head = table.head();
 
-            CYBERWAY_SESSION_ASSERT(head.revision() == undo_rev && undo_rev == test_rev,
-                "Wrong undo revision ${undo_revision} != (${revision}, ${test_revision}) "
-                "for the table ${table} for the scope '${scope}",
-                ("revision", head.revision())("undo_revision", undo_rev)("test_revision", test_rev)
+            CYBERWAY_SESSION_ASSERT(head.revision() == undo_rev,
+                "Wrong undo revision ${undo_revision} != ${revision} for the table ${table} for the scope '${scope}",
+                ("revision", head.revision())("undo_revision", undo_rev)
                 ("table", get_full_table_name(table.info()))("scope", get_scope_name(table.info())));
 
             auto ctx = journal_.create_ctx(table.info());
@@ -644,17 +638,16 @@ namespace cyberway { namespace chaindb {
             table.undo();
         }
 
-        void squash(table_undo_stack& table, const revision_t squash_rev, const revision_t test_rev) {
+        void squash(table_undo_stack& table, const revision_t squash_rev) {
             if (squash_rev > table.head_revision()) {
                 table.squash();
                 return;
             }
 
             auto& state = table.head();
-            CYBERWAY_SESSION_ASSERT(state.revision() == squash_rev && squash_rev == test_rev,
-                "Wrong squash revision ${squash_revision} != (${revision}, ${test_revision})"
-                "for the table ${table} for the scope '${scope}",
-                ("revision", state.revision())("squash_revision", squash_rev)("test_revision", test_rev)
+            CYBERWAY_SESSION_ASSERT(state.revision() == squash_rev,
+                "Wrong squash revision ${squash_revision} != ${revision} for the table ${table} for the scope '${scope}",
+                ("revision", state.revision())("squash_revision", squash_rev)
                 ("table", get_full_table_name(table.info()))("scope", get_scope_name(table.info())));
 
             // Only one stack item
@@ -857,15 +850,6 @@ namespace cyberway { namespace chaindb {
             }
         }
 
-        void undo_all(table_undo_stack& table) {
-            while (table.size() > 1) {
-                squash(table, table.revision(), table.revision());
-            }
-            if (!table.stack_empty()) {
-                undo(table, table.revision(), table.revision());
-            }
-        }
-
         void copy_undo_object(object_value& dst, const object_value& src) {
             dst.service.payer  = src.service.payer;
             dst.service.owner  = src.service.owner;
@@ -1039,8 +1023,8 @@ namespace cyberway { namespace chaindb {
         impl_->clear();
     }
 
-    chaindb_session undo_stack::start_undo_session(bool enabled) {
-        return chaindb_session(*this, impl_->start_undo_session(enabled));
+    revision_t undo_stack::start_undo_session(bool enabled) {
+        return impl_->start_undo_session(enabled);
     }
 
     void undo_stack::set_revision(const revision_t rev) {
@@ -1051,11 +1035,7 @@ namespace cyberway { namespace chaindb {
         return impl_->enabled();
     }
 
-    void undo_stack::apply_changes(const revision_t rev) {
-        impl_->apply_changes(rev);
-    }
-
-    void undo_stack::undo(const revision_t undo_rev) {
+    void undo_stack::undo(revision_t undo_rev) {
         impl_->undo(undo_rev);
     }
 
@@ -1065,14 +1045,6 @@ namespace cyberway { namespace chaindb {
 
     void undo_stack::commit(const revision_t commit_rev) {
         impl_->commit(commit_rev);
-    }
-
-    void undo_stack::undo_all() {
-        impl_->undo_all();
-    }
-
-    void undo_stack::undo() {
-        impl_->undo(impl_->revision());
     }
 
     void undo_stack::insert(const table_info& table, object_value obj) {
@@ -1085,55 +1057,6 @@ namespace cyberway { namespace chaindb {
 
     void undo_stack::remove(const table_info& table, object_value orig_obj) {
         impl_->remove(table,  std::move(orig_obj));
-    }
-
-    //------
-
-    chaindb_session::chaindb_session(undo_stack& stack, revision_t rev)
-    : stack_(stack),
-      apply_(true),
-      revision_(rev) {
-        if (rev == -1) {
-            apply_ = false;
-        }
-    }
-
-    chaindb_session::chaindb_session(chaindb_session&& mv)
-    : stack_(mv.stack_),
-      apply_(mv.apply_),
-      revision_(mv.revision_) {
-        mv.apply_ = false;
-    }
-
-    chaindb_session::~chaindb_session() {
-        if (apply_) {
-            stack_.undo(revision_);
-        }
-    }
-
-    void chaindb_session::apply_changes() {
-        if (apply_) {
-            stack_.apply_changes(revision_);
-        }
-        apply_ = false;
-    }
-
-    void chaindb_session::push() {
-        apply_ = false;
-    }
-
-    void chaindb_session::squash() {
-        if (apply_) {
-            stack_.squash(revision_);
-        }
-        apply_ = false;
-    }
-
-    void chaindb_session::undo() {
-        if (apply_) {
-            stack_.undo(revision_);
-        }
-        apply_ = false;
     }
 
 } } // namespace cyberway::chaindb

--- a/libraries/chain/chaindb/undo_state.cpp
+++ b/libraries/chain/chaindb/undo_state.cpp
@@ -1015,19 +1015,19 @@ namespace cyberway { namespace chaindb {
         impl_->add_abi_tables(abi);
     }
 
-    void undo_stack::restore() {
+    void undo_stack::restore() const {
         impl_->restore();
     }
 
-    void undo_stack::clear() {
+    void undo_stack::clear() const {
         impl_->clear();
     }
 
-    revision_t undo_stack::start_undo_session(bool enabled) {
+    revision_t undo_stack::start_undo_session(bool enabled) const {
         return impl_->start_undo_session(enabled);
     }
 
-    void undo_stack::set_revision(const revision_t rev) {
+    void undo_stack::set_revision(const revision_t rev) const {
         impl_->set_revision(rev);
     }
 
@@ -1035,27 +1035,27 @@ namespace cyberway { namespace chaindb {
         return impl_->enabled();
     }
 
-    void undo_stack::undo(revision_t undo_rev) {
+    void undo_stack::undo(revision_t undo_rev) const {
         impl_->undo(undo_rev);
     }
 
-    void undo_stack::squash(const revision_t squash_rev) {
+    void undo_stack::squash(const revision_t squash_rev) const {
         impl_->squash(squash_rev);
     }
 
-    void undo_stack::commit(const revision_t commit_rev) {
+    void undo_stack::commit(const revision_t commit_rev) const {
         impl_->commit(commit_rev);
     }
 
-    void undo_stack::insert(const table_info& table, object_value obj) {
+    void undo_stack::insert(const table_info& table, object_value obj) const {
         impl_->insert(table, std::move(obj));
     }
 
-    void undo_stack::update(const table_info& table, object_value orig_obj, object_value obj) {
+    void undo_stack::update(const table_info& table, object_value orig_obj, object_value obj) const {
         impl_->update(table,  std::move(orig_obj), std::move(obj));
     }
 
-    void undo_stack::remove(const table_info& table, object_value orig_obj) {
+    void undo_stack::remove(const table_info& table, object_value orig_obj) const {
         impl_->remove(table,  std::move(orig_obj));
     }
 

--- a/libraries/chain/chaindb/undo_state.cpp
+++ b/libraries/chain/chaindb/undo_state.cpp
@@ -346,7 +346,7 @@ namespace cyberway { namespace chaindb {
                 stage_ = undo_stage::Stack;
                 return revision_;
             } else {
-                return -1;
+                return impossible_revision;
             }
         }
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -201,7 +201,7 @@ struct controller_impl {
       head = prev;
 // TODO: removed by CyberWay
 //      db.undo();
-      chaindb.undo();
+      chaindb.undo_last_revision();
    }
 
 
@@ -331,7 +331,7 @@ struct controller_impl {
 
 // TODO: removed by CyberWay
 //      db.commit( s->block_num );
-      chaindb.commit( s->block_num );
+      chaindb.commit_revision( s->block_num );
 
       if( append_to_blog ) {
          blog.append(s->block);
@@ -483,7 +483,7 @@ struct controller_impl {
       while (chaindb.revision() > head->block_num) {
 // TODO: removed by CyberWay
 //         db.undo();
-         chaindb.undo();
+         chaindb.undo_last_revision();
       }
 
       if( report_integrity_hash ) {
@@ -518,7 +518,7 @@ struct controller_impl {
 //      // Rewind the database to the last irreversible block
 //       db.with_write_lock([&] {
 //         db.undo_all();
-//         chaindb.undo_all();
+//         chaindb.undo_all_revisions();
 //         /*
 //         FC_ASSERT(db.revision() == self.head_block_num(),
 //                   "Chainbase revision does not match head block num",

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -475,6 +475,7 @@ abi_def eosio_contract_abi(abi_def eos_abi)
          {"virtual_net_limit", "uint64"},
          {"virtual_cpu_limit", "uint64"},
          {"virtual_ram_limit", "uint64"},
+         {"reserved_ram_size", "uint64"},
       }
    });
 

--- a/libraries/chain/include/cyberway/chaindb/cache_map.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_map.hpp
@@ -1,10 +1,9 @@
 #pragma once
 
 #include <cyberway/chaindb/cache_item.hpp>
+#include <cyberway/chaindb/storage_payer_info.hpp>
 
 namespace cyberway { namespace chaindb {
-
-    struct table_info;
 
     class cache_map final {
     public:
@@ -15,7 +14,7 @@ namespace cyberway { namespace chaindb {
 
         void set_next_pk(const table_info&, primary_key_t) const;
 
-        cache_object_ptr create(const table_info&) const;
+        cache_object_ptr create(const table_info&, const storage_payer_info&) const;
         cache_object_ptr find(const table_info&, primary_key_t) const;
         cache_object_ptr find(const index_info&, const char*, size_t) const;
 
@@ -23,10 +22,15 @@ namespace cyberway { namespace chaindb {
         void remove(const table_info&, primary_key_t) const;
         void set_revision(const object_value&, revision_t) const;
 
+        void start_session(revision_t) const;
+        void push_session(revision_t) const;
+        void squash_session(revision_t) const;
+        void undo_session(revision_t) const;
+
         void clear() const;
 
     private:
-        std::unique_ptr<table_cache_map> impl_;
+        std::unique_ptr<cache_map_impl> impl_;
     }; // class cache_map
 
 } } // namespace cyberway::chaindb

--- a/libraries/chain/include/cyberway/chaindb/cache_map.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_map.hpp
@@ -23,7 +23,7 @@ namespace cyberway { namespace chaindb {
         void remove(const table_info&, primary_key_t) const;
         void set_revision(const object_value&, revision_t) const;
 
-        void clear();
+        void clear() const;
 
     private:
         std::unique_ptr<table_cache_map> impl_;

--- a/libraries/chain/include/cyberway/chaindb/common.hpp
+++ b/libraries/chain/include/cyberway/chaindb/common.hpp
@@ -102,9 +102,7 @@ namespace cyberway { namespace chaindb {
         void apply_changes();
 
         /** leaves the UNDO state on the stack when session goes out of scope */
-        void push() {
-            apply_ = false;
-        }
+        void push();
 
         /** Combines this session with the prior session */
         void squash();

--- a/libraries/chain/include/cyberway/chaindb/common.hpp
+++ b/libraries/chain/include/cyberway/chaindb/common.hpp
@@ -61,7 +61,6 @@ namespace cyberway { namespace chaindb {
     };
 
     class chaindb_controller;
-    class undo_stack;
     class abi_info;
 
     using abi_map = std::map<account_name /* code */, abi_info>;
@@ -103,7 +102,9 @@ namespace cyberway { namespace chaindb {
         void apply_changes();
 
         /** leaves the UNDO state on the stack when session goes out of scope */
-        void push();
+        void push() {
+            apply_ = false;
+        }
 
         /** Combines this session with the prior session */
         void squash();
@@ -116,11 +117,11 @@ namespace cyberway { namespace chaindb {
         }
 
     private:
-        friend class undo_stack;
+        friend class chaindb_controller;
 
-        chaindb_session(undo_stack& stack, revision_t revision);
+        chaindb_session(chaindb_controller&, revision_t);
 
-        undo_stack& stack_;
+        chaindb_controller& controller_;
         bool apply_ = true;
         const revision_t revision_ = -1;
     }; // struct session

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -141,13 +141,12 @@ namespace cyberway { namespace chaindb {
         void apply_all_changes();
         void apply_code_changes(const account_name&);
 
-        chaindb_session start_undo_session(bool enabled);
-        void undo();
-        void undo_all();
-        void commit(int64_t revision);
+        revision_t revision() const;
+        void set_revision(revision_t revision);
 
-        int64_t revision() const;
-        void set_revision(uint64_t revision);
+        chaindb_session start_undo_session(bool enabled);
+        void undo_last_revision();
+        void commit_revision(revision_t);
 
         find_info lower_bound(const index_request&, const char* key, size_t) const;
         find_info lower_bound(const table_request&, primary_key_t) const;
@@ -166,9 +165,6 @@ namespace cyberway { namespace chaindb {
         primary_key_t current(const cursor_request&);
         primary_key_t next(const cursor_request&);
         primary_key_t prev(const cursor_request&);
-
-        int32_t       datasize(const cursor_request&);
-        primary_key_t data(const cursor_request&, const char*, size_t);
 
         void set_cache_converter(const table_request&, const cache_converter_interface&);
         cache_object_ptr create_cache_object(const table_request&);
@@ -193,6 +189,8 @@ namespace cyberway { namespace chaindb {
         object_value object_at_cursor(const cursor_request& request) const;
 
     private:
+        friend class chaindb_session;
+
         struct controller_impl_;
         std::unique_ptr<controller_impl_> impl_;
     }; // class chaindb_controller

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -167,7 +167,7 @@ namespace cyberway { namespace chaindb {
         primary_key_t prev(const cursor_request&) const;
 
         void set_cache_converter(const table_request&, const cache_converter_interface&) const;
-        cache_object_ptr create_cache_object(const table_request&) const;
+        cache_object_ptr create_cache_object(const table_request&, const storage_payer_info&) const;
         cache_object_ptr get_cache_object(const cursor_request&, bool with_blob) const;
 
         primary_key_t available_pk(const table_request&) const;

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -26,17 +26,17 @@ namespace cyberway { namespace chaindb {
         ~chaindb_controller();
 
         template<typename Object>
-        auto get_table() {
+        auto get_table() const {
             return typename object_to_table<Object>::type(*this);
         }
 
         template<typename Object, typename Index>
-        auto get_index() {
+        auto get_index() const {
             return get_table<Object>().template get_index<Index>();
         }
 
         template<typename Object>
-        const Object* find(const primary_key_t pk) {
+        const Object* find(const primary_key_t pk) const {
             auto midx = get_table<Object>();
             auto itr = midx.find(pk);
             if (midx.end() == itr) {
@@ -47,12 +47,12 @@ namespace cyberway { namespace chaindb {
         }
 
         template<typename Object>
-        const Object* find(const oid<Object>& id = oid<Object>()) {
+        const Object* find(const oid<Object>& id = oid<Object>()) const {
             return find<Object>(id._id);
         }
 
         template<typename Object, typename ByIndex, typename Key>
-        const Object* find(Key&& key) {
+        const Object* find(Key&& key) const {
             auto midx = get_table<Object>();
             auto idx = midx.template get_index<ByIndex>();
             auto itr = idx.find(std::forward<Key>(key));
@@ -64,19 +64,19 @@ namespace cyberway { namespace chaindb {
         }
 
         template<typename Object>
-        const Object& get(const primary_key_t pk) {
+        const Object& get(const primary_key_t pk) const {
             auto midx = get_table<Object>();
             // should not be critical - object is stored in cache map
             return midx.get(pk);
         }
 
         template<typename Object>
-        const Object& get(const oid<Object>& id = oid<Object>()) {
+        const Object& get(const oid<Object>& id = oid<Object>()) const {
             return get<Object>(id._id);
         }
 
         template<typename Object, typename ByIndex, typename Key>
-        const Object& get(Key&& key) {
+        const Object& get(Key&& key) const {
             auto midx = get_table<Object>();
             auto idx = midx.template get_index<ByIndex>();
             // should not be critical - object is stored in cache map
@@ -84,12 +84,12 @@ namespace cyberway { namespace chaindb {
         }
 
         template<typename Object, typename Lambda>
-        const Object& emplace(Lambda&& constructor) {
+        const Object& emplace(Lambda&& constructor) const {
             return emplace<Object>({}, std::forward<Lambda>(constructor));
         }
 
         template<typename Object, typename Lambda>
-        const Object& emplace(const storage_payer_info& payer, Lambda&& constructor) {
+        const Object& emplace(const storage_payer_info& payer, Lambda&& constructor) const {
             auto midx = get_table<Object>();
             auto res = midx.emplace(payer, std::forward<Lambda>(constructor));
             // should not be critical - object is stored in cache map
@@ -97,56 +97,56 @@ namespace cyberway { namespace chaindb {
         }
 
         template<typename Object, typename Lambda>
-        int64_t modify(const Object& obj, Lambda&& updater) {
+        int64_t modify(const Object& obj, Lambda&& updater) const {
             auto midx = get_table<Object>();
             return midx.modify(obj, std::forward<Lambda>(updater));
         }
 
         template<typename Object, typename Lambda>
-        int64_t modify(const Object& obj, const storage_payer_info& payer, Lambda&& updater) {
+        int64_t modify(const Object& obj, const storage_payer_info& payer, Lambda&& updater) const {
             auto midx = get_table<Object>();
             return midx.modify(obj, payer, std::forward<Lambda>(updater));
         }
 
         template<typename Object>
-        int64_t erase(const Object& obj, const storage_payer_info& payer = {}) {
+        int64_t erase(const Object& obj, const storage_payer_info& payer = {}) const {
             auto midx = get_table<Object>();
             return midx.erase(obj, payer);
         }
 
         template<typename Object>
-        int64_t erase(const primary_key_t pk, const storage_payer_info& payer = {}) {
+        int64_t erase(const primary_key_t pk, const storage_payer_info& payer = {}) const {
             auto midx = get_table<Object>();
             return midx.erase(midx.get(pk), payer);
         }
 
         template<typename Object>
-        int64_t erase(const oid<Object>& id, const storage_payer_info& payer = {}) {
+        int64_t erase(const oid<Object>& id, const storage_payer_info& payer = {}) const {
             return erase<Object>(id._id, payer);
         }
 
-        void restore_db();
-        void drop_db();
-        void clear_cache();
+        void restore_db() const;
+        void drop_db() const;
+        void clear_cache() const;
 
-        bool has_abi(const account_name&);
-        void add_abi(const account_name&, abi_def);
-        void remove_abi(const account_name&);
+        bool has_abi(const account_name&) const;
+        void add_abi(const account_name&, abi_def) const;
+        void remove_abi(const account_name&) const;
 
         const abi_map& get_abi_map() const;
 
-        void close(const cursor_request&);
-        void close_code_cursors(const account_name&);
+        void close(const cursor_request&) const;
+        void close_code_cursors(const account_name&) const;
 
-        void apply_all_changes();
-        void apply_code_changes(const account_name&);
+        void apply_all_changes() const;
+        void apply_code_changes(const account_name&) const;
 
         revision_t revision() const;
-        void set_revision(revision_t revision);
+        void set_revision(revision_t revision) const;
 
-        chaindb_session start_undo_session(bool enabled);
-        void undo_last_revision();
-        void commit_revision(revision_t);
+        chaindb_session start_undo_session(bool enabled) const;
+        void undo_last_revision() const;
+        void commit_revision(revision_t) const;
 
         find_info lower_bound(const index_request&, const char* key, size_t) const;
         find_info lower_bound(const table_request&, primary_key_t) const;
@@ -156,36 +156,36 @@ namespace cyberway { namespace chaindb {
         find_info upper_bound(const table_request&, primary_key_t) const;
         find_info upper_bound(const index_request& request, const variant&) const;
 
-        find_info locate_to(const index_request&, const char* key, size_t, primary_key_t);
+        find_info locate_to(const index_request&, const char* key, size_t, primary_key_t) const;
 
-        find_info begin(const index_request&);
-        find_info end(const index_request&);
-        find_info clone(const cursor_request&);
+        find_info begin(const index_request&) const;
+        find_info end(const index_request&) const;
+        find_info clone(const cursor_request&) const;
 
-        primary_key_t current(const cursor_request&);
-        primary_key_t next(const cursor_request&);
-        primary_key_t prev(const cursor_request&);
+        primary_key_t current(const cursor_request&) const;
+        primary_key_t next(const cursor_request&) const;
+        primary_key_t prev(const cursor_request&) const;
 
-        void set_cache_converter(const table_request&, const cache_converter_interface&);
-        cache_object_ptr create_cache_object(const table_request&);
-        cache_object_ptr get_cache_object(const cursor_request&, bool with_blob);
+        void set_cache_converter(const table_request&, const cache_converter_interface&) const;
+        cache_object_ptr create_cache_object(const table_request&) const;
+        cache_object_ptr get_cache_object(const cursor_request&, bool with_blob) const;
 
-        primary_key_t available_pk(const table_request&);
+        primary_key_t available_pk(const table_request&) const;
 
-        int insert(const table_request&, const storage_payer_info&, primary_key_t, const char*, size_t);
-        int update(const table_request&, const storage_payer_info&, primary_key_t, const char*, size_t);
-        int remove(const table_request&, const storage_payer_info&, primary_key_t);
+        int insert(const table_request&, const storage_payer_info&, primary_key_t, const char*, size_t) const;
+        int update(const table_request&, const storage_payer_info&, primary_key_t, const char*, size_t) const;
+        int remove(const table_request&, const storage_payer_info&, primary_key_t) const;
 
-        int insert(const table_request&, primary_key_t, variant, const storage_payer_info&);
+        int insert(const table_request&, primary_key_t, variant, const storage_payer_info&) const;
 
-        int insert(cache_object&, variant, const storage_payer_info&);
-        int update(cache_object&, variant, const storage_payer_info&);
-        int remove(cache_object&, const storage_payer_info&);
+        int insert(cache_object&, variant, const storage_payer_info&) const;
+        int update(cache_object&, variant, const storage_payer_info&) const;
+        int remove(cache_object&, const storage_payer_info&) const;
 
-        void recalc_ram_usage(cache_object&, const storage_payer_info&);
+        void recalc_ram_usage(cache_object&, const storage_payer_info&) const;
 
-        variant value_by_pk(const table_request& request, primary_key_t pk);
-        variant value_at_cursor(const cursor_request& request);
+        variant value_by_pk(const table_request& request, primary_key_t pk) const;
+        variant value_at_cursor(const cursor_request& request) const;
         object_value object_at_cursor(const cursor_request& request) const;
 
     private:
@@ -209,7 +209,7 @@ namespace cyberway { namespace chaindb {
         }
 
     private:
-        chaindb_controller& controller_;
+        const chaindb_controller& controller_;
         const account_name& code_;
     }; // class chaindb_guard
 

--- a/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
+++ b/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
@@ -21,37 +21,37 @@ namespace cyberway { namespace chaindb {
     public:
         virtual ~driver_interface();
 
-        virtual void drop_db() = 0;
+        virtual void drop_db() const = 0;
 
         virtual std::vector<table_def> db_tables(const account_name& code) const = 0;
         virtual void create_index(const index_info&) const = 0;
         virtual void drop_index(const index_info&) const = 0;
         virtual void drop_table(const table_info&) const = 0;
 
-        virtual const cursor_info& clone(const cursor_request&) = 0;
+        virtual const cursor_info& clone(const cursor_request&) const = 0;
 
-        virtual void close(const cursor_request&) = 0;
-        virtual void close_code_cursors(const account_name& code) = 0;
+        virtual void close(const cursor_request&) const = 0;
+        virtual void close_code_cursors(const account_name& code) const = 0;
 
-        virtual void apply_all_changes() = 0;
-        virtual void apply_code_changes(const account_name& code) = 0;
+        virtual void apply_all_changes() const = 0;
+        virtual void apply_code_changes(const account_name& code) const = 0;
 
-        virtual cursor_info& lower_bound(index_info, variant key) = 0;
-        virtual cursor_info& upper_bound(index_info, variant key) = 0;
-        virtual cursor_info& locate_to(index_info, variant key, primary_key_t) = 0;
+        virtual cursor_info& lower_bound(index_info, variant key) const = 0;
+        virtual cursor_info& upper_bound(index_info, variant key) const = 0;
+        virtual cursor_info& locate_to(index_info, variant key, primary_key_t) const = 0;
 
-        virtual cursor_info& begin(index_info) = 0;
-        virtual cursor_info& end(index_info) = 0;
+        virtual cursor_info& begin(index_info) const = 0;
+        virtual cursor_info& end(index_info) const = 0;
 
-        virtual cursor_info& cursor(const cursor_request&) = 0;
-        virtual cursor_info& current(const cursor_info&) = 0;
-        virtual cursor_info& next(const cursor_info&) = 0;
-        virtual cursor_info& prev(const cursor_info&) = 0;
+        virtual cursor_info& cursor(const cursor_request&) const = 0;
+        virtual cursor_info& current(const cursor_info&) const = 0;
+        virtual cursor_info& next(const cursor_info&) const = 0;
+        virtual cursor_info& prev(const cursor_info&) const = 0;
 
-        virtual       object_value  object_by_pk(const table_info&, primary_key_t) = 0;
-        virtual const object_value& object_at_cursor(const cursor_info&) = 0;
+        virtual       object_value  object_by_pk(const table_info&, primary_key_t) const = 0;
+        virtual const object_value& object_at_cursor(const cursor_info&) const = 0;
 
-        virtual primary_key_t available_pk(const table_info&) = 0;
+        virtual primary_key_t available_pk(const table_info&) const = 0;
     }; // class driver_interface
 
 } } // namespace cyberway::chaindb

--- a/libraries/chain/include/cyberway/chaindb/exception.hpp
+++ b/libraries/chain/include/cyberway/chaindb/exception.hpp
@@ -98,6 +98,9 @@ namespace cyberway { namespace chaindb {
         FC_DECLARE_DERIVED_EXCEPTION(driver_wrong_object_exception, chaindb_internal_exception,
                                      3710018, "ChainDB driver return wrong object")
 
+        FC_DECLARE_DERIVED_EXCEPTION(cache_exception, chaindb_internal_exception,
+                                     3710019, "ChainDB cache failed")
+
     FC_DECLARE_DERIVED_EXCEPTION(chaindb_abi_exception, chaindb_exception,
                                  3720000, "ChainDB ABI exception")
 
@@ -157,12 +160,5 @@ namespace cyberway { namespace chaindb {
 
         FC_DECLARE_DERIVED_EXCEPTION(object_exception, chaindb_object_exception,
                                      3740003, "Object has reserved field name")
-
-    FC_DECLARE_DERIVED_EXCEPTION(chaindb_cache_exception, chaindb_exception,
-                                 3750000, "ChainDB cache exception")
-
-        FC_DECLARE_DERIVED_EXCEPTION(cache_usage_exception, chaindb_cache_exception,
-                                     3750001, "Object size exception")
-
 
 } } // namespace cyberway::chaindb

--- a/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
+++ b/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
@@ -18,32 +18,32 @@ namespace cyberway { namespace chaindb {
         void drop_index(const index_info&) const override;
         void drop_table(const table_info&) const override;
 
-        void drop_db() override;
+        void drop_db() const override;
 
-        const cursor_info& clone(const cursor_request&) override;
+        const cursor_info& clone(const cursor_request&) const override;
 
-        void close(const cursor_request&) override;
-        void close_code_cursors(const account_name& code) override;
+        void close(const cursor_request&) const override;
+        void close_code_cursors(const account_name& code) const override;
 
-        void apply_code_changes(const account_name& code) override;
-        void apply_all_changes() override;
+        void apply_code_changes(const account_name& code) const override;
+        void apply_all_changes() const override;
 
-        cursor_info& lower_bound(index_info, variant key) override;
-        cursor_info& upper_bound(index_info, variant key) override;
-        cursor_info& locate_to(index_info, variant key, primary_key_t) override;
+        cursor_info& lower_bound(index_info, variant key) const override;
+        cursor_info& upper_bound(index_info, variant key) const override;
+        cursor_info& locate_to(index_info, variant key, primary_key_t) const override;
 
-        cursor_info& begin(index_info) override;
-        cursor_info& end(index_info) override;
+        cursor_info& begin(index_info) const override;
+        cursor_info& end(index_info) const override;
 
-        cursor_info& cursor(const cursor_request&) override;
-        cursor_info& current(const cursor_info&) override;
-        cursor_info& next(const cursor_info&) override;
-        cursor_info& prev(const cursor_info&) override;
+        cursor_info& cursor(const cursor_request&) const override;
+        cursor_info& current(const cursor_info&) const override;
+        cursor_info& next(const cursor_info&) const override;
+        cursor_info& prev(const cursor_info&) const override;
 
-              object_value  object_by_pk(const table_info&, primary_key_t) override;
-        const object_value& object_at_cursor(const cursor_info&) override;
+              object_value  object_by_pk(const table_info&, primary_key_t) const override;
+        const object_value& object_at_cursor(const cursor_info&) const override;
 
-        primary_key_t available_pk(const table_info&) override;
+        primary_key_t available_pk(const table_info&) const override;
 
     private:
         struct mongodb_impl_;

--- a/libraries/chain/include/cyberway/chaindb/multi_index.hpp
+++ b/libraries/chain/include/cyberway/chaindb/multi_index.hpp
@@ -100,7 +100,7 @@ void safe_allocate(const Value& value, const char* error_msg, Lambda&& callback)
 
 template<bool IsPrimaryIndex> struct lower_bound final {
     template<typename Key>
-    find_info operator()(chaindb_controller& chaindb, const index_request& request, const Key& key) const {
+    find_info operator()(const chaindb_controller& chaindb, const index_request& request, const Key& key) const {
         find_info info;
         safe_allocate(key, "Invalid size of key on lower_bound", [&](auto& data, auto& size) {
             pack_object(key, data, size);
@@ -111,14 +111,14 @@ template<bool IsPrimaryIndex> struct lower_bound final {
 }; // struct lower_bound
 
 template<> struct lower_bound<true /*IsPrimaryIndex*/> final {
-    find_info operator()(chaindb_controller& chaindb, const table_request& request, const primary_key_t pk) const {
+    find_info operator()(const chaindb_controller& chaindb, const table_request& request, const primary_key_t pk) const {
         return chaindb.lower_bound(request, pk);
     }
 }; // struct lower_bound
 
 template<bool IsPrimaryIndex> struct upper_bound final {
     template<typename Key>
-    find_info operator()(chaindb_controller& chaindb, const index_request& request, const Key& key) const {
+    find_info operator()(const chaindb_controller& chaindb, const index_request& request, const Key& key) const {
         find_info info;
         safe_allocate(key, "Invalid size of key on upper_bound", [&](auto& data, auto& size) {
             pack_object(key, data, size);
@@ -129,7 +129,7 @@ template<bool IsPrimaryIndex> struct upper_bound final {
 }; // struct upper_bound
 
 template<> struct upper_bound<true /*IsPrimaryIndex*/> final {
-    find_info operator()(chaindb_controller& chaindb, const table_request& request, const primary_key_t pk) const {
+    find_info operator()(const chaindb_controller& chaindb, const table_request& request, const primary_key_t pk) const {
         return chaindb.upper_bound(request, pk);
     }
 }; // struct upper_bound
@@ -436,22 +436,22 @@ private:
         template<typename, typename> friend class index;
         template<typename, typename> friend struct iterator_extractor_impl;
 
-        const_iterator_impl(chaindb_controller* ctrl, const cursor_t cursor)
+        const_iterator_impl(const chaindb_controller* ctrl, const cursor_t cursor)
         : controller_(ctrl), cursor_(cursor) { }
 
-        const_iterator_impl(chaindb_controller* ctrl, const cursor_t cursor, const primary_key_t pk)
+        const_iterator_impl(const chaindb_controller* ctrl, const cursor_t cursor, const primary_key_t pk)
         : controller_(ctrl), cursor_(cursor), primary_key_(pk) { }
 
-        const_iterator_impl(chaindb_controller* ctrl, const cursor_t cursor, const primary_key_t pk, cache_object_ptr item)
+        const_iterator_impl(const chaindb_controller* ctrl, const cursor_t cursor, const primary_key_t pk, cache_object_ptr item)
         : controller_(ctrl), cursor_(cursor), primary_key_(pk), item_(std::move(item)) { }
 
-        chaindb_controller& controller() const {
+        const chaindb_controller& controller() const {
             CYBERWAY_ASSERT(controller_, chaindb_midx_logic_exception,
                 "Iterator is not initialized for the index ${index}", ("index", get_index_name()));
             return *controller_;
         }
 
-        chaindb_controller* controller_ = nullptr;
+        const chaindb_controller* controller_ = nullptr;
         mutable cursor_t cursor_ = uninitilized_cursor::state;
         mutable primary_key_t primary_key_ = end_primary_key;
         mutable cache_object_ptr item_;
@@ -554,7 +554,7 @@ public:
         constexpr static account_name_t code_name()  { return 0; }
         constexpr static account_name_t scope_name() { return 0; }
 
-        index(chaindb_controller& ctrl)
+        index(const chaindb_controller& ctrl)
         : controller_(ctrl) {
         }
 
@@ -711,11 +711,11 @@ public:
             return multi_index::get_index_name(index_name());
         }
 
-        chaindb_controller& controller_;
+        const chaindb_controller& controller_;
     }; // struct multi_index::index
 
 public:
-    multi_index(chaindb_controller& controller)
+    multi_index(const chaindb_controller& controller)
     : primary_idx_(controller) {
     }
 
@@ -728,7 +728,7 @@ public:
         return request;
     }
 
-    static void set_cache_converter(chaindb_controller& controller) {
+    static void set_cache_converter(const chaindb_controller& controller) {
         static cache_converter_ converter;
         controller.set_cache_converter(get_table_request(), converter);
     }

--- a/libraries/chain/include/cyberway/chaindb/multi_index.hpp
+++ b/libraries/chain/include/cyberway/chaindb/multi_index.hpp
@@ -591,7 +591,7 @@ public:
         const T& get(const key_type& key) const {
             auto itr = find(key);
             CYBERWAY_ASSERT(itr != cend(), chaindb_midx_find_exception,
-                "Unable to find key in the index ${index}", ("index", get_index_name()));
+                "Unable to find key ${key} in the index ${index}", ("key", key)("index", get_index_name()));
             return *itr;
         }
 

--- a/libraries/chain/include/cyberway/chaindb/multi_index.hpp
+++ b/libraries/chain/include/cyberway/chaindb/multi_index.hpp
@@ -457,7 +457,11 @@ private:
         mutable cache_object_ptr item_;
 
         void lazy_load_object() const {
-            if (item_ && !item_->is_deleted()) return;
+            if (item_) {
+                CYBERWAY_ASSERT(!item_->is_deleted(), chaindb_midx_logic_exception,
+                    "Object ${obj} is removed", ("obj", item_data::get_T(item_)));
+                return;
+            }
 
             lazy_open();
             CYBERWAY_ASSERT(primary_key_ != end_primary_key, chaindb_midx_pk_exception,
@@ -631,7 +635,7 @@ public:
 
         template<typename Lambda>
         emplace_result emplace(const storage_payer_info& payer, Lambda&& constructor) const {
-            auto cache = controller_.create_cache_object(get_table_request());
+            auto cache = controller_.create_cache_object(get_table_request(), payer);
             try {
                 auto pk = cache->pk();
                 cache->template set_data<item_data>([&](auto& o) {

--- a/libraries/chain/include/cyberway/chaindb/storage_payer_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/storage_payer_info.hpp
@@ -28,7 +28,7 @@ namespace cyberway { namespace chaindb {
         account_name owner;
         account_name payer;
         int          size   = 0;
-        int          delta  = 0;
+        int64_t      delta  = 0;
         bool         in_ram = true;
 
         storage_payer_info() = default;

--- a/libraries/chain/include/cyberway/chaindb/undo_state.hpp
+++ b/libraries/chain/include/cyberway/chaindb/undo_state.hpp
@@ -21,13 +21,13 @@ namespace cyberway { namespace chaindb {
 
         void add_abi_tables(eosio::chain::abi_def&) const;
 
-        void restore();
+        void restore() const;
 
-        void clear();
+        void clear() const;
 
-        revision_t start_undo_session(bool enabled);
+        revision_t start_undo_session(bool enabled) const;
 
-        void set_revision(revision_t rev);
+        void set_revision(revision_t rev) const;
         revision_t revision() const {
             return revision_;
         }
@@ -37,7 +37,7 @@ namespace cyberway { namespace chaindb {
          *  Restores the state to how it was prior to the current session discarding all changes
          *  made between the last revision and the current revision.
          */
-        void undo(revision_t rev);
+        void undo(revision_t rev) const;
 
         /**
          *  This method works similar to git squash, it merges the change set from the two most
@@ -45,27 +45,27 @@ namespace cyberway { namespace chaindb {
          *
          *  This method does not change the state of the index, only the state of the undo buffer.
          */
-        void squash(revision_t rev);
+        void squash(revision_t rev) const;
 
         /**
          * Discards all undo history prior to revision
          */
-        void commit(revision_t rev);
+        void commit(revision_t rev) const;
 
         /**
          * Event on create objects
          */
-        void insert(const table_info&, object_value obj);
+        void insert(const table_info&, object_value obj) const;
 
         /**
          * Event on modify objects
          */
-        void update(const table_info&, object_value orig_obj, object_value obj);
+        void update(const table_info&, object_value orig_obj, object_value obj) const;
 
         /**
          * Event on remove objects
          */
-        void remove(const table_info&, object_value orig_obj);
+        void remove(const table_info&, object_value orig_obj) const;
 
     private:
         struct undo_stack_impl_;

--- a/libraries/chain/include/cyberway/chaindb/undo_state.hpp
+++ b/libraries/chain/include/cyberway/chaindb/undo_state.hpp
@@ -25,15 +25,13 @@ namespace cyberway { namespace chaindb {
 
         void clear();
 
-        chaindb_session start_undo_session(bool enabled);
+        revision_t start_undo_session(bool enabled);
 
         void set_revision(revision_t rev);
         revision_t revision() const {
             return revision_;
         }
         bool enabled() const;
-
-        void apply_changes(revision_t rev);
 
         /**
          *  Restores the state to how it was prior to the current session discarding all changes
@@ -53,12 +51,6 @@ namespace cyberway { namespace chaindb {
          * Discards all undo history prior to revision
          */
         void commit(revision_t rev);
-
-        /**
-         * Unwinds all undo states
-         */
-        void undo_all();
-        void undo();
 
         /**
          * Event on create objects

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -25,7 +25,8 @@ const static auto default_state_dir_name     = "state";
 const static auto forkdb_filename            = "forkdb.dat";
 const static auto default_state_size            = 1*1024*1024*1024ll;
 const static auto default_state_guard_size      =    128*1024*1024ll;
-const static uint64_t default_virtual_ram_limit = 1024ll*1024*1024*32;
+const static uint64_t default_virtual_ram_limit = 1024ll*1024*1024*8;
+const static uint64_t default_reserved_ram_size = 1024ll*1024*512;
 const static uint64_t min_resource_usage_pct = percent_1 / 10;
 
 const static uint64_t system_account_name    = N(cyber);

--- a/libraries/chain/include/eosio/chain/resource_limits_private.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits_private.hpp
@@ -188,6 +188,7 @@ using namespace int_arithmetic;
       
       //TODO: smoothly increase this value when starting the chain
       uint64_t virtual_ram_limit = config::default_virtual_ram_limit;
+      uint64_t reserved_ram_size = config::default_reserved_ram_size;
    };
 
    using resource_limits_state_table = cyberway::chaindb::table_container<
@@ -219,4 +220,4 @@ FC_REFLECT(eosio::chain::resource_limits::resource_limits_config_object, (id)
 FC_REFLECT(eosio::chain::resource_limits::resource_limits_state_object, (id)
     (average_block_net_usage)(average_block_cpu_usage)(ram_usage)(storage_usage)
     (pending_net_usage)(pending_cpu_usage)
-    (virtual_net_limit)(virtual_cpu_limit)(virtual_ram_limit))
+    (virtual_net_limit)(virtual_cpu_limit)(virtual_ram_limit)(reserved_ram_size))

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -81,13 +81,8 @@ storage_payer_info resource_limits_manager::get_storage_payer(account_name owner
     return {*this, owner, owner};
 }
 
-void resource_limits_manager::initialize_account(const account_name& account, const storage_payer_info&) {
-   // no payer, because it will create the dead loop:
-   //     updating any object
-   //     -> storage usage is stored in resource_usage -> updating resource_usage
-   //     -> storage usage is stored in resource_usage -> updating resource_usage
-   //     -> storage usage is ....
-   _chaindb.emplace<resource_usage_object>([&]( resource_usage_object& bu ) {
+void resource_limits_manager::initialize_account(const account_name& account, const storage_payer_info& payer) {
+   _chaindb.emplace<resource_usage_object>(payer, [&]( resource_usage_object& bu ) {
       bu.owner = account;
    });
 }


### PR DESCRIPTION
Resolve #615: cache is organized as list of LRU blocks, which are rebuild only on success undo-sessions.
If undo-session fails the LRU item is removed from cache.

Additional changes:
- fix building of nodeos without mongodb chaindb driver.
- fix const qualifiers for chaindb object methods.
