### PR TITLE
Update existing accounts from genesis #656 + fix payer

### DIFF
--- a/libraries/chain/genesis/genesis_import.cpp
+++ b/libraries/chain/genesis/genesis_import.cpp
@@ -42,6 +42,24 @@ struct genesis_import::impl final {
         return resource_mng.get_storage_payer(0, row.ram_payer);
     };
 
+    void update_account(const sys_table_row& r) {
+        // we need primary key for update, but it depends on table. add this hacky shortcut for accounts
+        primary_key_t pk = ((primary_key_t*)r.data.data())[1];
+        const name n(pk);
+        const auto& old = db.get<account_object,by_name>(n);  // vm_type/vm_version/privileged not set in genesis, copy
+        fc::datastream<const char*> ds(r.data.data(), r.data.size());
+        auto acc = account_object([&](auto& a){
+            fc::raw::unpack(ds, a);
+        }, 0);
+        db.modify(old, [&](auto& a) {
+            a.last_code_update = acc.last_code_update;
+            a.code_version = acc.code_version;
+            a.creation_date = acc.creation_date;
+            a.code = acc.code;
+            a.abi = acc.abi;
+        });
+    }
+
     void import_state() {
         // file existance already checked when calculated hash
         std::cout << "Reading state from " << _state_file << "..." << std::endl;
@@ -62,16 +80,21 @@ struct genesis_import::impl final {
                 " (type: " << t.abi_type << ")" << std::endl;
             int i = 0;
             if (t.code == config::system_account_name) {
+                bool is_accounts_tbl = t.name == N(account);
                 while (i++ < t.count) {
                     sys_table_row r;
                     fc::raw::unpack(in, r);
                     EOS_ASSERT(r.data.size() >= 8, extract_genesis_exception, "System table row is too small");
                     primary_key_t pk = ((primary_key_t*)r.data.data())[0]; // all system tables have pk in the 1st field
-                    db.insert(r.request(t.name), ram_payer_info(r), pk, r.data.data(), r.data.size());
+                    if (is_accounts_tbl && pk == primary_key_t(-1)) {
+                        update_account(r);
+                    } else {
+                        db.insert(r.request(t.name), ram_payer_info(r), pk, r.data.data(), r.data.size());
+                    }
                     apply_db_changes();
 
                     // need to directly add abi to chaindb if exists
-                    if (!abis_initialized && t.name == N(account)) {
+                    if (!abis_initialized && is_accounts_tbl) {
                         fc::datastream<const char*> ds(static_cast<const char*>(r.data.data()), r.data.size());
                         auto acc = sys_abi.binary_to_variant("account_object", ds, abi_serializer_max_time);
                         auto abi_bytes = acc["abi"].as<bytes>();
@@ -117,4 +140,4 @@ void genesis_import::import() {
 }
 
 
-}} // cyberway::gensis
+}} // cyberway::genesis

--- a/programs/create-genesis/genesis_create.hpp
+++ b/programs/create-genesis/genesis_create.hpp
@@ -13,6 +13,7 @@ using namespace eosio::chain;
 namespace bfs = boost::filesystem;
 
 struct contract_abicode {
+    bool update;
     bytes abi;
     bytes code;
     fc::sha256 code_hash;

--- a/programs/create-genesis/genesis_info.hpp
+++ b/programs/create-genesis/genesis_info.hpp
@@ -21,7 +21,7 @@ struct genesis_info {
 
     struct permission {
         permission_name name;
-        fc::optional<permission_name> parent;   // defaults: "" for "owner" permission; "owner" for "active"; "active" for others
+        fc::optional<permission_name> parent;   // defaults: "" for "owner" permission; "owner" for "active"; "active" for others; numeric id if adding permission to existing account
         std::string key;                // can use "INITIAL"; only empty "key" can co-exist with non-empty "keys" and vice-versa
         std::vector<string> keys;       // can use "INITIAL"
         std::vector<string> accounts;   // can use "name@permission"
@@ -65,6 +65,7 @@ struct genesis_info {
 
     struct account {
         account_name name;
+        fc::optional<bool> update;
         std::vector<permission> permissions;
         fc::optional<file_hash> abi;
         fc::optional<file_hash> code;
@@ -155,7 +156,7 @@ struct genesis_info {
 
 FC_REFLECT(cyberway::genesis::genesis_info::file_hash, (path)(hash))
 FC_REFLECT(cyberway::genesis::genesis_info::permission, (name)(parent)(key)(keys)(accounts))
-FC_REFLECT(cyberway::genesis::genesis_info::account, (name)(permissions)(abi)(code))
+FC_REFLECT(cyberway::genesis::genesis_info::account, (name)(update)(permissions)(abi)(code))
 FC_REFLECT(cyberway::genesis::genesis_info::auth_link, (permission)(links))
 FC_REFLECT(cyberway::genesis::genesis_info::table::row, (scope)(payer)(pk)(data))
 FC_REFLECT(cyberway::genesis::genesis_info::table, (code)(table)(abi_type)(rows))

--- a/programs/create-genesis/main.cpp
+++ b/programs/create-genesis/main.cpp
@@ -103,6 +103,7 @@ fc::sha256 check_hash(const genesis_info::file_hash& fh) {
 }
 
 void read_contract(const genesis_info::account& acc, contract_abicode& abicode) {
+    abicode.update = acc.update && *acc.update;
     if (acc.abi) {
         auto fh = *acc.abi;
         check_hash(fh);
@@ -149,10 +150,10 @@ void config_reader::read_config(const variables_map& options) {
 void config_reader::read_contracts() {
     ilog("Reading pre-configured accounts");
     for (const auto& acc: info.accounts) {
-        ilog("  ${a}...", ("a",acc.name));
+        std::cout << "  " << acc.name << " account..." << std::flush;
         auto& data = contracts[acc.name];
         read_contract(acc, data);
-        ilog("    done: abi size: ${a}, code size: ${c}.", ("a",data.abi.size())("c",data.code.size()));
+        std::cout << " done: abi size: " << data.abi.size() << ", code size: " << data.code.size() << "." << std::endl;
     }
 }
 

--- a/programs/create-genesis/serializer.hpp
+++ b/programs/create-genesis/serializer.hpp
@@ -128,9 +128,9 @@ public:
         to_variant(obj, v);
         fc::datastream<char*> ds(_buffer.data(), _buffer.size());
         ser.variant_to_binary(_section.abi_type, v, ds, abi_serializer_max_time);
-        sys_table_row record{{}, {_buffer.begin(), _buffer.begin() + ds.tellp()}};
+        sys_table_row record{ram_payer, {_buffer.begin(), _buffer.begin() + ds.tellp()}};
 #else
-        sys_table_row record{{}, fc::raw::pack(obj)};
+        sys_table_row record{ram_payer, fc::raw::pack(obj)};
 #endif
         fc::raw::pack(out, record);
         _row_count--;

--- a/programs/create-genesis/state_reader.hpp
+++ b/programs/create-genesis/state_reader.hpp
@@ -243,7 +243,7 @@ public:
         // TODO: checksum
         EOS_ASSERT(fc::is_regular_file(_state_file), genesis_exception,
             "Genesis state file '${f}' does not exist.", ("f", _state_file.generic_string()));
-        std::cout << "Reading state from " << _state_file << "..." << std::endl;
+        ilog("Reading state from ${f}...", ("f", _state_file.generic_string()));
         read_maps();
 
         bfs::ifstream in(_state_file);
@@ -269,7 +269,7 @@ public:
             }
             std::cout << "  Done, " << i << " record(s) read." << std::endl;
         }
-        std::cout << "Done reading Genesis state." << std::endl;
+        ilog("Done reading Genesis state.");
         in.close();
     }
 };


### PR DESCRIPTION
+ genesis-create and genesis_import can now update system accounts (abi/code)
+ genesis-create can now add permissions to existing system accounts
+ fix storing payer of system tables while generate genesis
+ unify logs
+ create-genesis prints hash as the last line of output (can be used by scripts)
***
To update existing account set `account.update: true` in genesis info. `abi` and `code` will be updated to given (if any), and new permissions can be added.
To add permission, put it into `account.permissions` and set `permission.parent` to integer id of the parent permission. create-genesis have no access to db, so it can't fetch id by name if parent permission doesn't exist in `permissions`.

Note: this PR doesn't allow to change existing account permissions, because there is too tricky id usage.

