### PR TITLE
GenesisEndMessage #649

### DIFF
--- a/libraries/chain/genesis/genesis_import.cpp
+++ b/libraries/chain/genesis/genesis_import.cpp
@@ -38,7 +38,8 @@ struct genesis_import::impl final {
     }
 
     storage_payer_info ram_payer_info(const sys_table_row& row) {
-        return resource_mng.get_storage_payer(row.ram_payer);
+        // TODO: Fix better. I am not yet fully investigated storage paying, it just fixes build
+        return resource_mng.get_storage_payer(0, row.ram_payer);
     };
 
     void import_state() {

--- a/plugins/event_engine_plugin/event_engine_plugin.cpp
+++ b/plugins/event_engine_plugin/event_engine_plugin.cpp
@@ -362,6 +362,7 @@ void event_engine_plugin::plugin_startup() {
        for(const auto& file: my->genesis_files) {
            my->send_genesis_file(file);
        }
+       my->send_message(GenesisEndMessage(BaseMessage::GenesisEnd));
    }
 }
 

--- a/plugins/event_engine_plugin/include/eosio/event_engine_plugin/messages.hpp
+++ b/plugins/event_engine_plugin/include/eosio/event_engine_plugin/messages.hpp
@@ -65,6 +65,7 @@ namespace eosio {
            ApplyTrx,
 
            GenesisData,
+           GenesisEnd,
        };
 
        MsgType msg_type;
@@ -84,6 +85,13 @@ namespace eosio {
        , code(code)
        , name(name)
        , data(data)
+       {}
+   };
+
+   struct GenesisEndMessage : public BaseMessage {
+
+       GenesisEndMessage(BaseMessage::MsgType msg_type)
+       : BaseMessage(msg_type)
        {}
    };
 
@@ -160,9 +168,10 @@ FC_REFLECT(eosio::ActionData, (receiver)(code)(action)(data)(args)(events))
 FC_REFLECT(eosio::TrxMetadata, (id)(accepted)(implicit)(scheduled))
 FC_REFLECT(eosio::TrxReceipt, (id)(status)(cpu_usage_us)(net_usage_words))
 
-FC_REFLECT_ENUM(eosio::BaseMessage::MsgType, (Unknown)(GenesisData)(AcceptBlock)(CommitBlock)(AcceptTrx)(ApplyTrx))
+FC_REFLECT_ENUM(eosio::BaseMessage::MsgType, (Unknown)(GenesisData)(GenesisEnd)(AcceptBlock)(CommitBlock)(AcceptTrx)(ApplyTrx))
 FC_REFLECT(eosio::BaseMessage, (msg_type))
 FC_REFLECT_DERIVED(eosio::GenesisDataMessage, (eosio::BaseMessage), (code)(name)(data))
+FC_REFLECT_DERIVED(eosio::GenesisEndMessage, (eosio::BaseMessage), )
 FC_REFLECT_DERIVED(eosio::BlockMessage, (eosio::BaseMessage), (id)(block_num)(block_time)(validated)(in_current_chain))
 FC_REFLECT_DERIVED(eosio::AcceptedBlockMessage, (eosio::BlockMessage), (trxs)(events))
 FC_REFLECT_DERIVED(eosio::AcceptTrxMessage, (eosio::BaseMessage)(eosio::TrxMetadata), )


### PR DESCRIPTION
Resolves #649 

Added separate message `GenesisEnd` which sending after all `GenesisData` messages.

Client pseudocode is:
```
function genesisData() {
    ...
}

function genesisEnd() {
    events['genesis_data'] = null;
    events['genesis_end'] = null;
    events['block'] = block;
}

function block() {
    ...
}

// entry point

events['genesis_data'] = genesisData;
events['genesis_end'] = genesisEnd;
```
