### PR TITLE
 Refactor operation dump reading #683

### DIFF
--- a/programs/create-genesis-ee/genesis_ee_builder.cpp
+++ b/programs/create-genesis-ee/genesis_ee_builder.cpp
@@ -63,24 +63,24 @@ bool genesis_ee_builder::read_operation(bfs::ifstream& in, Operation& op) {
 void genesis_ee_builder::process_delete_comments() {
     std::cout << "-> Reading comment deletions..." << std::endl;
 
-    const auto& comment_index = maps_.get_index<comment_header_index, by_hash>();
+    const auto& comments = maps_.get_index<comment_header_index, by_hash>();
 
     bfs::ifstream in(in_dump_dir_ / "delete_comments");
     read_header(in);
 
     delete_comment_operation op;
     while (read_operation(in, op)) {
-        auto comment_itr = comment_index.find(op.hash);
-        if (comment_itr != comment_index.end()) {
-            maps_.modify(*comment_itr, [&](auto& comment) {
-                comment.last_delete_op = op.num;
+        auto comment = comments.find(op.hash);
+        if (comment != comments.end()) {
+            maps_.modify(*comment, [&](auto& c) {
+                c.last_delete_op = op.num;
             });
             continue;
         }
 
-        maps_.create<comment_header>([&](auto& comment) {
-            comment.hash = op.hash;
-            comment.last_delete_op = op.num;
+        maps_.create<comment_header>([&](auto& c) {
+            c.hash = op.hash;
+            c.last_delete_op = op.num;
         });
     }
 }
@@ -88,34 +88,34 @@ void genesis_ee_builder::process_delete_comments() {
 void genesis_ee_builder::process_comments() {
     std::cout << "-> Reading comments..." << std::endl;
 
-    const auto& comment_index = maps_.get_index<comment_header_index, by_hash>();
+    const auto& comments = maps_.get_index<comment_header_index, by_hash>();
 
     bfs::ifstream in(in_dump_dir_ / "comments");
     read_header(in);
 
     comment_operation op;
     while (read_operation(in, op)) {
-        auto comment_itr = comment_index.find(op.hash);
-        if (comment_itr != comment_index.end()) {
-            if (comment_itr->last_delete_op > op.num) {
+        auto comment = comments.find(op.hash);
+        if (comment != comments.end()) {
+            if (comment->last_delete_op > op.num) {
                 continue;
             }
 
-            maps_.modify(*comment_itr, [&](auto& comment) {
-                comment.offset = op.offset;
-                comment.create_op = op.num;
-                if (comment.created == fc::time_point_sec::min()) {
-                    comment.created = op.timestamp;
+            maps_.modify(*comment, [&](auto& c) {
+                c.offset = op.offset;
+                c.create_op = op.num;
+                if (c.created == fc::time_point_sec::min()) {
+                    c.created = op.timestamp;
                 }
             });
             continue;
         }
 
-        maps_.create<comment_header>([&](auto& comment) {
-            comment.hash = op.hash;
-            comment.offset = op.offset;
-            comment.create_op = op.num;
-            comment.created = op.timestamp;
+        maps_.create<comment_header>([&](auto& c) {
+            c.hash = op.hash;
+            c.offset = op.offset;
+            c.create_op = op.num;
+            c.created = op.timestamp;
         });
     }
 }
@@ -123,20 +123,20 @@ void genesis_ee_builder::process_comments() {
 void genesis_ee_builder::process_rewards() {
     std::cout << "-> Reading rewards..." << std::endl;
 
-    const auto& comment_index = maps_.get_index<comment_header_index, by_hash>();
+    const auto& comments = maps_.get_index<comment_header_index, by_hash>();
 
     bfs::ifstream in(in_dump_dir_ / "total_comment_rewards");
     read_header(in);
 
     total_comment_reward_operation op;
     while (read_operation(in, op)) {
-        auto comment_itr = comment_index.find(op.hash);
-        if (comment_itr != comment_index.end() && op.num > comment_itr->last_delete_op) {
-            maps_.modify(*comment_itr, [&](auto& comment) {
-                comment.author_reward += op.author_reward.get_amount();
-                comment.benefactor_reward += op.benefactor_reward.get_amount();
-                comment.curator_reward += op.curator_reward.get_amount();
-                comment.net_rshares = op.net_rshares;
+        auto comment = comments.find(op.hash);
+        if (comment != comments.end() && op.num > comment->last_delete_op) {
+            maps_.modify(*comment, [&](auto& c) {
+                c.author_reward += op.author_reward.get_amount();
+                c.benefactor_reward += op.benefactor_reward.get_amount();
+                c.curator_reward += op.curator_reward.get_amount();
+                c.net_rshares = op.net_rshares;
             });
         }
     }
@@ -145,31 +145,31 @@ void genesis_ee_builder::process_rewards() {
 void genesis_ee_builder::process_votes() {
     std::cout << "-> Reading votes..." << std::endl;
 
-    const auto& vote_index = maps_.get_index<vote_header_index, by_hash_voter>();
+    const auto& votes = maps_.get_index<vote_header_index, by_hash_voter>();
 
     bfs::ifstream in(in_dump_dir_ / "votes");
     read_header(in);
 
     vote_operation op;
     while (read_operation(in, op)) {
-        auto vote_itr = vote_index.find(std::make_tuple(op.hash, op.voter));
-        if (vote_itr != vote_index.end()) {
-            maps_.modify(*vote_itr, [&](auto& vote) {
-                vote.op_num = op.num;
-                vote.weight = op.weight;
-                vote.rshares = op.rshares;
-                vote.timestamp = op.timestamp;
+        auto vote = votes.find(std::make_tuple(op.hash, op.voter));
+        if (vote != votes.end()) {
+            maps_.modify(*vote, [&](auto& v) {
+                v.op_num = op.num;
+                v.weight = op.weight;
+                v.rshares = op.rshares;
+                v.timestamp = op.timestamp;
             });
             continue;
         }
 
-        maps_.create<vote_header>([&](auto& vote) {
-            vote.hash = op.hash;
-            vote.voter = op.voter;
-            vote.op_num = op.num;
-            vote.weight = op.weight;
-            vote.rshares = op.rshares;
-            vote.timestamp = op.timestamp;
+        maps_.create<vote_header>([&](auto& v) {
+            v.hash = op.hash;
+            v.voter = op.voter;
+            v.op_num = op.num;
+            v.weight = op.weight;
+            v.rshares = op.rshares;
+            v.timestamp = op.timestamp;
         });
     }
 }
@@ -177,27 +177,27 @@ void genesis_ee_builder::process_votes() {
 void genesis_ee_builder::process_reblogs() {
     std::cout << "-> Reading reblogs..." << std::endl;
 
-    const auto& reblog_index = maps_.get_index<reblog_header_index, by_hash_account>();
+    const auto& reblogs = maps_.get_index<reblog_header_index, by_hash_account>();
 
     bfs::ifstream in(in_dump_dir_ / "reblogs");
     read_header(in);
 
     reblog_operation op;
     while (read_operation(in, op)) {
-        auto reblog_itr = reblog_index.find(std::make_tuple(op.hash, op.account));
-        if (reblog_itr != reblog_index.end()) {
-            maps_.modify(*reblog_itr, [&](auto& reblog) {
-                reblog.op_num = op.num;
-                reblog.offset = op.offset;
+        auto reblog = reblogs.find(std::make_tuple(op.hash, op.account));
+        if (reblog != reblogs.end()) {
+            maps_.modify(*reblog, [&](auto& r) {
+                r.op_num = op.num;
+                r.offset = op.offset;
             });
             continue;
         }
 
-        maps_.create<reblog_header>([&](auto& reblog) {
-            reblog.hash = op.hash;
-            reblog.account = op.account;
-            reblog.op_num = op.num;
-            reblog.offset = op.offset;
+        maps_.create<reblog_header>([&](auto& r) {
+            r.hash = op.hash;
+            r.account = op.account;
+            r.op_num = op.num;
+            r.offset = op.offset;
         });
     }
 }
@@ -205,16 +205,16 @@ void genesis_ee_builder::process_reblogs() {
 void genesis_ee_builder::process_delete_reblogs() {
     std::cout << "-> Reading delete reblogs..." << std::endl;
 
-    const auto& reblog_index = maps_.get_index<reblog_header_index, by_hash_account>();
+    const auto& reblogs = maps_.get_index<reblog_header_index, by_hash_account>();
 
     bfs::ifstream in(in_dump_dir_ / "delete_reblogs");
     read_header(in);
 
     delete_reblog_operation op;
     while (read_operation(in, op)) {
-        auto reblog_itr = reblog_index.find(std::make_tuple(op.hash, op.account));
-        if (op.num > reblog_itr->op_num) {
-            maps_.remove(*reblog_itr);
+        auto reblog = reblogs.find(std::make_tuple(op.hash, op.account));
+        if (op.num > reblog->op_num) {
+            maps_.remove(*reblog);
         }
     }
 }
@@ -222,7 +222,7 @@ void genesis_ee_builder::process_delete_reblogs() {
 void genesis_ee_builder::process_follows() {
     std::cout << "-> Reading follows..." << std::endl;
 
-    const auto& follow_index = maps_.get_index<follow_header_index, by_pair>();
+    const auto& follows = maps_.get_index<follow_header_index, by_pair>();
 
     bfs::ifstream in(in_dump_dir_ / "follows");
     read_header(in);
@@ -234,15 +234,15 @@ void genesis_ee_builder::process_follows() {
             ignores = true;
         }
 
-        auto follow_itr = follow_index.find(std::make_tuple(op.follower, op.following));
-        if (follow_itr != follow_index.end()) {
+        auto follow = follows.find(std::make_tuple(op.follower, op.following));
+        if (follow != follows.end()) {
             if (op.what == 0) {
-                maps_.remove(*follow_itr);
+                maps_.remove(*follow);
                 continue;
             }
 
-            maps_.modify(*follow_itr, [&](auto& follow) {
-                follow.ignores = ignores;
+            maps_.modify(*follow, [&](auto& f) {
+                f.ignores = ignores;
             });
             continue;
         }
@@ -251,10 +251,10 @@ void genesis_ee_builder::process_follows() {
             continue;
         }
 
-        maps_.create<follow_header>([&](auto& follow) {
-            follow.follower = op.follower;
-            follow.following = op.following;
-            follow.ignores = ignores;
+        maps_.create<follow_header>([&](auto& f) {
+            f.follower = op.follower;
+            f.following = op.following;
+            f.ignores = ignores;
         });
     }
 }
@@ -273,21 +273,22 @@ void genesis_ee_builder::read_operation_dump(const bfs::path& in_dump_dir) {
     process_follows();
 }
 
-
 void genesis_ee_builder::build_votes(std::vector<vote_info>& votes, uint64_t msg_hash, operation_number msg_created) {
-    const auto& vote_index = maps_.get_index<vote_header_index, by_hash_voter>();
+    const auto& vote_idx = maps_.get_index<vote_header_index, by_hash_voter>();
 
-    auto vote_itr = vote_index.lower_bound(msg_hash);
-    for (; vote_itr != vote_index.end() && vote_itr->hash == msg_hash; ++vote_itr) {
-        if (vote_itr->op_num < msg_created) {
+    auto vote_itr = vote_idx.lower_bound(msg_hash);
+    for (; vote_itr != vote_idx.end() && vote_itr->hash == msg_hash; ++vote_itr) {
+        auto& vote = *vote_itr;
+
+        if (vote.op_num < msg_created) {
             continue;
         }
 
         votes.emplace_back([&](auto& v) {
-            v.voter = generate_name(vote_itr->voter);
-            v.weight = vote_itr->weight;
-            v.time = vote_itr->timestamp;
-            v.rshares = vote_itr->rshares;
+            v.voter = generate_name(vote.voter);
+            v.weight = vote.weight;
+            v.time = vote.timestamp;
+            v.rshares = vote.rshares;
         }, 0);
 
         std::sort(votes.begin(), votes.end(), [&](const auto& a, const auto& b) {
@@ -301,22 +302,23 @@ void genesis_ee_builder::build_reblogs(std::vector<reblog_info>& reblogs, uint64
 
     auto reblog_itr = reblog_idx.lower_bound(msg_hash);
     for (; reblog_itr != reblog_idx.end() && reblog_itr->hash == msg_hash; ++reblog_itr) {
-        if (reblog_itr->op_num < msg_created) {
+        auto& reblog = *reblog_itr;
+
+        if (reblog.op_num < msg_created) {
             continue;
         }
 
-        dump_reblogs.seekg(reblog_itr->offset);
+        dump_reblogs.seekg(reblog.offset);
         reblog_operation op;
         read_operation(dump_reblogs, op);
 
         reblogs.emplace_back([&](auto& r) {
-            r.account = generate_name(reblog_itr->account);
+            r.account = generate_name(reblog.account);
             r.title = op.title;
             r.body = op.body;
             r.time = op.timestamp;
         }, 0);
     }
-
 }
 
 void genesis_ee_builder::build_messages() {
@@ -327,11 +329,13 @@ void genesis_ee_builder::build_messages() {
     bfs::ifstream dump_comments(in_dump_dir_ / "comments");
     bfs::ifstream dump_reblogs(in_dump_dir_ / "reblogs");
 
-    const auto& comment_index = maps_.get_index<comment_header_index, by_created>();
+    const auto& comment_idx = maps_.get_index<comment_header_index, by_created>();
 
-    auto comment_itr = comment_index.upper_bound(fc::time_point_sec::min());
-    for (; comment_itr != comment_index.end(); ++comment_itr) {
-        dump_comments.seekg(comment_itr->offset);
+    auto comment_itr = comment_idx.upper_bound(fc::time_point_sec::min());
+    for (; comment_itr != comment_idx.end(); ++comment_itr) {
+        auto& comment = *comment_itr;
+
+        dump_comments.seekg(comment.offset);
         comment_operation op;
         read_operation(dump_comments, op);
 
@@ -340,17 +344,17 @@ void genesis_ee_builder::build_messages() {
             c.parent_permlink = op.parent_permlink;
             c.author = generate_name(op.author);
             c.permlink = op.permlink;
-            c.created = comment_itr->created;
             c.title = op.title;
             c.body = op.body;
             c.tags = op.tags;
             c.language = op.language;
-            c.net_rshares = comment_itr->net_rshares;
-            c.author_reward = asset(comment_itr->author_reward, symbol(GLS));
-            c.benefactor_reward = asset(comment_itr->benefactor_reward, symbol(GLS));
-            c.curator_reward = asset(comment_itr->curator_reward, symbol(GLS));
-            build_votes(c.votes, comment_itr->hash, comment_itr->last_delete_op);
-            build_reblogs(c.reblogs, comment_itr->hash, comment_itr->last_delete_op, dump_reblogs);
+            c.created = comment.created;
+            c.net_rshares = comment.net_rshares;
+            c.author_reward = asset(comment.author_reward, symbol(GLS));
+            c.benefactor_reward = asset(comment.benefactor_reward, symbol(GLS));
+            c.curator_reward = asset(comment.curator_reward, symbol(GLS));
+            build_votes(c.votes, comment.hash, comment.last_delete_op);
+            build_reblogs(c.reblogs, comment.hash, comment.last_delete_op, dump_reblogs);
         });
     }
 }

--- a/programs/create-genesis-ee/genesis_ee_builder.hpp
+++ b/programs/create-genesis-ee/genesis_ee_builder.hpp
@@ -11,8 +11,8 @@
 
 namespace cyberway { namespace genesis {
 
+using namespace cyberway::golos;
 namespace bfs = boost::filesystem;
-using mvo = fc::mutable_variant_object;
 
 FC_DECLARE_EXCEPTION(genesis_exception, 9000000, "genesis create exception");
 
@@ -26,7 +26,8 @@ public:
     void build(const bfs::path& out_dir);
 private:
     golos_dump_header read_header(bfs::ifstream& in);
-    bool read_op_header(bfs::ifstream& in, operation_header& op);
+    template<typename Operation>
+    bool read_operation(bfs::ifstream& in, Operation& op);
 
     void process_delete_comments();
     void process_comments();

--- a/programs/create-genesis-ee/golos_dump_container.hpp
+++ b/programs/create-genesis-ee/golos_dump_container.hpp
@@ -4,7 +4,7 @@
 #include <utility>
 #include <fc/reflect/reflect.hpp>
 
-namespace cyberway { namespace genesis {
+namespace cyberway { namespace golos {
 
 struct golos_dump_header {
     char magic[13] = "";
@@ -16,11 +16,23 @@ struct golos_dump_header {
 
 using operation_number = std::pair<uint32_t, uint16_t>;
 
-struct operation_header {
-	operation_number num;
-	uint64_t hash = 0;
+struct operation {
+    operation_number num;
+    uint64_t offset = 0; // Do not reflect
 };
 
-} } // cyberway::genesis
+struct hashed_operation : operation {
+    uint64_t hash = 0;
+};
 
-FC_REFLECT(cyberway::genesis::operation_header, (num)(hash))
+} } // cyberway::golos
+
+FC_REFLECT(cyberway::golos::operation, (num))
+
+FC_REFLECT_DERIVED(cyberway::golos::hashed_operation, (cyberway::golos::operation),(hash))
+
+#define REFLECT_OP(OP, FIELDS) \
+	FC_REFLECT_DERIVED(OP, (cyberway::golos::operation), FIELDS)
+
+#define REFLECT_OP_HASHED(OP, FIELDS) \
+	FC_REFLECT_DERIVED(OP, (cyberway::golos::hashed_operation), FIELDS)

--- a/programs/create-genesis-ee/golos_operations.hpp
+++ b/programs/create-genesis-ee/golos_operations.hpp
@@ -4,7 +4,7 @@
 
 namespace cyberway { namespace golos {
 
-struct comment_operation {
+struct comment_operation : hashed_operation {
     account_name_type parent_author;
     string parent_permlink;
 
@@ -18,7 +18,10 @@ struct comment_operation {
     fc::time_point_sec timestamp;
 };
 
-struct vote_operation {
+struct delete_comment_operation : hashed_operation {
+};
+
+struct vote_operation : hashed_operation {
     account_name_type voter;
     account_name_type author;
     string permlink;
@@ -27,7 +30,7 @@ struct vote_operation {
     fc::time_point_sec timestamp;
 };
 
-struct reblog_operation {
+struct reblog_operation : hashed_operation {
     account_name_type account;
     account_name_type author;
     string permlink;
@@ -36,11 +39,11 @@ struct reblog_operation {
     fc::time_point_sec timestamp;
 };
 
-struct delete_reblog_operation {
+struct delete_reblog_operation : hashed_operation {
     account_name_type account;
 };
 
-struct transfer_operation {
+struct transfer_operation : operation {
     account_name_type from;
     /// Account to transfer asset to
     account_name_type to;
@@ -59,13 +62,13 @@ enum follow_type {
     ignore
 };
 
-struct follow_operation {
+struct follow_operation : hashed_operation {
     account_name_type follower;
     account_name_type following;
     uint16_t what;
 };
 
-struct author_reward_operation {
+struct author_reward_operation : hashed_operation {
     account_name_type author;
     string permlink;
     asset sbd_payout;
@@ -73,27 +76,27 @@ struct author_reward_operation {
     asset vesting_payout;
 };
 
-struct comment_benefactor_reward_operation {
+struct comment_benefactor_reward_operation : hashed_operation {
     account_name_type benefactor;
     account_name_type author;
     string permlink;
     asset reward;
 };
 
-struct curation_reward_operation {
+struct curation_reward_operation : hashed_operation {
     account_name_type curator;
     asset reward;
     account_name_type comment_author;
     string comment_permlink;
 };
 
-struct auction_window_reward_operation {
+struct auction_window_reward_operation : hashed_operation {
     asset reward;
     account_name_type comment_author;
     string comment_permlink;
 };
 
-struct total_comment_reward_operation {
+struct total_comment_reward_operation : hashed_operation {
     account_name_type author;
     string permlink;
     asset author_reward;
@@ -104,16 +107,26 @@ struct total_comment_reward_operation {
 
 } } // cyberway::golos
 
-FC_REFLECT(cyberway::golos::comment_operation, (parent_author)(parent_permlink)(author)(permlink)(title)(body)(tags)(language)(timestamp))
-FC_REFLECT(cyberway::golos::vote_operation, (voter)(author)(permlink)(weight)(rshares)(timestamp))
-FC_REFLECT(cyberway::golos::reblog_operation, (account)(author)(permlink)(title)(body)(timestamp))
-FC_REFLECT(cyberway::golos::delete_reblog_operation, (account))
-FC_REFLECT(cyberway::golos::transfer_operation, (from)(to)(amount)(memo)(timestamp))
-FC_REFLECT(cyberway::golos::follow_operation, (follower)(following)(what))
+REFLECT_OP_HASHED(cyberway::golos::comment_operation, (parent_author)(parent_permlink)(author)(permlink)(title)(body)(tags)(language)(timestamp))
 
-FC_REFLECT(cyberway::golos::author_reward_operation, (author)(permlink)(sbd_payout)(steem_payout)(vesting_payout))
-FC_REFLECT(cyberway::golos::curation_reward_operation, (curator)(reward)(comment_author)(comment_permlink))
-FC_REFLECT(cyberway::golos::auction_window_reward_operation, (reward)(comment_author)(comment_permlink))
-FC_REFLECT(cyberway::golos::comment_benefactor_reward_operation, (benefactor)(author)(permlink)(reward))
-FC_REFLECT(cyberway::golos::total_comment_reward_operation, (author)(permlink)(author_reward)(benefactor_reward)(curator_reward)
-    (net_rshares))
+REFLECT_OP_HASHED(cyberway::golos::delete_comment_operation, )
+
+REFLECT_OP_HASHED(cyberway::golos::vote_operation, (voter)(author)(permlink)(weight)(rshares)(timestamp))
+
+REFLECT_OP_HASHED(cyberway::golos::reblog_operation, (account)(author)(permlink)(title)(body)(timestamp))
+
+REFLECT_OP_HASHED(cyberway::golos::delete_reblog_operation, (account))
+
+REFLECT_OP(cyberway::golos::transfer_operation, (from)(to)(amount)(memo)(timestamp))
+
+REFLECT_OP_HASHED(cyberway::golos::follow_operation, (follower)(following)(what))
+
+REFLECT_OP_HASHED(cyberway::golos::author_reward_operation, (author)(permlink)(sbd_payout)(steem_payout)(vesting_payout))
+
+REFLECT_OP_HASHED(cyberway::golos::curation_reward_operation, (curator)(reward)(comment_author)(comment_permlink))
+
+REFLECT_OP_HASHED(cyberway::golos::auction_window_reward_operation, (reward)(comment_author)(comment_permlink))
+
+REFLECT_OP_HASHED(cyberway::golos::comment_benefactor_reward_operation, (benefactor)(author)(permlink)(reward))
+
+REFLECT_OP_HASHED(cyberway::golos::total_comment_reward_operation, (author)(permlink)(author_reward)(benefactor_reward)(curator_reward)(net_rshares))


### PR DESCRIPTION
Resolves #683:

Updates `create-genesis-ee` to support operation dump after this: https://github.com/GolosChain/golos/pull/1301

Refactors some things:
- Don't read header of each entity separately, read entities as single whole
- `chainbase.create/modify` lambdas - only 1 letter in variable name
- Don't use `_itr` postfix where not iterating
- Miscs