### PR TITLE
Add reputation to EE genesis #646

### DIFF
--- a/programs/create-genesis/event_engine_genesis.cpp
+++ b/programs/create-genesis/event_engine_genesis.cpp
@@ -25,7 +25,6 @@ static abi_def create_usernames_abi() {
     });
 
     return abi;
-
 }
 
 static abi_def create_balances_abi() {
@@ -51,12 +50,27 @@ static abi_def create_balances_abi() {
     return abi;
 }
 
+static abi_def create_reputations_abi() {
+    abi_def abi;
+    abi.version = ABI_VERSION;
+
+    abi.structs.emplace_back( struct_def {
+        "changereput_event", "", {
+            {"author", "name"},
+            {"reputation", "int64"},
+        }
+    });
+
+    return abi;
+}
+
 event_engine_genesis::event_engine_genesis() {}
 event_engine_genesis::~event_engine_genesis() {}
 
 void event_engine_genesis::start(const bfp::path& ee_directory, const fc::sha256& hash) {
     usernames.start(ee_directory / "usernames.dat", hash, create_usernames_abi());
     balances.start(ee_directory / "balances.dat", hash, create_balances_abi());
+    reputations.start(ee_directory / "reputations.dat", hash, create_reputations_abi());
 }
 
 void event_engine_genesis::finalize() {

--- a/programs/create-genesis/event_engine_genesis.cpp
+++ b/programs/create-genesis/event_engine_genesis.cpp
@@ -4,7 +4,7 @@ namespace cyberway { namespace genesis {
 
 #define ABI_VERSION "cyberway::abi/1.0"
 
-static abi_def create_usernames_abi() {
+static abi_def create_accounts_abi() {
     abi_def abi;
     abi.version = ABI_VERSION;
 
@@ -17,10 +17,11 @@ static abi_def create_usernames_abi() {
     });
 
     abi.structs.emplace_back( struct_def {
-        "username_info", "", {
+        "account_info", "", {
             {"creator", "name"},
             {"owner", "name"},
-            {"name", "string"}
+            {"name", "string"},
+            {"reputation", "int64"},
         }
     });
 
@@ -50,31 +51,16 @@ static abi_def create_balances_abi() {
     return abi;
 }
 
-static abi_def create_reputations_abi() {
-    abi_def abi;
-    abi.version = ABI_VERSION;
-
-    abi.structs.emplace_back( struct_def {
-        "changereput_event", "", {
-            {"author", "name"},
-            {"reputation", "int64"},
-        }
-    });
-
-    return abi;
-}
-
 event_engine_genesis::event_engine_genesis() {}
 event_engine_genesis::~event_engine_genesis() {}
 
 void event_engine_genesis::start(const bfp::path& ee_directory, const fc::sha256& hash) {
-    usernames.start(ee_directory / "usernames.dat", hash, create_usernames_abi());
+    accounts.start(ee_directory / "accounts.dat", hash, create_accounts_abi());
     balances.start(ee_directory / "balances.dat", hash, create_balances_abi());
-    reputations.start(ee_directory / "reputations.dat", hash, create_reputations_abi());
 }
 
 void event_engine_genesis::finalize() {
-    usernames.finalize();
+    accounts.finalize();
     balances.finalize();
 }
 

--- a/programs/create-genesis/event_engine_genesis.hpp
+++ b/programs/create-genesis/event_engine_genesis.hpp
@@ -20,9 +20,8 @@ public:
     ~event_engine_genesis();
 
 public:
-    ee_genesis_serializer usernames;
+    ee_genesis_serializer accounts;
     ee_genesis_serializer balances;
-    ee_genesis_serializer reputations;
 };
 
 

--- a/programs/create-genesis/event_engine_genesis.hpp
+++ b/programs/create-genesis/event_engine_genesis.hpp
@@ -22,6 +22,7 @@ public:
 public:
     ee_genesis_serializer usernames;
     ee_genesis_serializer balances;
+    ee_genesis_serializer reputations;
 };
 
 

--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -49,6 +49,8 @@ using mvo = mutable_variant_object;
 constexpr uint64_t accounts_tbl_start_id = 7;           // some accounts created natively by node, this value is starting autoincrement for tables
 constexpr uint64_t permissions_tbl_start_id = 17;       // Note: usage_id is id-1
 
+static constexpr uint64_t gls_social_account_name = N(gls.social);
+
 
 using eosio::chain::uint128_t;
 uint64_t to_fbase(uint64_t value)   { return value << fixp_fract_digits; }
@@ -347,6 +349,18 @@ struct genesis_create::genesis_create_impl final {
                 ("creator", app)
                 ("owner", n)
                 ("name", s)
+            );
+        }
+
+        ee_genesis.reputations.start_section(gls_social_account_name, N(changereput), "changereput_event");
+        for (auto& acc_pair : _visitor.accounts) {
+            auto& acc = acc_pair.second;
+            if (!acc.reputation || *acc.reputation == 0) {
+                continue;
+            }
+            ee_genesis.reputations.insert(mvo
+                ("author", name_by_acc(acc.name))
+                ("reputation", *acc.reputation)
             );
         }
 

--- a/programs/create-genesis/golos_objects.hpp
+++ b/programs/create-genesis/golos_objects.hpp
@@ -92,6 +92,7 @@ struct account_object {
     uint16_t referrer_interest_rate;
     time_point_sec referral_end_date;
     asset referral_break_fee;
+    fc::optional<share_type> reputation;
 };
 struct account_authority_object {
     id_type id;
@@ -420,7 +421,7 @@ FC_REFLECT(cyberway::golos::account_object,
     (benefaction_rewards)(curation_rewards)(delegation_rewards)(posting_rewards)
     (proxied_vsf_votes)(witnesses_voted_for)
     (last_post)
-    (referrer_account)(referrer_interest_rate)(referral_end_date)(referral_break_fee)
+    (referrer_account)(referrer_interest_rate)(referral_end_date)(referral_break_fee)(reputation)
 )
 FC_REFLECT(cyberway::golos::account_authority_object, (id)(account)(owner)(active)(posting)(last_owner_update))
 FC_REFLECT(cyberway::golos::account_bandwidth_object,


### PR DESCRIPTION
Resolves #646 

`user_info` in EE genesis is refactored to `account_info` and contains `reputation` field.
`usernames.dat` is renamed to `accounts.dat`, and contains 2 sections - with `domain_info` and with `account_info`.