### PR TITLE
Performance optimization creation of Event Engine Genesis #626

### DIFF
--- a/libraries/chain/include/cyberway/genesis/ee_genesis_container.hpp
+++ b/libraries/chain/include/cyberway/genesis/ee_genesis_container.hpp
@@ -14,7 +14,7 @@ struct ee_genesis_header {
     uint32_t version = 1;
     fc::sha256 hash;
 
-    bool is_valid() {
+    bool is_valid() const {
         ee_genesis_header oth;
         return string(magic) == oth.magic && version == oth.version;
     }

--- a/libraries/chain/include/cyberway/genesis/ee_genesis_serializer.hpp
+++ b/libraries/chain/include/cyberway/genesis/ee_genesis_serializer.hpp
@@ -66,7 +66,7 @@ public:
         fc::raw::pack(out, _section);
 
         out.seekp(pos);
-        wlog("Finished with count: ${count}", ("count", _section.count));
+        wlog("Finished section: ${s}", ("s", _section));
 
         _section_offset = 0;
     }

--- a/plugins/event_engine_plugin/event_engine_plugin.cpp
+++ b/plugins/event_engine_plugin/event_engine_plugin.cpp
@@ -4,6 +4,7 @@
  */
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/fstream.hpp>
+#include <boost/iostreams/device/mapped_file.hpp>
 #include <eosio/event_engine_plugin/event_engine_plugin.hpp>
 #include <eosio/event_engine_plugin/messages.hpp>
 #include <eosio/chain_plugin/chain_plugin.hpp>
@@ -214,37 +215,31 @@ void event_engine_plugin_impl::send_genesis_file(const bfs::path& genesis_file) 
     using cyberway::genesis::ee_table_header;
 
     std::cout << "Reading event engine genesis data from " << genesis_file << "..." << std::endl;
-    bfs::ifstream in(genesis_file);
-    ee_genesis_header h{"", 0};
+    boost::iostreams::mapped_file mfile;
+    mfile.open(genesis_file, boost::iostreams::mapped_file::readonly);
+    EOS_ASSERT(mfile.is_open(), ee_extract_genesis_exception, "File not opened");
 
-    in.read((char*)&h, sizeof(h));
+    ee_genesis_header &h = *(ee_genesis_header*)mfile.const_data();
     std::cout << "Header magic: " << h.magic << "; ver: " << h.version << std::endl;
     EOS_ASSERT(h.is_valid(), ee_extract_genesis_exception, "Unknown format of the Genesis state file.");
 
+    fc::datastream<const char*> ds(mfile.const_data()+sizeof(h), mfile.size()-sizeof(h));
     // Read ABI
     abi_def abi;
     abi_serializer serializer;
 
-    fc::raw::unpack(in, abi);
+    fc::raw::unpack(ds, abi);
     serializer.set_abi(abi, abi_serializer_max_time);
 
-    while (in) {
+    while (ds.remaining()) {
         ee_table_header t;
-        fc::raw::unpack(in, t);
-        if (!in)
+        fc::raw::unpack(ds, t);
+        if (ds.remaining() == 0)
             break;
 
         std::cout << "Reading " << t.count << " record(s) with type: " << t.abi_type << std::endl;
         for (unsigned i = 0; i < t.count; ++i) {
-            bytes data;
-            fc::raw::unpack(in, data);
-
-            fc::variant args;
-            if (data.size() != 0) {
-                fc::datastream<const char*> ds(static_cast<const char*>(data.data()), data.size());
-                args = serializer.binary_to_variant(t.abi_type, ds, abi_serializer_max_time);
-            }
-
+            fc::variant args = serializer.binary_to_variant(t.abi_type, ds, abi_serializer_max_time);
             GenesisDataMessage msg(BaseMessage::GenesisData, t.code, t.name, args);
             send_message(msg);
         }

--- a/plugins/event_engine_plugin/event_engine_plugin.cpp
+++ b/plugins/event_engine_plugin/event_engine_plugin.cpp
@@ -219,7 +219,7 @@ void event_engine_plugin_impl::send_genesis_file(const bfs::path& genesis_file) 
     mfile.open(genesis_file, boost::iostreams::mapped_file::readonly);
     EOS_ASSERT(mfile.is_open(), ee_extract_genesis_exception, "File not opened");
 
-    ee_genesis_header &h = *(ee_genesis_header*)mfile.const_data();
+    const ee_genesis_header &h = *(ee_genesis_header*)mfile.const_data();
     std::cout << "Header magic: " << h.magic << "; ver: " << h.version << std::endl;
     EOS_ASSERT(h.is_valid(), ee_extract_genesis_exception, "Unknown format of the Genesis state file.");
 

--- a/plugins/event_engine_plugin/event_engine_plugin.cpp
+++ b/plugins/event_engine_plugin/event_engine_plugin.cpp
@@ -219,7 +219,7 @@ void event_engine_plugin_impl::send_genesis_file(const bfs::path& genesis_file) 
     mfile.open(genesis_file, boost::iostreams::mapped_file::readonly);
     EOS_ASSERT(mfile.is_open(), ee_extract_genesis_exception, "File not opened");
 
-    const ee_genesis_header &h = *(ee_genesis_header*)mfile.const_data();
+    const ee_genesis_header &h = *(const ee_genesis_header*)mfile.const_data();
     std::cout << "Header magic: " << h.magic << "; ver: " << h.version << std::endl;
     EOS_ASSERT(h.is_valid(), ee_extract_genesis_exception, "Unknown format of the Genesis state file.");
 

--- a/programs/create-genesis-ee/event_engine_genesis.hpp
+++ b/programs/create-genesis-ee/event_engine_genesis.hpp
@@ -22,4 +22,71 @@ public:
     ee_genesis_serializer pinblocks;
 };
 
+struct vote_info {
+    OBJECT_CTOR(vote_info);
+
+    name voter;
+    int16_t weight;
+    fc::time_point_sec time;
+};
+
+struct reblog_info {
+    OBJECT_CTOR(reblog_info);
+
+    name account;
+    string title;
+    string body;
+    fc::time_point_sec time;
+};
+
+struct comment_info {
+    OBJECT_CTOR(comment_info);
+    
+    name parent_author;
+    string parent_permlink;
+    name author;
+    string permlink;
+    string title;
+    string body;
+    fc::flat_set<string> tags;
+    string language;
+    int64_t net_rshares;
+    asset author_reward;
+    asset benefactor_reward;
+    asset curator_reward;
+    std::vector<vote_info> votes;
+    std::vector<reblog_info> reblogs;
+};
+
+struct transfer_info {
+    OBJECT_CTOR(transfer_info);
+
+    name from;
+    name to;
+    asset quantity;
+    string memo;
+};
+
+struct pin_info {
+    OBJECT_CTOR(pin_info);
+
+    name pinner;
+    name pinning;
+};
+
+struct block_info {
+    OBJECT_CTOR(block_info);
+
+    name blocker;
+    name blocking;
+};
+
 } } // cyberway::genesis
