### PR TITLE
Filter scope on MongoDB-driver side. #659

### DIFF
--- a/libraries/chain/include/cyberway/chaindb/mongo_driver_utils.hpp
+++ b/libraries/chain/include/cyberway/chaindb/mongo_driver_utils.hpp
@@ -36,7 +36,8 @@ namespace cyberway { namespace chaindb {
     struct table_info;
     struct object_value;
 
-    using primary_key_t = uint64_t;
+    using primary_key_t  = uint64_t;
+    using account_name_t = uint64_t;
 
     namespace basic = bsoncxx::builder::basic;
     namespace types = bsoncxx::types;
@@ -49,6 +50,7 @@ namespace cyberway { namespace chaindb {
 
     basic::sub_document& build_document(basic::sub_document&, const object_value&);
     basic::sub_document& build_document(basic::sub_document&, const std::string&, const fc::variant&);
+    basic::sub_document& build_bound_document(basic::sub_document&, const std::string&, int);
     basic::sub_document& build_service_document(basic::sub_document&, const table_info&, const object_value&);
     basic::sub_document& build_undo_service_document(basic::sub_document&, const table_info&, const object_value&);
     basic::sub_document& build_find_pk_document(basic::sub_document&, const table_info&, const object_value&);
@@ -67,5 +69,6 @@ namespace cyberway { namespace chaindb {
     types::b_date to_date(const fc::time_point& date);
 
     primary_key_t get_pk_value(const table_info&, const bsoncxx::document::view&);
+    account_name_t get_scope_value(const table_info&, const bsoncxx::document::view&);
 
 }} // namespace cyberway::chaindb


### PR DESCRIPTION
Resolve #659:

Filtering of scope by MongoDB server is very slow operation for case of big tables, because if collection doesn't contain objects w/ `scope`, that is requires full-scan of the collection.
Alternative way is to use min/max operators of MongoDB and filter `scope` on nodeos-side. If the located object by min/max has other `scope`, the mongodb-driver interpret it as end-of-cursor.