### PR TITLE
Implement LRU cache strategy for replying mode. #630

### DIFF
--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -431,6 +431,11 @@ namespace cyberway { namespace chaindb {
             return object_at_cursor(current(request));
         }
 
+        void set_revision(revision_t revision) {
+            undo_.set_revision(revision);
+            cache_.set_revision(revision);
+        }
+
         chaindb_session start_undo_session(bool enabled) {
             auto revision = undo_.start_undo_session(enabled);
             if (enabled) {
@@ -942,7 +947,7 @@ namespace cyberway { namespace chaindb {
     }
 
     void chaindb_controller::set_revision(revision_t revision) const {
-        return impl_->undo_.set_revision(revision);
+        return impl_->set_revision(revision);
     }
 
     chaindb_session chaindb_controller::start_undo_session(bool enabled) const {

--- a/libraries/chain/include/cyberway/chaindb/cache_map.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_map.hpp
@@ -23,6 +23,7 @@ namespace cyberway { namespace chaindb {
         void set_revision(const object_value&, revision_t) const;
 
         uint64_t calc_ram_bytes(revision_t) const;
+        void set_revision(revision_t) const;
         void start_session(revision_t) const;
         void push_session(revision_t) const;
         void squash_session(revision_t) const;


### PR DESCRIPTION
Resolve #630.

The special case for system transactions which should be reverted on fail on replaying.
For them new undo session is started (independent on skip-undo-sessions for replaying irreversible blocks).
Such sessions should be squashed to absent block on success, and undo on fail.