### PR TITLE
Import recovery account as multisig with wait #470,#471

### DIFF
--- a/libraries/chain/include/cyberway/genesis/genesis_generate_name.hpp
+++ b/libraries/chain/include/cyberway/genesis/genesis_generate_name.hpp
@@ -5,6 +5,7 @@
 namespace cyberway { namespace genesis {
 
 inline eosio::chain::name generate_name(std::string txt) {
+    if (txt.length() == 0) return name();
     auto hash = fc::sha1::hash(txt);    // can implement something faster like MurmurHash3, but sha1 looks enough
     uint64_t data = ((uint64_t*)(hash.data()))[0];
     uint64_t r = 0;

--- a/programs/create-genesis/config.hpp
+++ b/programs/create-genesis/config.hpp
@@ -19,6 +19,7 @@ constexpr auto VESTS = SY(6,GOLOS);                 // Golos dApp vesting
 constexpr auto posting_auth_name = "posting";
 constexpr auto golos_domain_name = "golos";
 
+constexpr auto owner_recovery_wait_seconds = 60*60*24*30;
 constexpr auto withdraw_interval_seconds = 60*60*24*7;
 constexpr auto withdraw_intervals = 13;
 


### PR DESCRIPTION
+ Put recovery account to owner authority.accounts with wait for 30 days. Rules:
    + set owner auth threshold to 2
    + put recovery_account with weight 1 to authority.accounts
    + put wait with weight 1 delayed to 30 days
    + only do this for accounts, which have all the following true:
        1. have non-empty recovery_account
        2. have threshold = 1
        3. have empty owner auth accounts
+ fixed `generate_name()` to return `name()` if empty string passed