+
+FC_REFLECT(cyberway::genesis::vote_info, (voter)(weight)(time))
+FC_REFLECT(cyberway::genesis::reblog_info, (account)(title)(body)(time))
+FC_REFLECT(cyberway::genesis::comment_info, (parent_author)(parent_permlink)(author)(permlink)(title)(body)
+        (tags)(language)(net_rshares)(author_reward)(benefactor_reward)(curator_reward)(votes)(reblogs))
+FC_REFLECT(cyberway::genesis::transfer_info, (from)(to)(quantity)(memo))
+FC_REFLECT(cyberway::genesis::pin_info, (pinner)(pinning))
+FC_REFLECT(cyberway::genesis::block_info, (blocker)(blocking))

--- a/programs/create-genesis-ee/genesis_ee_builder.hpp
+++ b/programs/create-genesis-ee/genesis_ee_builder.hpp
@@ -37,7 +37,7 @@ private:
     void process_follows();
 
     void build_votes(std::vector<vote_info>& votes, uint64_t msg_hash, operation_number msg_created);
-    void build_reblogs(std::vector<reblog_info>& reblogsi, uint64_t msg_hash, operation_number msg_created, bfs::ifstream& dump_reblogs);
+    void build_reblogs(std::vector<reblog_info>& reblogs, uint64_t msg_hash, operation_number msg_created, bfs::ifstream& dump_reblogs);
     void build_messages();
     void build_transfers();
     void build_pinblocks();

