### PR TITLE
hotfix freezing the get_account in the get_core_liquid_balance function

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -420,7 +420,7 @@ fc::optional<eosio::chain::asset> chain_api_plugin_impl::get_account_core_liquid
     auto accounts_it = db_controller.begin(request);
     const auto end_it = db_controller.end(request);
 
-    for (; accounts_it.pk != end_it.pk; ++accounts_it.pk) {
+    for (; accounts_it.pk != end_it.pk; accounts_it.pk = db_controller.next({token_code, accounts_it.cursor})) {
         const auto value = db_controller.value_at_cursor({token_code, accounts_it.cursor});
 
         const auto balance_object = value["balance"];


### PR DESCRIPTION
Fix iterating in API `get_account` and `get_core_liquid_balance`
