### PR TITLE
Add permissions, auth links, tables, config to genesis-info #633,#647,#650

### DIFF
--- a/programs/create-genesis/config.hpp
+++ b/programs/create-genesis/config.hpp
@@ -4,27 +4,14 @@
 
 namespace cyberway { namespace genesis {
 
-static constexpr uint64_t gls_issuer_account_name = N(gls.issuer);
-static constexpr uint64_t gls_ctrl_account_name = N(gls.ctrl);
-static constexpr uint64_t gls_vest_account_name = N(gls.vesting);
-static constexpr uint64_t gls_post_account_name = N(gls.publish);
-static constexpr uint64_t gls_social_account_name = N(gls.social);
-static constexpr uint64_t gls_charge_account_name = N(gls.charge);
-constexpr auto notify_account_name = gls_ctrl_account_name;
-
 constexpr auto GBG = SY(3,GBG);
 constexpr auto GLS = SY(3,GOLOS);
 constexpr auto GESTS = SY(6,GESTS);
 constexpr auto VESTS = SY(6,GOLOS);                 // Golos dApp vesting
 constexpr auto posting_auth_name = "posting";
-constexpr auto golos_domain_name = "golos";
 
-constexpr auto owner_recovery_wait_seconds = 60*60*24*30;
 constexpr auto withdraw_interval_seconds = 60*60*24*7;
 constexpr auto withdraw_intervals = 13;
-
-constexpr int64_t system_max_supply = 1'000'000'000ll * 10000;  // 4 digits precision
-constexpr int64_t golos_max_supply = 1'000'000'000ll * 1000;    // 3 digits precision
 
 constexpr int fixp_fract_digits = 12;
 

--- a/programs/create-genesis/genesis_info.hpp
+++ b/programs/create-genesis/genesis_info.hpp
@@ -1,8 +1,11 @@
 #pragma once
 #include "posting_rules.hpp"
 #include <eosio/chain/types.hpp>
+#include <eosio/chain/authority.hpp>
 #include <fc/reflect/reflect.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/classification.hpp>
 
 namespace cyberway { namespace genesis {
 
@@ -16,10 +19,53 @@ struct genesis_info {
         fc::sha256 hash;
     };
 
+    struct permission {
+        permission_name name;
+        fc::optional<permission_name> parent;   // defaults: "" for "owner" permission; "owner" for "active"; "active" for others
+        std::string key;                // can use "INITIAL"; only empty "key" can co-exist with non-empty "keys" and vice-versa
+        std::vector<string> keys;       // can use "INITIAL"
+        std::vector<string> accounts;   // can use "name@permission"
+
+        void init() {
+            if (key.length() > 0) {
+                keys.emplace_back(key);
+                key = "";
+            }
+        }
+
+        permission_name get_parent() const {
+            if (parent) {
+                return *parent;
+            }
+            return name == N(owner) ? N() : name == N(active) ? N(owner) : N(active);
+        }
+
+        std::vector<key_weight> key_weights(const public_key_type& initial_key) const {
+            std::vector<key_weight> r;
+            for (const auto& k: keys) {
+                r.emplace_back(key_weight{k == "INITIAL" ? initial_key : public_key_type(k), 1});
+            }
+            return r;
+        }
+        std::vector<permission_level_weight> perm_levels(account_name code) const {
+            std::vector<permission_level_weight> r;
+            for (const auto& a: accounts) {
+                std::vector<string> parts;
+                split(parts, a, boost::algorithm::is_any_of("@"));
+                auto acc = parts[0].size() == 0 ? code : account_name(parts[0]);
+                auto perm = account_name(parts.size() == 1 ? "" : parts[1].c_str());
+                r.emplace_back(permission_level_weight{permission_level{acc, perm}, 1});
+            }
+            return r;
+        }
+        authority make_authority(const public_key_type& initial_key, account_name code) const {
+            return authority(1, key_weights(initial_key), perm_levels(code));
+        }
+    };
+
     struct account {
         account_name name;
-        std::string owner_key;      // use string here to allow "INITIAL" keyword
-        std::string active_key;
+        std::vector<permission> permissions;
         fc::optional<file_hash> abi;
         fc::optional<file_hash> code;
     };
@@ -28,7 +74,65 @@ struct genesis_info {
     bfs::path genesis_json;
     std::vector<account> accounts;
 
+    struct auth_link {
+        using names_pair = std::pair<name,name>;
+        string permission;              // account@permission
+        std::vector<string> links;      // each link is "contract:action" or "contract:*" (simple "contract" also works)
+
+        names_pair get_permission() const {
+            std::vector<string> parts;
+            split(parts, permission, boost::algorithm::is_any_of("@"));
+            return names_pair{name(parts[0]), name(parts[1])};
+        }
+
+        std::vector<names_pair> get_links() const {
+            std::vector<names_pair> r;
+            for (const auto& l: links) {
+                std::vector<string> parts;
+                split(parts, l, boost::algorithm::is_any_of(":"));
+                name action{parts.size() > 1 ? string_to_name(parts[1].c_str()) : 0};
+                r.emplace_back(names_pair{name(parts[0]), action});
+            }
+            return r;
+        }
+    };
+    std::vector<auth_link> auth_links;
+
+    struct table {
+        struct row {
+            name scope;
+            name payer;
+            uint64_t pk;
+            variant data;
+        };
+        account_name code;
+        name table;
+        string abi_type;
+        std::vector<row> rows;
+    };
+    std::vector<table> tables;
+
     // parameters
+    struct golos_config {
+        std::string domain;
+
+        struct golos_names {
+            account_name issuer;
+            account_name control;
+            account_name vesting;
+            account_name posting;
+            account_name social;
+            account_name charge;
+        } names;
+
+        struct recovery_params {
+            uint32_t wait_days;
+        } recovery;
+
+        int64_t max_supply;
+        int64_t sys_max_supply;
+    } golos;
+
     struct stake_params {
         std::vector<uint8_t> max_proxies;
         int64_t payout_step_length;
@@ -50,9 +154,16 @@ struct genesis_info {
 }} // cyberway::genesis
 
 FC_REFLECT(cyberway::genesis::genesis_info::file_hash, (path)(hash))
-FC_REFLECT(cyberway::genesis::genesis_info::account, (name)(owner_key)(active_key)(abi)(code))
+FC_REFLECT(cyberway::genesis::genesis_info::permission, (name)(parent)(key)(keys)(accounts))
+FC_REFLECT(cyberway::genesis::genesis_info::account, (name)(permissions)(abi)(code))
+FC_REFLECT(cyberway::genesis::genesis_info::auth_link, (permission)(links))
+FC_REFLECT(cyberway::genesis::genesis_info::table::row, (scope)(payer)(pk)(data))
+FC_REFLECT(cyberway::genesis::genesis_info::table, (code)(table)(abi_type)(rows))
+FC_REFLECT(cyberway::genesis::genesis_info::golos_config::golos_names, (issuer)(control)(vesting)(posting)(social)(charge))
+FC_REFLECT(cyberway::genesis::genesis_info::golos_config::recovery_params, (wait_days))
+FC_REFLECT(cyberway::genesis::genesis_info::golos_config, (domain)(names)(recovery)(max_supply)(sys_max_supply))
 FC_REFLECT(cyberway::genesis::genesis_info::stake_params,
     (max_proxies)(payout_step_length)(payout_steps_num)(min_own_staked_for_election))
 FC_REFLECT(cyberway::genesis::genesis_info::hardfork_info, (version)(time))
 FC_REFLECT(cyberway::genesis::genesis_info::parameters, (stake)(posting_rules)(require_hardfork))
-FC_REFLECT(cyberway::genesis::genesis_info, (state_file)(genesis_json)(accounts)(params))
+FC_REFLECT(cyberway::genesis::genesis_info, (state_file)(genesis_json)(accounts)(auth_links)(tables)(golos)(params))

--- a/programs/create-genesis/serializer.hpp
+++ b/programs/create-genesis/serializer.hpp
@@ -23,7 +23,7 @@ const fc::microseconds abi_serializer_max_time = fc::seconds(10);
 
 enum class stored_contract_tables: int {
     domains,        usernames,
-    permissionlink,
+    permissionlink, sys_permissionlink,
     token_stats,    vesting_stats,
     token_balance,  vesting_balance,
     delegation,     rdelegation,
@@ -87,7 +87,8 @@ public:
 
     void prepare_serializers(const contracts_map& contracts) {
         abi_def abi;
-        abis[name()] = abi_serializer(eosio_contract_abi(abi), abi_serializer_max_time);
+        abis[name()] = abis[config::system_account_name] =
+            abi_serializer(eosio_contract_abi(abi), abi_serializer_max_time);
         for (const auto& c: contracts) {
             auto abi_bytes = c.second.abi;
             if (abi_bytes.size() > 0) {

--- a/programs/create-genesis/state_reader.hpp
+++ b/programs/create-genesis/state_reader.hpp
@@ -216,14 +216,14 @@ public:
         bfs::ifstream im(map_file);
 
         auto read_map = [&](char type, vector<string>& map) {
-            std::cout << " reading map of type " << type << "... ";
+            std::cout << " reading map of type " << type << "... " << std::flush;
             char t;
             uint32_t len;
             im >> t;
             im.read((char*)&len, sizeof(len));
             EOS_ASSERT(im, genesis_exception, "Unknown format of Genesis state map file.");
             EOS_ASSERT(t == type, genesis_exception, "Unexpected map type in Genesis state map file.");
-            std::cout << "count=" << len << "... ";
+            std::cout << "count=" << len << "... " << std::flush;
             while (im && len) {
                 string a;
                 std::getline(im, a, '\0');
@@ -258,7 +258,7 @@ public:
             if (!in)
                 break;
             auto type = t.type_id;
-            std::cout << "Reading " << t.records_count << " record(s) from table with id=" << type << std::endl;
+            std::cout << "Reading " << t.records_count << " record(s) from table with id=" << type << "." << std::flush;
             objects o;
             o.set_which(type);
             auto unpacker = fc::raw::unpack_static_variant<decltype(in)>(in);
@@ -267,7 +267,7 @@ public:
                 o.visit(unpacker);
                 o.visit(visitor);
             }
-            std::cout << "  done, " << i << " record(s) read." << std::endl;
+            std::cout << "  Done, " << i << " record(s) read." << std::endl;
         }
         std::cout << "Done reading Genesis state." << std::endl;
         in.close();


### PR DESCRIPTION
+ Most config parameters moved to `genesis_info.golos`
+ Accounts defined in genesis-info now support custom permissions
+ `auth_links` added to describe contracts/actions linked to permissions of account
+ `tables` added to insert custom tables rows in genesis
+ some logging improvements

***
Notes:
1. `account.permissions` should be ordered by hierarchy: permission should be created before using it as parent.
2. In most cases `account.permission.parent` can be omitted, default value (depending on permission name) will be used.
3. `golos.sys_max_supply` and `golos.max_supply` are integer parts of asset, there is no need to pre-multiply them by precision.
***
sample usage:
```json
{
    "accounts": [
        {
            "name": "gls",
            "permissions": [
                {"name": "owner", "key": "INITIAL"},
                {"name": "active", "key": "INITIAL", "accounts": ["gls.ctrl@cyber.code", "gls.emit@cyber.code"]},
                {"name": "issue", "keys": ["INITIAL", "GLS5a2eDuRETEg7uy8eHbiCqGZM3wnh2pLjiXrFduLWBKVZKCkB62"]},
                {"name": "witn.smajor", "key": "INITIAL"},
                {"name": "witn.major", "parent": "witn.smajor", "key": "INITIAL"},
                {"name": "witn.minor", "parent": "witn.major", "key": "INITIAL"}
            ]
        }
    ],
    "auth_links": [
        {
            "permission": "cyber@createuser",
            "links": ["cyber:newaccount", "cyber.token:open", "gls.vesting:open"]
        }, {
            "permission": "gls@issue",
            "links": ["cyber.token:issue", "cyber.token:transfer"]
        }
    ],
    "tables": [
        {
            "code": "",
            "table": "domain",
            "abi_type": "domain_object",
            "rows": [
                {"scope":"cyber", "payer": "cyber", "pk": 1, "data": {
                    "id": 1,
                    "owner": "zxcat",
                    "linked_to": "",
                    "creation_date": "2019-05-14T15:00:00.000",
                    "name": "zxcat"
                }}
            ]
        }
    ],
```