--- a/programs/create-genesis-ee/genesis_ee_builder.hpp
+++ b/programs/create-genesis-ee/genesis_ee_builder.hpp
@@ -25,8 +25,8 @@ public:
     void read_operation_dump(const bfs::path& in_dump_dir);
     void build(const bfs::path& out_dir);
 private:
-    golos_dump_header read_header(bfs::fstream& in);
-    bool read_op_header(bfs::fstream& in, operation_header& op);
+    golos_dump_header read_header(bfs::ifstream& in);
+    bool read_op_header(bfs::ifstream& in, operation_header& op);
 
     void process_comments();
     void process_delete_comments();
@@ -36,8 +36,8 @@ private:
     void process_delete_reblogs();
     void process_follows();
 
-    variants build_votes(uint64_t msg_hash, operation_number msg_created);
-    variants build_reblogs(uint64_t msg_hash, operation_number msg_created, bfs::fstream& dump_reblogs);
+    void build_votes(std::vector<vote_info>& votes, uint64_t msg_hash, operation_number msg_created);
+    void build_reblogs(std::vector<reblog_info>& reblogsi, uint64_t msg_hash, operation_number msg_created, bfs::ifstream& dump_reblogs);
     void build_messages();
     void build_transfers();
     void build_pinblocks();

--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -524,7 +524,7 @@ struct genesis_create::genesis_create_impl final {
 
         // add usernames
         db.start_section(config::system_account_name, N(domain), "domain_object", 1);
-        ee_genesis.usernames.start_section(config::system_account_name, N(domain), "domain_info", 1);
+        ee_genesis.usernames.start_section(config::system_account_name, N(domain), "domain_info");
         const auto app = gls_issuer_account_name;
         db.emplace<domain_object>([&](auto& a) {
             a.owner = app;
@@ -539,7 +539,7 @@ struct genesis_create::genesis_create_impl final {
         );
 
         db.start_section(config::system_account_name, N(username), "username_object", _visitor.auths.size());
-        ee_genesis.usernames.start_section(config::system_account_name, N(username), "username_info", _visitor.auths.size());
+        ee_genesis.usernames.start_section(config::system_account_name, N(username), "username_info");
         for (const auto& auth : _visitor.auths) {                // loop through auths to preserve names order
             const auto& n = auth.account.value(_accs_map);
             db.emplace<username_object>([&](auto& u) {
@@ -816,7 +816,7 @@ struct genesis_create::genesis_create_impl final {
         // token stats
         const auto n_stats = 2;
         db.start_section(config::token_account_name, N(stat), "currency_stats", n_stats);
-        ee_genesis.balances.start_section(config::token_account_name, N(currency), "currency_stats", n_stats);
+        ee_genesis.balances.start_section(config::token_account_name, N(currency), "currency_stats");
 
         auto supply = gp.current_supply + golos_from_gbg;
         auto insert_stat_record = [&](const asset& supply, int64_t max_supply, name issuer) {
@@ -846,7 +846,7 @@ struct genesis_create::genesis_create_impl final {
         // funds
         const auto n_balances = 3 + 2*data.gbg.size();
         db.start_section(config::token_account_name, N(accounts), "account", n_balances);
-        ee_genesis.balances.start_section(config::token_account_name, N(balance), "balance_event", n_balances);
+        ee_genesis.balances.start_section(config::token_account_name, N(balance), "balance_event");
         auto insert_balance_record = [&](name account, const asset& balance, primary_key_t pk, name ram_payer) {
             auto record = mvo
                 ("balance", balance)


### PR DESCRIPTION
Resolves #626
Decrease time of execution `create-genesis-ee` from 45 minutes to 15.
Remove `count` argument from `start_section` (write actual rows count in `finish_section`).