### PR TITLE
Typed scope for chaindb tables. #114

### DIFF
--- a/CMakeModules/ChaindbMongo.cmake
+++ b/CMakeModules/ChaindbMongo.cmake
@@ -36,7 +36,11 @@ if (BUILD_CYBERWAY_CHAINDB_MONGO)
         set(CHAINDB_DEFS ${CHAINDB_DEFS} CYBERWAY_CHAINDB=1 ${LIBMONGOCXX_STATIC_DEFINITIONS} ${LIBBSONCXX_STATIC_DEFINITIONS})
         set(CHAINDB_INCS ${CHAINDB_INCS} ${BSON_INCLUDE_DIRS} ${LIBMONGOCXX_STATIC_INCLUDE_DIRS} ${LIBBSONCXX_STATIC_INCLUDE_DIRS})
         set(CHAINDB_LIBS ${CHAINDB_LIBS} ${CHAINDB_LIBMONGOCXX} ${CHAINDB_LIBBSONCXX} ${BSON_LIBRARIES})
-        set(CHAINDB_SRCS ${CHAINDB_SRCS} chaindb/mongo_driver.cpp chaindb/mongo_driver_utils.cpp chaindb/mongo_bigint_converter.cpp)
+        set(CHAINDB_SRCS ${CHAINDB_SRCS}
+            chaindb/mongo_driver.cpp
+            chaindb/mongo_driver_utils.cpp
+            chaindb/mongo_bigint_converter.cpp
+            chaindb/mongo_asset_converter.cpp)
 
     else()
         message("Could NOT find MongoDB. chaindb with MongoDB support will not be included.")

--- a/contracts/eosio.token/eosio.token.abi
+++ b/contracts/eosio.token/eosio.token.abi
@@ -62,7 +62,7 @@
       "indexes": [{
           "name": "primary",
           "unique": "true",
-          "orders": [{"field": "balance.sym", "order": "asc"}]
+          "orders": [{"field": "balance._sym", "order": "asc"}]
         }
       ]
 
@@ -72,7 +72,7 @@
       "indexes": [{
           "name": "primary",
           "unique": "true",
-          "orders": [{"field": "supply.sym", "order": "asc"}]
+          "orders": [{"field": "supply._sym", "order": "asc"}]
         }
       ]
     }

--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library( eosio_chain
              chaindb/journal.cpp
              chaindb/abi_info.cpp
              chaindb/storage_calculator.cpp
+             chaindb/typed_name.cpp
 
              cyberway/domain_name.cpp
              cyberway/cyberway_contract.cpp

--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -102,8 +102,8 @@ namespace eosio { namespace chain {
       built_in_types.emplace("asset",                     pack_unpack<asset_info>());
    }
 
-   void abi_serializer::disable_check_field_name() {
-       check_field_name_ = false;
+   void abi_serializer::set_check_field_name(const bool value) {
+       check_field_name_ = value;
    }
 
    void abi_serializer::set_abi(const abi_def& abi, const fc::microseconds& max_serialization_time) {

--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -51,7 +51,7 @@ namespace eosio { namespace chain {
    }
 
    abi_serializer::abi_serializer( const abi_def& abi, const fc::microseconds& max_serialization_time ) {
-      configure_built_in_types();
+      configure_built_in_types(PublicMode);
       set_abi(abi, max_serialization_time);
    }
 
@@ -60,7 +60,7 @@ namespace eosio { namespace chain {
       built_in_types[name] = std::move( unpack_pack );
    }
 
-   void abi_serializer::configure_built_in_types() {
+   void abi_serializer::configure_built_in_types(mode m) {
 
       built_in_types.emplace("bool",                      pack_unpack<bool>());
       built_in_types.emplace("int8",                      pack_unpack<int8_t>());
@@ -97,9 +97,24 @@ namespace eosio { namespace chain {
       built_in_types.emplace("public_key",                pack_unpack<public_key_type>());
       built_in_types.emplace("signature",                 pack_unpack<signature_type>());
 
-      built_in_types.emplace("symbol",                    pack_unpack<symbol_info>());
       built_in_types.emplace("symbol_code",               pack_unpack<symbol_code>());
-      built_in_types.emplace("asset",                     pack_unpack<asset_info>());
+
+      switch (m) {
+         default:
+            assert(false);
+
+         case PublicMode: {
+            built_in_types.emplace("symbol",              pack_unpack<symbol>());
+            built_in_types.emplace("asset",               pack_unpack<asset>());
+         }
+         break;
+
+         case DBMode: {
+            built_in_types.emplace("symbol",              pack_unpack<symbol_info>());
+            built_in_types.emplace("asset",               pack_unpack<asset_info>());
+         }
+         break;
+      }
    }
 
    void abi_serializer::set_check_field_name(const bool value) {

--- a/libraries/chain/chaindb/abi_info.cpp
+++ b/libraries/chain/chaindb/abi_info.cpp
@@ -200,12 +200,16 @@ namespace cyberway { namespace chaindb {
 
             auto& k = p.orders.front();
             CYBERWAY_ASSERT(
-                k.type == "int64" || k.type == "uint64" ||
-                k.type == "name"  ||
-                k.type == "symbol_code" || k.type == "symbol",
+                primary_key::is_valid_kind(k.type),
                 invalid_primary_key_exception,
                 "The field ${field} of the table ${table} is declared as primary and it should has type: "
                 "int64, uint64, name, symbol_code or symbol",
+                ("field", k.field)("table", get_table_name(table)));
+
+            CYBERWAY_ASSERT(
+                scope_name::is_valid_kind(table.scope_type),
+                invalid_scope_name_exception,
+                "Scope type should has type: int64, uint64, name, symbol_code or symbol",
                 ("field", k.field)("table", get_table_name(table)));
         }
     }; // struct index_builder

--- a/libraries/chain/chaindb/abi_info.cpp
+++ b/libraries/chain/chaindb/abi_info.cpp
@@ -199,10 +199,13 @@ namespace cyberway { namespace chaindb {
                 ("table", get_table_name(table))("index", get_index_name(p)));
 
             auto& k = p.orders.front();
-            CYBERWAY_ASSERT(k.type == "int64" || k.type == "uint64" || k.type == "name" || k.type == "symbol_code",
+            CYBERWAY_ASSERT(
+                k.type == "int64" || k.type == "uint64" ||
+                k.type == "name"  ||
+                k.type == "symbol_code" || k.type == "symbol",
                 invalid_primary_key_exception,
-                "The field ${field} of the table ${table} is declared as primary "
-                "and it should has type int64, uint64, name or symbol_code",
+                "The field ${field} of the table ${table} is declared as primary and it should has type: "
+                "int64, uint64, name, symbol_code or symbol",
                 ("field", k.field)("table", get_table_name(table)));
         }
     }; // struct index_builder

--- a/libraries/chain/chaindb/abi_info.cpp
+++ b/libraries/chain/chaindb/abi_info.cpp
@@ -223,7 +223,8 @@ namespace cyberway { namespace chaindb {
     const fc::microseconds abi_info::max_abi_time_ = fc::seconds(60);
 
     abi_info::abi_info(const account_name& code, abi_def abi)
-    : code_(code) {
+    : code_(code),
+      serializer_(eosio::chain::abi_serializer::DBMode) {
         if (is_system_code(code)) {
             serializer_.set_check_field_name(false);
         }

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -738,6 +738,9 @@ namespace cyberway { namespace chaindb {
 
         void add_lru_object(cache_object_ptr obj_ptr) {
             assert(obj_ptr);
+            if (lru_cell_list_.empty()) {
+                set_revision(-1);
+            }
             auto& lru = lru_cell_list_.back();
             add_ram_usage(lru, obj_ptr->service().size);
             lru.emplace(std::move(obj_ptr));

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -192,6 +192,10 @@ namespace cyberway { namespace chaindb {
             return current(driver_.cursor(request));
         }
 
+        table_info table_by_request(const table_request& request) {
+            return get_table(request);
+        }
+
         const cursor_info& lower_bound(const index_request& request, const char* key, const size_t size) {
             auto  index  = get_index(request);
             auto  value  = index.abi->to_object(index, key, size);
@@ -819,6 +823,10 @@ namespace cyberway { namespace chaindb {
 
     variant chaindb_controller::value_at_cursor(const cursor_request& request) const {
         return impl_->object_at_cursor(request).value;
+    }
+
+    table_info chaindb_controller::table_by_request(const table_request& request) const {
+        return impl_->table_by_request(request);
     }
 
     index_info chaindb_controller::index_at_cursor(const cursor_request& request) const {

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -821,6 +821,10 @@ namespace cyberway { namespace chaindb {
         return impl_->object_at_cursor(request).value;
     }
 
+    index_info chaindb_controller::index_at_cursor(const cursor_request& request) const {
+        return impl_->current(request).index;
+    }
+
     object_value chaindb_controller::object_at_cursor(const cursor_request& request) const {
         return impl_->object_at_cursor(request);
     }

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -290,7 +290,7 @@ namespace cyberway { namespace chaindb {
 
             auto item = cache_.find(cursor.index, cursor.pk);
             if (BOOST_UNLIKELY(!item)) {
-                auto obj = object_at_cursor(cursor);
+                auto obj = object_at_cursor(cursor, false);
                 if (!obj.is_null()) {
                     item = cache_.emplace(cursor.index, std::move(obj));
                 }
@@ -390,8 +390,8 @@ namespace cyberway { namespace chaindb {
             return object_by_pk(table, pk);
         }
 
-        object_value object_at_cursor(const cursor_request& request) {
-            return object_at_cursor(current(request));
+        object_value object_at_cursor(const cursor_request& request, const bool with_decors) {
+            return object_at_cursor(current(request), with_decors);
         }
 
         void set_revision(revision_t revision) {
@@ -426,8 +426,8 @@ namespace cyberway { namespace chaindb {
         }
 
     private:
-        object_value object_at_cursor(const cursor_info& cursor) {
-            auto obj = driver_.object_at_cursor(cursor);
+        object_value object_at_cursor(const cursor_info& cursor, const bool with_decors) {
+            auto obj = driver_.object_at_cursor(cursor, with_decors);
             validate_object(cursor.index, obj, cursor.pk);
             return obj;
         }
@@ -502,7 +502,7 @@ namespace cyberway { namespace chaindb {
             if (abi_cursor.pk == primary_key::End) {
                 return {};
             }
-            return object_at_cursor({N(), abi_cursor.id}).value["abi"].as_blob().data;
+            return object_at_cursor({N(), abi_cursor.id}, false).value["abi"].as_blob().data;
         }
 
         static abi_def bytes_to_abi(const std::vector<char>& abi_bytes) {
@@ -822,7 +822,7 @@ namespace cyberway { namespace chaindb {
     }
 
     variant chaindb_controller::value_at_cursor(const cursor_request& request) const {
-        return impl_->object_at_cursor(request).value;
+        return impl_->object_at_cursor(request, false).value;
     }
 
     table_info chaindb_controller::table_by_request(const table_request& request) const {
@@ -834,7 +834,7 @@ namespace cyberway { namespace chaindb {
     }
 
     object_value chaindb_controller::object_at_cursor(const cursor_request& request) const {
-        return impl_->object_at_cursor(request);
+        return impl_->object_at_cursor(request, true);
     }
 
     revision_t chaindb_controller::revision() const {

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -80,39 +80,6 @@ namespace cyberway { namespace chaindb {
                 "Invalid type ${type} of ChainDB connection", ("type", type));
         }
 
-        variant get_pk_value(const table_info& table, const primary_key_t pk) {
-            auto& pk_order = *table.pk_order;
-
-            variant value;
-            switch (pk_order.type.front()) {
-                case 'i': // int64
-                    value = variant(static_cast<int64_t>(pk));
-                    break;
-                case 'u': // uint64
-                    value = variant(pk);
-                    break;
-                case 'n': // name
-                    value = variant(name(pk).to_string());
-                    break;
-                case 's':
-                    if (is_symbol_type(pk_order.type)) { // symbol
-                        value = variant(symbol_info(symbol(pk)));
-                    } else {                             // symbol_code
-                        value = variant(symbol(pk << 8).name());
-                    }
-                    break;
-                default:
-                    CYBERWAY_ASSERT(false, invalid_primary_key_exception,
-                        "Invalid type ${type} of the primary key for the table ${table}",
-                        ("type", pk_order.type)("table", get_full_table_name(table)));
-            }
-
-            for (auto itr = pk_order.path.rbegin(), etr = pk_order.path.rend(); etr != itr; ++itr) {
-                value = variant(mutable_variant_object(*itr, value));
-            }
-            return value;
-        }
-
     } } // namespace _detail
 
     //------------------------------------
@@ -215,7 +182,7 @@ namespace cyberway { namespace chaindb {
         }
 
         const cursor_info& current(const cursor_info& cursor) const {
-            if (unset_primary_key == cursor.pk) {
+            if (primary_key::Unset == cursor.pk) {
                 driver_.current(cursor);
             }
             return cursor;
@@ -243,7 +210,7 @@ namespace cyberway { namespace chaindb {
 
         const cursor_info& lower_bound(const table_request& request, const primary_key_t pk) {
             auto  index  = get_pk_index(request);
-            auto  value  = _detail::get_pk_value(index, pk);
+            auto  value  = primary_key::to_variant(index, pk);
             auto  cache  = cache_.find(index, pk);
             auto& cursor = driver_.lower_bound(std::move(index), std::move(value));
 
@@ -268,7 +235,7 @@ namespace cyberway { namespace chaindb {
 
         const cursor_info& upper_bound(const table_request& request, const primary_key_t pk) {
             auto index = get_pk_index(request);
-            auto value = _detail::get_pk_value(index, pk);
+            auto value = primary_key::to_variant(index, pk);
             return current(driver_.upper_bound(std::move(index), std::move(value)));
         }
 
@@ -313,7 +280,7 @@ namespace cyberway { namespace chaindb {
         cache_object_ptr get_cache_object(const cursor_request& req, const bool with_blob) {
             auto& cursor = current(req);
 
-            CYBERWAY_ASSERT(end_primary_key != cursor.pk, driver_absent_object_exception,
+            CYBERWAY_ASSERT(primary_key::End != cursor.pk, driver_absent_object_exception,
                 "Requesting object from the end of the table ${table}",
                 ("table", get_full_table_name(cursor.index)));
 
@@ -528,7 +495,7 @@ namespace cyberway { namespace chaindb {
             index_request request{N(), N(), N(account), N(name)};
             const auto abi_cursor = lower_bound(request, fc::mutable_variant_object()("name", abi_code));
 
-            if (abi_cursor.pk == end_primary_key) {
+            if (abi_cursor.pk == primary_key::End) {
                 return {};
             }
             return object_at_cursor({N(), abi_cursor.id}).value["abi"].as_blob().data;
@@ -566,97 +533,8 @@ namespace cyberway { namespace chaindb {
             return obj;
         }
 
-        void validate_pk_field(const table_info& table, const variant& row, const primary_key_t pk) const try {
-            CYBERWAY_ASSERT(pk != unset_primary_key && pk != end_primary_key, primary_key_exception,
-                "Value ${pk} can't be used as primary key in the row ${row} "
-                "from the table ${table} for the scope '${scope}'",
-                ("pk", pk)("row", row)("table", get_full_table_name(table))("scope", get_scope_name(table)));
-
-            auto& pk_order = *table.pk_order;
-            const variant* value = &row;
-            for (auto& key: pk_order.path) {
-                CYBERWAY_ASSERT(value->is_object(), primary_key_exception,
-                    "The part ${key} in the primary key is not an object in the row ${row}"
-                    "from the table ${table} for the scope '${scope}'",
-                    ("key", key)("row", row)("table", get_full_table_name(table))("scope", get_scope_name(table)));
-
-                auto& object = value->get_object();
-                auto itr = object.find(key);
-                CYBERWAY_ASSERT(object.end() != itr, primary_key_exception,
-                    "Can't find the part ${key} for the primary key in the row ${row} "
-                    "from the table ${table} for the scope '${scope}'",
-                    ("key", key)("row", row)("table", get_full_table_name(table))("scope", get_scope_name(table)));
-
-                value = &(*itr).value();
-            }
-
-            auto type = value->get_type();
-
-            auto validate_type = [&](const bool test) {
-                CYBERWAY_ASSERT(test, primary_key_exception,
-                    "Wrong value type '${type}' for the primary key in the row ${row} "
-                    "from the table ${table} for the scope '${scope}'",
-                    ("type", type)("row", row)("table", get_full_table_name(table))("scope", get_scope_name(table)));
-            };
-
-            auto validate_value = [&](const bool test) {
-                CYBERWAY_ASSERT(test, primary_key_exception,
-                    "Wrong value ${pk} != ${value} for the primary key in the row ${row}"
-                    "from the table ${table} for the scope '${scope}'",
-                    ("pk", pk)("value", *value)
-                    ("type", type)("row", row)("table", get_full_table_name(table))("scope", get_scope_name(table)));
-            };
-
-            switch(pk_order.type.front()) {
-                case 'i': { // int64
-                    validate_type(variant::type_id::int64_type == type);
-                    validate_value(value->as_uint64() == pk);
-                    break;
-                }
-                case 'u': { // uint64
-                    validate_type(variant::type_id::uint64_type == type);
-                    validate_value(value->as_uint64() == pk);
-                    break;
-                }
-                case 'n': { // name
-                    validate_type(variant::type_id::string_type == type);
-                    validate_value(name(value->as_string()).value == pk);
-                    break;
-                }
-                case 's': {
-                    if (is_symbol_type(pk_order.type)) { // symbol
-                        validate_type(variant::type_id::object_type == type);
-
-                        auto& decs = (*value)[names::decs_part_name.c_str()];
-                        type = decs.get_type();
-                        validate_type(variant::type_id::uint64_type == type);
-                        validate_value(decs.as_uint64() <= symbol::max_precision);
-
-                        auto& sym  = (*value)[names::sym_part_name.c_str()];
-                        type = sym.get_type();
-                        validate_type(variant::type_id::string_type == type);
-
-                        validate_value(symbol(decs.as_uint64(), sym.get_string().c_str()).value() == pk);
-                    } else {                             // symbol_code
-                        validate_type(variant::type_id::string_type == type);
-                        validate_value(symbol(0, value->as_string().c_str()).to_symbol_code() == pk);
-                    }
-                    break;
-                }
-                default:
-                    validate_type(false);
-            }
-        } catch (const primary_key_exception&) {
-            throw;
-        } catch (...) {
-            CYBERWAY_ASSERT(false, primary_key_exception,
-                "Wrong value of the primary key in the row ${row} "
-                "from the table ${table} for the scope '${scope}'",
-                ("row", row)("table", get_full_table_name(table))("scope", get_scope_name(table)));
-        }
-
         void validate_object(const table_info& table, const object_value& obj, const primary_key_t pk) const {
-            if (end_primary_key == obj.pk()) {
+            if (primary_key::End == obj.pk()) {
                 CYBERWAY_ASSERT(obj.is_null(), driver_wrong_object_exception,
                     "Driver returns the row '${obj}' from the table ${table} instead of null for end iterator",
                     ("obj", obj.value)("table", get_full_table_name(table)));
@@ -668,13 +546,11 @@ namespace cyberway { namespace chaindb {
                 ("obj", obj.value)("table", get_full_table_name(table)));
             auto& value = obj.value.get_object();
 
-            if (pk == end_primary_key && obj.service.pk == pk) return;
+            if (pk == primary_key::End && obj.service.pk == pk) return;
 
             CYBERWAY_ASSERT(value.end() == value.find(names::service_field), reserved_field_exception,
-                "Object has the reserved field ${field} for the table ${table} for the scope '${scope}'",
-                ("field", names::service_field)("table", get_full_table_name(table))("scope", get_scope_name(table)));
-
-            validate_pk_field(table, obj.value, pk);
+                "Object has the reserved field ${field} for the table ${table}",
+                ("field", names::service_field)("table", get_full_table_name(table)));
         }
 
         abi_map::iterator set_abi(const account_name& code, abi_info info) {

--- a/libraries/chain/chaindb/journal.cpp
+++ b/libraries/chain/chaindb/journal.cpp
@@ -30,7 +30,7 @@ namespace cyberway { namespace chaindb {
                 case write_operation::Insert:
                 case write_operation::Update:
                 case write_operation::Revision:
-                    CYBERWAY_ASSERT(false, driver_write_exception, "Wrong state on insert");
+                    CYBERWAY_THROW(driver_write_exception, "Wrong state on insert");
             }
         }
 
@@ -46,7 +46,7 @@ namespace cyberway { namespace chaindb {
                     break;
 
                 case write_operation::Remove:
-                    CYBERWAY_ASSERT(false, driver_write_exception, "Wrong state on update_revision");
+                    CYBERWAY_THROW(driver_write_exception, "Wrong state on update_revision");
             }
         }
 
@@ -62,7 +62,7 @@ namespace cyberway { namespace chaindb {
                     break;
 
                 case write_operation::Remove:
-                    CYBERWAY_ASSERT(false, driver_write_exception, "Wrong state on update");
+                    CYBERWAY_THROW(driver_write_exception, "Wrong state on update");
             }
         }
 
@@ -81,7 +81,7 @@ namespace cyberway { namespace chaindb {
                     break;
 
                 case write_operation::Remove:
-                    CYBERWAY_ASSERT(false, driver_write_exception, "Wrong state on delete");
+                    CYBERWAY_THROW(driver_write_exception, "Wrong state on delete");
             }
         }
 
@@ -141,10 +141,8 @@ namespace cyberway { namespace chaindb {
         auto& info = ctx.info(data.object.pk());
         _detail::write(std::move(data), info.data);
     } FC_CAPTURE_LOG_AND_RETHROW(
-        (get_full_table_name(data.object.service))
-        (get_scope_name(data.object.service))(data.object.service.pk)
+        (data.object.service)
     )
-
 
     void journal::write_data(const table_info& table, write_operation data) {
         auto ctx = create_ctx(table);
@@ -166,8 +164,7 @@ namespace cyberway { namespace chaindb {
             _detail::write(std::move(undo), itr->second);
         }
     } FC_CAPTURE_LOG_AND_RETHROW(
-        (get_full_table_name(undo.object.service))
-        (get_scope_name(undo.object.service))(undo.object.service.pk)
+        (undo.object.service)
     )
 
     void journal::write(write_ctx& ctx, write_operation data, write_operation undo) {

--- a/libraries/chain/chaindb/mongo_asset_converter.cpp
+++ b/libraries/chain/chaindb/mongo_asset_converter.cpp
@@ -1,0 +1,89 @@
+#include <bsoncxx/builder/basic/document.hpp>
+
+#include <fc/variant_object.hpp>
+
+#include <cyberway/chaindb/mongo_driver_utils.hpp>
+#include <cyberway/chaindb/mongo_asset_converter.hpp>
+#include <cyberway/chaindb/names.hpp>
+
+#include <eosio/chain/asset.hpp>
+
+namespace cyberway { namespace chaindb {
+
+    mongo_asset_converter::mongo_asset_converter(const bsoncxx::document::view& src) {
+        convert(src);
+    }
+
+    void mongo_asset_converter::convert(const bsoncxx::document::view& src) try {
+        auto tmp_kind   = Unknown;
+        auto amount_itr = src.begin();
+        auto decs_itr   = amount_itr;
+
+        if (!amount_itr->key().compare(names::amount_field)) {
+            tmp_kind = Asset;
+            ++decs_itr;
+        }
+
+        if (!decs_itr->key().compare(names::decs_field)) {
+            if (Unknown == tmp_kind) {
+                tmp_kind = Symbol;
+                amount_itr = src.end();
+            }
+        } else {
+            return; // !`amount` && !`decs`
+        }
+
+        auto sym_itr = decs_itr; ++sym_itr;
+        if (sym_itr->key().compare(names::sym_field)) {
+            return;
+        }
+
+        auto end_itr = sym_itr; ++end_itr;
+        if (end_itr != src.end()) {
+            return; // external fields
+        }
+
+        auto decs = from_decimal128(decs_itr->get_decimal128());
+        auto sym  = sym_itr->get_utf8().value.to_string();
+
+        switch (tmp_kind) {
+            case Asset: {
+                auto amount = amount_itr->get_int64().value;
+                convert_to_asset(amount, decs, sym);
+                break;
+            }
+
+            case Symbol:
+                convert_to_symbol(decs, sym);
+                break;
+
+            case Unknown:
+            default:
+                break;
+        }
+    } catch (...) {
+        // do nothing
+    }
+
+    fc::variant mongo_asset_converter::get_variant() const {
+        assert(is_valid_value());
+        return fc::variant(value_);
+    }
+
+    void mongo_asset_converter::convert_to_asset(const int64_t amount, const uint64_t decs, const string& sym) {
+        auto symbol_name  = std::to_string(decs).append(1, ',').append(sym);
+        auto symbol_value = eosio::chain::symbol::from_string(symbol_name);
+
+        value_ = eosio::chain::asset(amount, symbol_value).to_string();
+        kind_  = Asset;
+    }
+
+    void mongo_asset_converter::convert_to_symbol(const uint64_t decs, const string& sym) {
+        auto symbol_name  = std::to_string(decs).append(1, ',').append(sym);
+
+        eosio::chain::symbol::from_string(symbol_name);
+        value_ = std::move(symbol_name);
+        kind_  = Symbol;
+    }
+
+} } // namespace cyberway::chaindb

--- a/libraries/chain/chaindb/mongo_bigint_converter.cpp
+++ b/libraries/chain/chaindb/mongo_bigint_converter.cpp
@@ -15,8 +15,8 @@ namespace cyberway { namespace chaindb {
         constexpr size_t NUMBER_128_BLOB_SIZE   = sizeof(__int128) + 1;
     }
 
-    const std::string mongo_bigint_converter::BINARY_FIELD = "binary";
-    const std::string mongo_bigint_converter::STRING_FIELD = "string";
+    const std::string mongo_bigint_converter::BINARY_FIELD = "_binary";
+    const std::string mongo_bigint_converter::STRING_FIELD = "_string";
 
     mongo_bigint_converter::mongo_bigint_converter(const bsoncxx::document::view& document) {
         type_ = type::invalid;
@@ -30,6 +30,7 @@ namespace cyberway { namespace chaindb {
 
         auto end_itr = string_itr;
         ++end_itr;
+        if (end_itr != document.end()) return;
 
         parse_binary(cyberway::chaindb::build_blob_content(binary_itr->get_binary()));
     }

--- a/libraries/chain/chaindb/mongo_driver.cpp
+++ b/libraries/chain/chaindb/mongo_driver.cpp
@@ -230,7 +230,7 @@ namespace cyberway { namespace chaindb {
             return *this;
         }
 
-        const object_value& get_object_value() {
+        const object_value& get_object_value(bool with_decors = false) {
             lazy_open();
             if (!object_.value.is_null()) return object_;
 
@@ -242,7 +242,7 @@ namespace cyberway { namespace chaindb {
                 object_.service.table = index.table->name;
             } else {
                 auto& view = *source_->begin();
-                object_ = build_object(index, view);
+                object_ = build_object(index, view, with_decors);
                 pk      = object_.service.pk;
             }
 
@@ -664,7 +664,7 @@ namespace cyberway { namespace chaindb {
             auto doc = get_db_table(table).find_one(pk_doc.view());
 
             if (!!doc) {
-                return build_object(table, doc->view());
+                return build_object(table, doc->view(), false);
             } else {
                 obj.clear();
                 obj.service.pk    = primary_key::End;
@@ -982,9 +982,9 @@ namespace cyberway { namespace chaindb {
         return impl_->object_by_pk(table, pk);
     }
 
-    const object_value& mongodb_driver::object_at_cursor(const cursor_info& info) const {
+    const object_value& mongodb_driver::object_at_cursor(const cursor_info& info, bool with_decors) const {
         return impl_->get_applied_cursor(info)
-            .get_object_value();
+            .get_object_value(with_decors);
     }
 
 } } // namespace cyberway::chaindb

--- a/libraries/chain/chaindb/mongo_driver.cpp
+++ b/libraries/chain/chaindb/mongo_driver.cpp
@@ -108,13 +108,13 @@ namespace cyberway { namespace chaindb {
                     object = &itr->value().get_object();
                 }
             }
-            CYBERWAY_ASSERT(false, driver_absent_field_exception,
+            CYBERWAY_THROW(driver_absent_field_exception,
                 "Wrong logic on parsing of the field ${field} in the row ${row} from the table ${table}",
                 ("table", get_full_table_name(index))("field", order.field)("row", row));
         } catch (const driver_absent_field_exception&) {
             throw;
         } catch (...) {
-            CYBERWAY_ASSERT(false, driver_absent_field_exception,
+            CYBERWAY_THROW(driver_absent_field_exception,
                 "External database can't read the field ${field} in the row ${row} from the table ${table}",
                 ("field", order.field)("table", get_full_table_name(index))("row", row));
         }
@@ -141,7 +141,7 @@ namespace cyberway { namespace chaindb {
                 throw;
             }
 
-            CYBERWAY_ASSERT(false, driver_open_exception, "Fail to connect to MongoDB server");
+            CYBERWAY_THROW(driver_open_exception, "Fail to connect to MongoDB server");
         }
 
     } } // namespace _detail
@@ -215,7 +215,7 @@ namespace cyberway { namespace chaindb {
             if (direction::Forward == direction_) {
                 change_direction(direction::Backward);
                 lazy_open();
-            } else if (end_primary_key == pk) {
+            } else if (primary_key::End == pk) {
                 lazy_open();
             } else {
                 lazy_next();
@@ -224,7 +224,7 @@ namespace cyberway { namespace chaindb {
         }
 
         mongodb_cursor_info& current() {
-            if (unset_primary_key == pk) {
+            if (primary_key::Unset == pk) {
                 lazy_open();
             }
             return *this;
@@ -234,7 +234,7 @@ namespace cyberway { namespace chaindb {
             lazy_open();
             if (!object_.value.is_null()) return object_;
 
-            if (end_primary_key == get_pk_value()) {
+            if (primary_key::End == get_pk_value()) {
                 object_.clear();
                 object_.service.pk    = pk;
                 object_.service.code  = index.code;
@@ -257,7 +257,7 @@ namespace cyberway { namespace chaindb {
         collection    db_table_;
 
         direction     direction_ = direction::Forward;
-        primary_key_t find_pk_   = unset_primary_key;
+        primary_key_t find_pk_   = primary_key::Unset;
         variant       find_key_;
 
         std::unique_ptr<mongocxx::cursor> source_;
@@ -274,7 +274,7 @@ namespace cyberway { namespace chaindb {
         }
 
         void reset_object() {
-            pk = unset_primary_key;
+            pk = primary_key::Unset;
             if (!object_.is_null()) object_.clear();
         }
 
@@ -287,7 +287,7 @@ namespace cyberway { namespace chaindb {
                 find_object = &find_key_.get_object();
             }
 
-            bound.append(kvp(names::scope_path, get_scope_name(index)));
+            append_scope_value(bound, index);
 
             auto& orders = index.index->orders;
             for (auto& o: orders) {
@@ -300,7 +300,7 @@ namespace cyberway { namespace chaindb {
             }
 
             if (!index.index->unique) {
-                if (find_pk_ != end_primary_key && find_pk_ != unset_primary_key) {
+                if (primary_key::is_good(find_pk_)) {
                     append_pk_value(bound, index, find_pk_);
                 } else {
                     build_bound_document(bound, index.pk_order->field, order);
@@ -334,7 +334,7 @@ namespace cyberway { namespace chaindb {
             auto bound = create_bound_document();
             auto sort  = create_sort_document();
 
-            find_pk_ = unset_primary_key;
+            find_pk_ = primary_key::Unset;
 
             auto opts = options::find()
                 .hint(mongocxx::hint(db_name_to_string(index.index->name)))
@@ -353,7 +353,7 @@ namespace cyberway { namespace chaindb {
         }
 
         bool is_end() const {
-            return source_->begin() == source_->end() || scope_ != index.scope.value;
+            return source_->begin() == source_->end() || scope_ != index.scope;
         }
 
         void lazy_next() {
@@ -374,7 +374,7 @@ namespace cyberway { namespace chaindb {
         }
 
         primary_key_t get_pk_value() {
-            if (unset_primary_key == pk) {
+            if (primary_key::Unset == pk) {
                 init_pk_value();
             }
             return pk;
@@ -389,7 +389,7 @@ namespace cyberway { namespace chaindb {
 
         void init_pk_value() {
             if (is_end()) {
-                pk = end_primary_key;
+                pk = primary_key::End;
             } else {
                 pk = chaindb::get_pk_value(index, *source_->begin());
             }
@@ -667,7 +667,7 @@ namespace cyberway { namespace chaindb {
                 return build_object(table, doc->view());
             } else {
                 obj.clear();
-                obj.service.pk    = end_primary_key;
+                obj.service.pk    = primary_key::End;
                 obj.service.code  = table.code;
                 obj.service.scope = table.scope;
                 obj.service.table = table.table->name;
@@ -770,11 +770,11 @@ namespace cyberway { namespace chaindb {
             }
 
             void add_prepare_undo(const write_operation& op) {
-                append_bulk(build_find_undo_pk_document, build_undo_service_document, data_bulk_list_.front(), op);
+                append_bulk(build_find_undo_pk_document, build_undo_document, data_bulk_list_.front(), op);
             }
 
             void add_complete_undo(const write_operation& op) {
-                append_bulk(build_find_undo_pk_document, build_undo_service_document, *complete_undo_bulk_, op);
+                append_bulk(build_find_undo_pk_document, build_undo_document, *complete_undo_bulk_, op);
             }
 
             void write() {
@@ -817,11 +817,12 @@ namespace cyberway { namespace chaindb {
                         break;
 
                     case write_operation::Unknown:
-                        CYBERWAY_ASSERT(false, driver_write_exception,
-                            "Wrong operation type on writing into the table ${table} for the scope '${scope}"
+                        CYBERWAY_THROW(driver_write_exception,
+                            "Wrong operation type on writing into the table ${table}:${scope} "
                             "with the revision (find: ${find_rev}, set: ${set_rev}) and with the primary key ${pk}",
-                            ("table", get_full_table_name(*table_))("scope", get_scope_name(*table_))
-                            ("find_rev", op.find_revision)("set_rev", op.object.service.revision)("pk", op.object.pk()));
+                            ("table", get_full_table_name(*table_))("scope", table_->scope)
+                            ("find_rev", op.find_revision)("set_rev", op.object.service.revision)
+                            ("pk", op.object.pk()));
                         return;
                 }
 
@@ -916,7 +917,7 @@ namespace cyberway { namespace chaindb {
 
     cursor_info& mongodb_driver::lower_bound(index_info index, variant key) const {
         return impl_->create_cursor(std::move(index))
-            .open(direction::Forward, std::move(key), unset_primary_key);
+            .open(direction::Forward, std::move(key), primary_key::Unset);
     }
 
     cursor_info& mongodb_driver::upper_bound(index_info index, variant key) const {
@@ -927,7 +928,7 @@ namespace cyberway { namespace chaindb {
 
         auto& cursor = impl_->create_cursor(std::move(index))
             // 1. open at the max(), which exclude current value
-            .open(direction::Backward, key, unset_primary_key)
+            .open(direction::Backward, key, primary_key::Unset)
             // 2. return to the value which was excluded by max()
             .next();
 
@@ -946,12 +947,12 @@ namespace cyberway { namespace chaindb {
 
     cursor_info& mongodb_driver::begin(index_info index) const {
         return impl_->create_cursor(std::move(index))
-            .open(direction::Forward, {}, unset_primary_key);
+            .open(direction::Forward, {}, primary_key::Unset);
     }
 
     cursor_info& mongodb_driver::end(index_info index) const {
         return impl_->create_cursor(std::move(index))
-            .open(direction::Backward, {}, end_primary_key);
+            .open(direction::Backward, {}, primary_key::End);
     }
 
     cursor_info& mongodb_driver::cursor(const cursor_request& request) const {

--- a/libraries/chain/chaindb/mongo_fail_driver.cpp
+++ b/libraries/chain/chaindb/mongo_fail_driver.cpp
@@ -97,7 +97,7 @@ namespace cyberway { namespace chaindb {
         NOT_SUPPORTED;
     }
 
-    const object_value& mongodb_driver::object_at_cursor(const cursor_info&) const {
+    const object_value& mongodb_driver::object_at_cursor(const cursor_info&, bool ) const {
         NOT_SUPPORTED;
     }
 

--- a/libraries/chain/chaindb/mongo_fail_driver.cpp
+++ b/libraries/chain/chaindb/mongo_fail_driver.cpp
@@ -1,7 +1,7 @@
 #include <cyberway/chaindb/mongo_driver.hpp>
 #include <cyberway/chaindb/exception.hpp>
 
-#define NOT_SUPPORTED CYBERWAY_ASSERT(false, broken_driver_exception, "MongoDB driver is not supported")
+#define NOT_SUPPORTED CYBERWAY_THROW(broken_driver_exception, "MongoDB driver is not supported")
 
 namespace cyberway { namespace chaindb {
     struct mongodb_driver::mongodb_impl_ {

--- a/libraries/chain/chaindb/names.cpp
+++ b/libraries/chain/chaindb/names.cpp
@@ -58,12 +58,7 @@ namespace cyberway { namespace chaindb {
         return value;
     }
 
-    bool is_symbol_type(const type_name& type) {
-        static constexpr size_t symbol_len = sizeof("symbol") / sizeof("symbol"[0]) - 1;
-        return type.front() == 's' && type.size() == symbol_len;
-    }
-
-    // name can't contains _ that is why they are used for internal db and key names
+    // name can't start from _ that is why they are used for internal db and key names
 
     const string names::unknown          = "_UNKNOWN_";
 
@@ -77,6 +72,10 @@ namespace cyberway { namespace chaindb {
     const string names::table_field      = "table";
     const string names::scope_field      = "scope";
     const string names::pk_field         = "pk";
+
+    const string names::amount_field     = "_amount";
+    const string names::decs_field       = "_decs";
+    const string names::sym_field        = "_sym";
 
     const string names::next_pk_field    = "npk";
     const string names::undo_pk_field    = "upk";
@@ -99,6 +98,4 @@ namespace cyberway { namespace chaindb {
     const string names::asc_order        = "asc";
     const string names::desc_order       = "desc";
 
-    const string names::decs_part_name   = "decs";
-    const string names::sym_part_name    = "sym";
 } } // namespace cyberway::chaindb

--- a/libraries/chain/chaindb/names.cpp
+++ b/libraries/chain/chaindb/names.cpp
@@ -58,6 +58,11 @@ namespace cyberway { namespace chaindb {
         return value;
     }
 
+    bool is_symbol_type(const type_name& type) {
+        static constexpr size_t symbol_len = sizeof("symbol") / sizeof("symbol"[0]) - 1;
+        return type.front() == 's' && type.size() == symbol_len;
+    }
+
     // name can't contains _ that is why they are used for internal db and key names
 
     const string names::unknown          = "_UNKNOWN_";
@@ -93,4 +98,7 @@ namespace cyberway { namespace chaindb {
 
     const string names::asc_order        = "asc";
     const string names::desc_order       = "desc";
+
+    const string names::decs_part_name   = "decs";
+    const string names::sym_part_name    = "sym";
 } } // namespace cyberway::chaindb

--- a/libraries/chain/chaindb/storage_calculator.cpp
+++ b/libraries/chain/chaindb/storage_calculator.cpp
@@ -94,8 +94,10 @@ namespace cyberway { namespace chaindb {
             case variant::type_id::uint128_type:
                 return base_size + 32;
 
-            case variant::type_id::string_type:
-                return base_size + var.get_string().size();
+            case variant::type_id::string_type: {
+                auto size = base_size + var.get_string().size();
+                return ((size >> 4) + 1) << 4;
+            }
 
             case variant::type_id::blob_type:
                 return base_size + 2 * var.get_blob().data.size();

--- a/libraries/chain/chaindb/typed_name.cpp
+++ b/libraries/chain/chaindb/typed_name.cpp
@@ -1,0 +1,268 @@
+#include <cyberway/chaindb/typed_name.hpp>
+#include <cyberway/chaindb/exception.hpp>
+#include <cyberway/chaindb/common.hpp>
+#include <cyberway/chaindb/names.hpp>
+
+#include <eosio/chain/symbol.hpp>
+#include <eosio/chain/name.hpp>
+
+#include <assert.h>
+
+#define TYPED_ASSERT(expr, FORMAT, ...) CYBERWAY_ASSERT(expr, invalid_typed_name_exception, FORMAT, __VA_ARGS__)
+#define TYPED_THROW(FORMAT, ...) CYBERWAY_THROW(invalid_typed_name_exception, FORMAT, __VA_ARGS__)
+
+namespace cyberway { namespace chaindb {
+
+    using eosio::chain::name;
+    using eosio::chain::symbol;
+    using eosio::chain::symbol_info;
+
+    typed_name::typed_name(const typed_name::value_kind kind, const typed_name::value_type value)
+    : kind_(kind),
+      value_(value) {
+    }
+
+    typed_name typed_name::create(const typed_name::value_kind kind, const typed_name::value_type value) {
+        TYPED_ASSERT(is_valid(kind, value), "Invalid typed name");
+        return typed_name(kind, value);
+    }
+
+    typed_name::value_kind typed_name::kind_from_string(const string& kind) {
+        constexpr auto symbol_len = (sizeof("symbol") / sizeof(("symbol")[0])) - 1;
+
+        switch (kind.front()) {
+            case 'i':
+                assert(kind == "int64");
+                return Int64;
+
+            case 'u':
+                assert(kind == "uint64");
+                return Uint64;
+
+            case 'n':
+                assert(kind == "name");
+                return Name;
+
+            case 's':
+                if (kind.size() == symbol_len) {
+                    assert(kind == "symbol");
+                    return Symbol;
+                } else {
+                    assert(kind == "symbol_code");
+                    return SymbolCode;
+                }
+                break;
+
+            default:
+                break;
+        }
+
+        return Unknown;
+    }
+
+    typed_name typed_name::from_value(const value_kind) {
+        return create(Unknown, 0);
+    }
+
+    typed_name typed_name::from_value(const value_kind kind, const int64_t value) {
+        switch (kind) {
+            case Int64:
+                return create(kind, static_cast<value_type>(value));
+
+            case Uint64:
+            case Name:
+            case Symbol:
+            case SymbolCode:
+            case Unknown:
+            default:
+                break;
+        }
+
+        TYPED_THROW("Bad kind of typed name on initialize from int64");
+    }
+
+    typed_name typed_name::from_value(const value_kind kind, const uint64_t value) {
+        switch (kind) {
+            case Uint64:
+                return create(kind, value);
+
+            case Int64:
+            case Name:
+            case Symbol:
+            case SymbolCode:
+            case Unknown:
+            default:
+                break;
+        }
+
+        TYPED_THROW("Bad kind of typed name on initialize from uint64");
+    }
+
+    typed_name typed_name::from_value(const value_kind kind, const string& value) {
+        switch (kind) {
+            case Name:
+                return create(kind, name(value).value);
+
+            case SymbolCode:
+                return create(kind, symbol(0, value.c_str()).to_symbol_code());
+
+            case Symbol:
+                return create(kind, symbol::from_string(value).value());
+
+            case Int64:
+            case Uint64:
+            case Unknown:
+            default:
+                break;
+        }
+
+        TYPED_THROW("Bad kind of typed name on initialize from string");
+    }
+
+    bool typed_name::is_valid(const value_kind kind , const value_type value) {
+        switch (kind) {
+            case Int64:
+            case Uint64:
+            case Name:
+                return true; // all range
+
+            case Symbol:
+                return symbol(value).valid(); // 'A'-'Z' and precision
+
+            case SymbolCode:
+                return symbol(value << 8).valid(); // 'A'-'Z'
+
+            case Unknown:
+            default:
+                break;
+        }
+        return false;
+    }
+
+    bool typed_name::is_valid() const {
+       return is_valid(kind_, value_);
+    }
+
+    bool typed_name::is_valid_kind(const string& kind) {
+        return
+            kind == "int64" ||
+            kind == "uint64" ||
+            kind == "name"  ||
+            kind == "symbol_code" ||
+            kind == "symbol";
+    }
+
+    string typed_name::to_string() const {
+        switch (kind_) {
+            case Int64:
+                return std::to_string(static_cast<int64_t>(value_));
+
+            case Uint64:
+                return std::to_string(static_cast<uint64_t>(value_));
+
+            case Name:
+                return name(value_).to_string();
+
+            case Symbol:
+                return symbol(value_).to_string();
+
+            case SymbolCode:
+                return symbol(value_ << 8).name();
+
+            case Unknown:
+            default:
+                break;
+        }
+
+        TYPED_THROW("Invalid type of the typed name on converting to string");
+    }
+
+    variant typed_name::to_variant() const {
+        switch (kind_) {
+            case Int64:
+                return variant(static_cast<int64_t>(value_));
+
+            case Uint64:
+                return variant(value_);
+
+            case Name:
+                return variant(name(value_));
+
+            case Symbol:
+                return variant(symbol_info(value_));
+
+            case SymbolCode:
+                return variant(symbol(value_ << 8).name());
+
+            case Unknown:
+            default:
+                break;
+        }
+
+        CYBERWAY_THROW(invalid_typed_name_exception, "Invalid type of the typed name on converting to variant");
+    }
+
+    ///------------------------------------
+
+    primary_key::primary_key(typed_name&& src)
+    : typed_name(src.kind(), src.value()) {
+    }
+
+    typed_name::value_kind primary_key::kind_from_table(const table_info& info) {
+        assert(info.pk_order);
+        assert(!info.pk_order->path.empty());
+
+        return kind_from_string(info.pk_order->type);
+    }
+
+    primary_key primary_key::from_table(const table_info& info, const value_type value) {
+        assert(info.pk_order);
+        assert(!info.pk_order->type.empty());
+
+        return create(kind_from_string(info.pk_order->type), value);
+    }
+
+    variant primary_key::to_variant(const table_info& info) const {
+        assert(info.pk_order);
+        assert(!info.pk_order->path.empty());
+
+        auto& pk_path = info.pk_order->path;
+        auto  value   = typed_name::to_variant();
+
+        for (auto itr = pk_path.rbegin(), etr = pk_path.rend(); etr != itr; ++itr) {
+            value = variant(fc::mutable_variant_object(*itr, value));
+        }
+
+        return value;
+    }
+
+    variant primary_key::to_variant(const table_info& info, const value_type value) {
+        return from_table(info, value).to_variant(info);
+    }
+
+    ///------------------------------------
+
+    scope_name::scope_name(typed_name&& src)
+    : typed_name(src.kind(), src.value()) {
+    }
+
+    typed_name::value_kind scope_name::kind_from_table(const table_info& info) {
+        assert(info.table);
+
+        auto& scope_type = info.table->scope_type;
+        // by default as eosio::chain::name
+        if (scope_type.empty()) {
+            return typed_name::Name;
+        }
+        return typed_name::kind_from_string(scope_type);
+    }
+
+    scope_name scope_name::from_table(const table_info& info) {
+        return create(kind_from_table(info), info.scope);
+    }
+
+    bool scope_name::is_valid_kind(const string& kind) {
+        return kind.empty() || typed_name::is_valid_kind(kind);
+    }
+
+} } // namespace cyberway::chaindb

--- a/libraries/chain/chaindb/typed_name.cpp
+++ b/libraries/chain/chaindb/typed_name.cpp
@@ -119,6 +119,25 @@ namespace cyberway { namespace chaindb {
         TYPED_THROW("Bad kind of typed name on initialize from string");
     }
 
+    typed_name typed_name::from_string(const value_kind kind, const string& value) {
+        switch (kind) {
+            case Int64:
+                return from_value(kind, fc::to_int64(value));
+
+            case Uint64:
+                return from_value(kind, fc::to_uint64(value));
+
+            case Name:
+            case SymbolCode:
+            case Symbol:
+            case Unknown:
+            default:
+                break;
+        }
+
+        return from_value(kind, value);
+    }
+
     bool typed_name::is_valid(const value_kind kind , const value_type value) {
         switch (kind) {
             case Int64:
@@ -215,6 +234,10 @@ namespace cyberway { namespace chaindb {
         return kind_from_string(info.pk_order->type);
     }
 
+    primary_key primary_key::from_string(const table_info& info, const string& value) {
+        return typed_name::from_string(kind_from_table(info), value);
+    }
+
     primary_key primary_key::from_table(const table_info& info, const value_type value) {
         assert(info.pk_order);
         assert(!info.pk_order->type.empty());
@@ -255,6 +278,10 @@ namespace cyberway { namespace chaindb {
             return typed_name::Name;
         }
         return typed_name::kind_from_string(scope_type);
+    }
+
+    scope_name scope_name::from_string(const table_info& info, const string& value) {
+        return typed_name::from_string(kind_from_table(info), value);
     }
 
     scope_name scope_name::from_table(const table_info& info) {

--- a/libraries/chain/chaindb/undo_state.cpp
+++ b/libraries/chain/chaindb/undo_state.cpp
@@ -487,7 +487,7 @@ namespace cyberway { namespace chaindb {
 
             auto& cursor = driver_.lower_bound(std::move(index), {});
             for (; cursor.pk != primary_key::End; driver_.next(cursor)) {
-                auto  obj   = driver_.object_at_cursor(cursor);
+                auto  obj   = driver_.object_at_cursor(cursor, false);
                 auto  pk    = obj.pk();
                 auto& state = get_state(obj.service);
 

--- a/libraries/chain/chaindb/undo_state.cpp
+++ b/libraries/chain/chaindb/undo_state.cpp
@@ -39,7 +39,7 @@ namespace cyberway { namespace chaindb {
         object_value next_pk_object(variant val = variant()) const;
 
         bool has_next_pk() const {
-            return unset_primary_key != next_pk_;
+            return primary_key::Unset != next_pk_;
         }
 
         primary_key_t next_pk() const {
@@ -62,8 +62,8 @@ namespace cyberway { namespace chaindb {
         pk_value_map_t_   removed_values_;
 
     private:
-        primary_key_t     next_pk_      = unset_primary_key;
-        primary_key_t     undo_next_pk_ = unset_primary_key;
+        primary_key_t     next_pk_      = primary_key::Unset;
+        primary_key_t     undo_next_pk_ = primary_key::Unset;
         revision_t        revision_     = impossible_revision;
     }; // struct undo_state
 
@@ -268,8 +268,8 @@ namespace cyberway { namespace chaindb {
     }
 
     void undo_state::reset_next_pk() {
-        next_pk_      = unset_primary_key;
-        undo_next_pk_ = unset_primary_key;
+        next_pk_      = primary_key::Unset;
+        undo_next_pk_ = primary_key::Unset;
     }
 
     object_value undo_state::next_pk_object(variant val) const {
@@ -304,6 +304,7 @@ namespace cyberway { namespace chaindb {
             undo_abi_.tables.emplace_back( eosio::chain::table_def {
                 names::undo_table,
                 names::undo_table,
+                "uint64",
                 {{"primary", true, {{ names::undo_pk_path , names::asc_order}} }},
             });
 
@@ -485,7 +486,7 @@ namespace cyberway { namespace chaindb {
             index.index = &undo_table_.table->indexes.front();
 
             auto& cursor = driver_.lower_bound(std::move(index), {});
-            for (; cursor.pk != end_primary_key; driver_.next(cursor)) {
+            for (; cursor.pk != primary_key::End; driver_.next(cursor)) {
                 auto  obj   = driver_.object_at_cursor(cursor);
                 auto  pk    = obj.pk();
                 auto& state = get_state(obj.service);
@@ -545,9 +546,9 @@ namespace cyberway { namespace chaindb {
             auto& head = table.head();
 
             CYBERWAY_SESSION_ASSERT(head.revision() == undo_rev,
-                "Wrong undo revision ${undo_revision} != ${revision} for the table ${table} for the scope '${scope}",
+                "Wrong undo revision ${undo_revision} != ${revision} for the table ${table}:${scope}",
                 ("revision", head.revision())("undo_revision", undo_rev)
-                ("table", get_full_table_name(table.info()))("scope", get_scope_name(table.info())));
+                ("table", get_full_table_name(table.info()))("scope", table.scope()));
 
             auto ctx = journal_.create_ctx(table.info());
 
@@ -649,9 +650,9 @@ namespace cyberway { namespace chaindb {
 
             auto& state = table.head();
             CYBERWAY_SESSION_ASSERT(state.revision() == squash_rev,
-                "Wrong squash revision ${squash_revision} != ${revision} for the table ${table} for the scope '${scope}",
+                "Wrong squash revision ${squash_revision} != ${revision} for the table ${table}:${scope}",
                 ("revision", state.revision())("squash_revision", squash_rev)
-                ("table", get_full_table_name(table.info()))("scope", get_scope_name(table.info())));
+                ("table", get_full_table_name(table.info()))("scope", table.scope()));
 
             // Only one stack item
             if (table.size() == 1) {

--- a/libraries/chain/cyberway/cyberway_contract.cpp
+++ b/libraries/chain/cyberway/cyberway_contract.cpp
@@ -112,8 +112,8 @@ void apply_cyber_domain_newusername(apply_context& context) {
 
 #define _CYBERWAY_OBJECT_QUERY_CHECK(_CHECK, _OP)  \
     EOS_ASSERT((_CHECK), eosio::chain::object_query_exception, \
-        "Object with the primary key ${scope}:${pk} doesn't exist in the table ${table}", \
-        ("pk", (_OP).pk)("scope", chaindb::get_scope_name((_OP).scope))("table", chaindb::get_full_table_name(_OP)))
+        "Object with the primary key ${pk} doesn't exist in the table ${table}:${scope}", \
+        ("pk", (_OP).pk)("table", chaindb::get_full_table_name(_OP))("scope", (_OP).scope))
 
 template <typename Operation>
 chaindb::cache_object_ptr get_cache_object(apply_context& context, const Operation& op) {
@@ -138,9 +138,8 @@ void apply_cyber_setrampayer(apply_context& context) {
         context.require_authorization(owner);
 
         EOS_ASSERT(op.new_payer != cache->service().payer, eosio::chain::object_ram_payer_exception,
-            "Object with the primary key ${scope}:${pk} in the table ${table} already has the RAM payer ${payer}",
-            ("pk", op.pk)("scope", chaindb::get_scope_name(op.scope))("table", chaindb::get_full_table_name(op))
-            ("payer", op.new_payer));
+            "Object with the primary key ${pk} in the table ${table}:${scope} already has the RAM payer ${payer}",
+            ("pk", op.pk)("scope", op.scope)("table", chaindb::get_full_table_name(op))("payer", op.new_payer));
 
         context.chaindb.recalc_ram_usage(*cache.get(), context.get_storage_payer(owner, op.new_payer));
     } FC_CAPTURE_AND_RETHROW((op))
@@ -156,9 +155,8 @@ void apply_set_ram_state(
     validate(service);
 
     EOS_ASSERT(op.in_ram != cache->service().in_ram, eosio::chain::object_ram_state_exception,
-        "Object with the primary key ${scope}:${pk} in the table ${table} already has RAM state = ${state}",
-        ("pk", op.pk)("scope", chaindb::get_scope_name(op.scope))("table", chaindb::get_full_table_name(op))
-        ("state", op.in_ram));
+        "Object with the primary key ${pk} in the table ${table}:${scope} already has RAM state = ${state}",
+        ("pk", op.pk)("table", chaindb::get_full_table_name(op))("scope", op.scope)("state", op.in_ram));
 
     auto info = context.get_storage_payer(service.owner, service.payer);
     info.in_ram  = op.in_ram;

--- a/libraries/chain/include/cyberway/chaindb/cache_item.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_item.hpp
@@ -35,8 +35,8 @@ namespace cyberway { namespace chaindb {
     }; // struct cache_converter_interface
 
     struct cache_index_value final: public boost::intrusive::set_base_hook<> {
-        const index_name index;
-        const bytes      blob;
+        const index_name_t index;
+        const bytes        blob;
         const cache_object* const object = nullptr;
 
         cache_index_value(index_name, bytes, const cache_object&);

--- a/libraries/chain/include/cyberway/chaindb/common.hpp
+++ b/libraries/chain/include/cyberway/chaindb/common.hpp
@@ -5,16 +5,14 @@
 #include <eosio/chain/types.hpp>
 #include <eosio/chain/abi_def.hpp>
 
+#include <cyberway/chaindb/typed_name.hpp>
+
 namespace cyberway { namespace chaindb {
 
     using revision_t = int64_t;
     static constexpr revision_t impossible_revision = (-1);
     static constexpr revision_t unset_revision = (-2);
     static constexpr revision_t start_revision = (1);
-
-    using primary_key_t = uint64_t;
-    static constexpr primary_key_t unset_primary_key = (-2);
-    static constexpr primary_key_t end_primary_key = (-1);
 
     using cursor_t = int32_t;
     static constexpr cursor_t invalid_cursor = (0);
@@ -30,21 +28,23 @@ namespace cyberway { namespace chaindb {
     using eosio::chain::field_name;
     using eosio::chain::type_name;
 
-    using table_name_t = table_name::value_type;
-    using index_name_t = index_name::value_type;
+    using primary_key_t  = primary_key::value_type;
+    using table_name_t   = table_name::value_type;
+    using index_name_t   = index_name::value_type;
     using account_name_t = account_name::value_type;
+    using scope_name_t   = scope_name::value_type;
 
     struct table_request final {
-        const account_name code;
-        const account_name scope;
-        const table_name_t table;
+        const account_name_t code  = 0;
+        const scope_name_t   scope = 0;
+        const table_name_t   table = 0;
     }; // struct table_request
 
     struct index_request final {
-        const account_name code;
-        const account_name scope;
-        const table_name_t table;
-        const index_name_t index;
+        const account_name_t code  = 0;
+        const scope_name_t   scope = 0;
+        const table_name_t   table = 0;
+        const index_name_t   index = 0;
 
         operator table_request() const {
             return {code, scope, table};
@@ -52,8 +52,8 @@ namespace cyberway { namespace chaindb {
     }; // struct index_request
 
     struct cursor_request final {
-        const account_name code;
-        const cursor_t     id;
+        const account_name_t code;
+        const cursor_t       id;
     }; // struct cursor_request
 
     enum class chaindb_type {
@@ -67,14 +67,14 @@ namespace cyberway { namespace chaindb {
     using abi_map = std::map<account_name /* code */, abi_info>;
 
     struct table_info {
-        const account_name code;
-        const account_name scope;
-        const table_def*   table    = nullptr;
-        const order_def*   pk_order = nullptr;
-        const abi_info*    abi      = nullptr;
+        const account_name_t code     = 0;
+        const scope_name_t   scope    = 0;
+        const table_def*     table    = nullptr;
+        const order_def*     pk_order = nullptr;
+        const abi_info*      abi      = nullptr;
 
-        table_info(const account_name& code, const account_name& scope)
-        : code(code), scope(scope) {
+        table_info(account_name_t c, scope_name_t s)
+        : code(c), scope(s) {
         }
     }; // struct table_info
 
@@ -90,7 +90,7 @@ namespace cyberway { namespace chaindb {
 
     struct find_info final {
         cursor_t      cursor = invalid_cursor;
-        primary_key_t pk     = end_primary_key;
+        primary_key_t pk     = primary_key::End;
     }; // struct find_info
 
     class chaindb_session final {
@@ -124,7 +124,7 @@ namespace cyberway { namespace chaindb {
 
         chaindb_controller& controller_;
         bool apply_ = true;
-        const revision_t revision_ = -1;
+        const revision_t revision_ = impossible_revision;
     }; // struct session
 
     std::ostream& operator<<(std::ostream&, const chaindb_type);

--- a/libraries/chain/include/cyberway/chaindb/common.hpp
+++ b/libraries/chain/include/cyberway/chaindb/common.hpp
@@ -28,6 +28,7 @@ namespace cyberway { namespace chaindb {
     using eosio::chain::index_def;
     using eosio::chain::order_def;
     using eosio::chain::field_name;
+    using eosio::chain::type_name;
 
     using table_name_t = table_name::value_type;
     using index_name_t = index_name::value_type;

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -184,6 +184,7 @@ namespace cyberway { namespace chaindb {
 
         variant value_by_pk(const table_request& request, primary_key_t pk) const;
         variant value_at_cursor(const cursor_request&) const;
+        table_info   table_by_request(const table_request&) const;
         index_info   index_at_cursor(const cursor_request&) const;
         object_value object_at_cursor(const cursor_request&) const;
 

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -183,8 +183,9 @@ namespace cyberway { namespace chaindb {
         void recalc_ram_usage(cache_object&, const storage_payer_info&) const;
 
         variant value_by_pk(const table_request& request, primary_key_t pk) const;
-        variant value_at_cursor(const cursor_request& request) const;
-        object_value object_at_cursor(const cursor_request& request) const;
+        variant value_at_cursor(const cursor_request&) const;
+        index_info   index_at_cursor(const cursor_request&) const;
+        object_value object_at_cursor(const cursor_request&) const;
 
     private:
         friend class chaindb_session;

--- a/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
+++ b/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
@@ -14,7 +14,7 @@ namespace cyberway { namespace chaindb {
     struct cursor_info {
         cursor_t      id = invalid_cursor;
         index_info    index;
-        primary_key_t pk = end_primary_key;
+        primary_key_t pk = primary_key::End;
     }; // struct cursor_info
 
     class driver_interface {

--- a/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
+++ b/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
@@ -49,7 +49,7 @@ namespace cyberway { namespace chaindb {
         virtual cursor_info& prev(const cursor_info&) const = 0;
 
         virtual       object_value  object_by_pk(const table_info&, primary_key_t) const = 0;
-        virtual const object_value& object_at_cursor(const cursor_info&) const = 0;
+        virtual const object_value& object_at_cursor(const cursor_info&, bool with_decors) const = 0;
 
         virtual primary_key_t available_pk(const table_info&) const = 0;
     }; // class driver_interface

--- a/libraries/chain/include/cyberway/chaindb/exception.hpp
+++ b/libraries/chain/include/cyberway/chaindb/exception.hpp
@@ -3,6 +3,7 @@
 #include <eosio/chain/exceptions.hpp>
 
 #define CYBERWAY_ASSERT(expr, exc_type, FORMAT, ...) EOS_ASSERT(expr, exc_type, FORMAT, __VA_ARGS__)
+#define CYBERWAY_THROW(exc_type, FORMAT, ...) FC_THROW_EXCEPTION(exc_type, FORMAT, __VA_ARGS__)
 
 namespace cyberway { namespace chaindb {
 
@@ -34,6 +35,7 @@ namespace cyberway { namespace chaindb {
      *  chaindb_exception
      *   |- chaindb_internal_exception
      *   |- chaindb_abi_exception
+     *      |- invalid_typed_name_exception
      *   |- chaindb_contract_exception
      *   |- chaindb_object_exception
      */
@@ -101,6 +103,9 @@ namespace cyberway { namespace chaindb {
         FC_DECLARE_DERIVED_EXCEPTION(cache_exception, chaindb_internal_exception,
                                      3710019, "ChainDB cache failed")
 
+        FC_DECLARE_DERIVED_EXCEPTION(driver_scope_exception, chaindb_internal_exception,
+                                     3710020, "ChainDB driver returns bad scope")
+
     FC_DECLARE_DERIVED_EXCEPTION(chaindb_abi_exception, chaindb_exception,
                                  3720000, "ChainDB ABI exception")
 
@@ -112,9 +117,6 @@ namespace cyberway { namespace chaindb {
 
         FC_DECLARE_DERIVED_EXCEPTION(invalid_abi_store_type_exception, chaindb_abi_exception,
                                      3720003, "Invalid type for serialization")
-
-        FC_DECLARE_DERIVED_EXCEPTION(invalid_primary_key_exception, chaindb_abi_exception,
-                                     3720004, "Invalid primary key information")
 
         FC_DECLARE_DERIVED_EXCEPTION(invalid_index_description_exception, chaindb_abi_exception,
                                      3720005, "Invalid index description")
@@ -139,6 +141,15 @@ namespace cyberway { namespace chaindb {
 
         FC_DECLARE_DERIVED_EXCEPTION(array_field_exception, chaindb_abi_exception,
                                      3720012, "Array field can't be used for index")
+
+        FC_DECLARE_DERIVED_EXCEPTION(invalid_typed_name_exception, chaindb_abi_exception,
+                                     3721000, "Invalid typed name information")
+
+            FC_DECLARE_DERIVED_EXCEPTION(invalid_primary_key_exception, invalid_typed_name_exception,
+                                         3721001, "Invalid primary key information")
+
+            FC_DECLARE_DERIVED_EXCEPTION(invalid_scope_name_exception, invalid_typed_name_exception,
+                                         3721002, "Invalid scope name information")
 
     FC_DECLARE_DERIVED_EXCEPTION(chaindb_contract_exception, chaindb_exception,
                                  3730000, "ChainDB contract exception")

--- a/libraries/chain/include/cyberway/chaindb/journal.hpp
+++ b/libraries/chain/include/cyberway/chaindb/journal.hpp
@@ -126,7 +126,7 @@ namespace cyberway { namespace chaindb {
         }; // struct table_t_
 
         class write_ctx final {
-            primary_key_t pk_   = unset_primary_key;
+            primary_key_t pk_   = primary_key::Unset;
             info_t_*      info_ = nullptr;
 
         public:

--- a/libraries/chain/include/cyberway/chaindb/mongo_asset_converter.hpp
+++ b/libraries/chain/include/cyberway/chaindb/mongo_asset_converter.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <bsoncxx/config/prelude.hpp>
+
+namespace bsoncxx {
+BSONCXX_INLINE_NAMESPACE_BEGIN
+    namespace document {
+        class view;
+    } // namespace document
+BSONCXX_INLINE_NAMESPACE_END
+} // namespace bsoncxx
+
+namespace fc {
+    class variant;
+} // namespace fc
+
+namespace cyberway { namespace chaindb {
+
+    using std::string;
+
+    struct mongo_asset_converter final {
+        using value_type = string;
+
+        enum value_kind {
+            Unknown,
+            Asset,
+            Symbol
+        }; // enum value_kind
+
+        mongo_asset_converter(const bsoncxx::document::view&);
+
+        value_kind kind() const {
+            return kind_;
+        }
+
+        const value_type& value() const {
+            assert(is_valid_value());
+            return value_;
+        }
+
+        fc::variant get_variant() const;
+
+        bool is_valid_value() const {
+            return Unknown != kind_;
+        }
+
+    private:
+        value_kind kind_ = Unknown;
+        value_type value_;
+
+        void convert(const bsoncxx::document::view&);
+
+        void convert_to_asset(int64_t, uint64_t, const string&);
+        void convert_to_symbol(uint64_t, const string&);
+    }; // struct asset_converter
+
+} } // namespace cyberway::chaindb

--- a/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
+++ b/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
@@ -41,7 +41,7 @@ namespace cyberway { namespace chaindb {
         cursor_info& prev(const cursor_info&) const override;
 
               object_value  object_by_pk(const table_info&, primary_key_t) const override;
-        const object_value& object_at_cursor(const cursor_info&) const override;
+        const object_value& object_at_cursor(const cursor_info&, bool) const override;
 
         primary_key_t available_pk(const table_info&) const override;
 

--- a/libraries/chain/include/cyberway/chaindb/mongo_driver_utils.hpp
+++ b/libraries/chain/include/cyberway/chaindb/mongo_driver_utils.hpp
@@ -44,7 +44,7 @@ namespace cyberway { namespace chaindb {
 
     std::string to_json(const bsoncxx::document::view&);
 
-    object_value build_object(const table_info&, const bsoncxx::document::view&);
+    object_value build_object(const table_info&, const bsoncxx::document::view&, bool with_decors);
 
     basic::sub_document& append_scope_value(basic::sub_document&, const table_info&);
     basic::sub_document& append_pk_value(basic::sub_document&, const table_info&, primary_key_t);

--- a/libraries/chain/include/cyberway/chaindb/mongo_driver_utils.hpp
+++ b/libraries/chain/include/cyberway/chaindb/mongo_driver_utils.hpp
@@ -46,13 +46,14 @@ namespace cyberway { namespace chaindb {
 
     object_value build_object(const table_info&, const bsoncxx::document::view&);
 
+    basic::sub_document& append_scope_value(basic::sub_document&, const table_info&);
     basic::sub_document& append_pk_value(basic::sub_document&, const table_info&, primary_key_t);
 
     basic::sub_document& build_document(basic::sub_document&, const object_value&);
     basic::sub_document& build_document(basic::sub_document&, const std::string&, const fc::variant&);
     basic::sub_document& build_bound_document(basic::sub_document&, const std::string&, int);
     basic::sub_document& build_service_document(basic::sub_document&, const table_info&, const object_value&);
-    basic::sub_document& build_undo_service_document(basic::sub_document&, const table_info&, const object_value&);
+    basic::sub_document& build_undo_document(basic::sub_document&, const table_info&, const object_value&);
     basic::sub_document& build_find_pk_document(basic::sub_document&, const table_info&, const object_value&);
     basic::sub_document& build_find_undo_pk_document(basic::sub_document&, const table_info&, const object_value&);
 

--- a/libraries/chain/include/cyberway/chaindb/multi_index.hpp
+++ b/libraries/chain/include/cyberway/chaindb/multi_index.hpp
@@ -336,7 +336,7 @@ private:
         constexpr static table_name_t   table_name() { return code_extractor<TableName>::get_code(); }
         constexpr static index_name_t   index_name() { return code_extractor<IndexName>::get_code(); }
         constexpr static account_name_t code_name()  { return 0; }
-        constexpr static account_name_t scope_name() { return 0; }
+        constexpr static scope_name_t   scope_name() { return 0; }
 
         const T& operator*() const {
             lazy_load_object();
@@ -365,7 +365,7 @@ private:
         }
         const_iterator_impl& operator++() {
             lazy_open();
-            CYBERWAY_ASSERT(primary_key_ != end_primary_key, chaindb_midx_pk_exception,
+            CYBERWAY_ASSERT(primary_key_ != primary_key::End, chaindb_midx_pk_exception,
                 "Can't increment end iterator for the index ${index}", ("index", get_index_name()));
             primary_key_ = controller().next(get_cursor_request());
             item_.reset();
@@ -381,7 +381,7 @@ private:
             lazy_open();
             primary_key_ = controller().prev(get_cursor_request());
             item_.reset();
-            CYBERWAY_ASSERT(primary_key_ != end_primary_key, chaindb_midx_pk_exception,
+            CYBERWAY_ASSERT(primary_key_ != primary_key::End, chaindb_midx_pk_exception,
                 "Out of range on decrement of iterator for the index ${index}", ("index", get_index_name()));
             return *this;
         }
@@ -400,7 +400,7 @@ private:
             item_ = std::move(src.item_);
 
             src.cursor_ = uninitilized_cursor::state;
-            src.primary_key_ = end_primary_key;
+            src.primary_key_ = primary_key::End;
 
             return *this;
         }
@@ -453,7 +453,7 @@ private:
 
         const chaindb_controller* controller_ = nullptr;
         mutable cursor_t cursor_ = uninitilized_cursor::state;
-        mutable primary_key_t primary_key_ = end_primary_key;
+        mutable primary_key_t primary_key_ = primary_key::End;
         mutable cache_object_ptr item_;
 
         void lazy_load_object() const {
@@ -464,7 +464,7 @@ private:
             }
 
             lazy_open();
-            CYBERWAY_ASSERT(primary_key_ != end_primary_key, chaindb_midx_pk_exception,
+            CYBERWAY_ASSERT(primary_key_ != primary_key::End, chaindb_midx_pk_exception,
                 "Cannot load object from the end iterator for the index ${index}", ("index", get_index_name()));
 
             auto ptr = controller().get_cache_object({code_name(), cursor_}, false);
@@ -556,7 +556,7 @@ public:
         constexpr static table_name_t   table_name() { return code_extractor<TableName>::get_code(); }
         constexpr static index_name_t   index_name() { return code_extractor<IndexName>::get_code(); }
         constexpr static account_name_t code_name()  { return 0; }
-        constexpr static account_name_t scope_name() { return 0; }
+        constexpr static scope_name_t   scope_name() { return 0; }
 
         index(const chaindb_controller& ctrl)
         : controller_(ctrl) {
@@ -725,7 +725,7 @@ public:
 
     constexpr static table_name_t   table_name() { return code_extractor<TableName>::get_code(); }
     constexpr static account_name_t code_name()  { return 0; }
-    constexpr static account_name_t scope_name() { return 0; }
+    constexpr static scope_name_t   scope_name() { return 0; }
 
     static const table_request& get_table_request() {
         static table_request request{code_name(), scope_name(), table_name()};

--- a/libraries/chain/include/cyberway/chaindb/names.hpp
+++ b/libraries/chain/include/cyberway/chaindb/names.hpp
@@ -32,6 +32,10 @@ namespace cyberway { namespace chaindb {
         static const string size_field;
         static const string ram_field;
 
+        static const string amount_field;
+        static const string decs_field;
+        static const string sym_field;
+
         static const string scope_path;
         static const string undo_pk_path;
         static const string revision_path;
@@ -39,15 +43,9 @@ namespace cyberway { namespace chaindb {
         static const string asc_order;
         static const string desc_order;
 
-        static const string decs_part_name;
-        static const string sym_part_name;
 
         static constexpr uint64_t primary_index = N(primary);
     }; // struct names
-
-    ///----
-
-    bool is_symbol_type(const type_name&);
 
     ///----
 
@@ -78,17 +76,6 @@ namespace cyberway { namespace chaindb {
     template <typename Info>
     inline string get_code_name(const Info& info) {
         return get_code_name(info.code);
-    }
-
-    ///----
-
-    inline string get_scope_name(const account_name& scope) {
-        return scope.to_string();
-    }
-
-    template <typename Info>
-    inline string get_scope_name(const Info& info) {
-        return get_scope_name(info.scope);
     }
 
     ///---

--- a/libraries/chain/include/cyberway/chaindb/names.hpp
+++ b/libraries/chain/include/cyberway/chaindb/names.hpp
@@ -39,9 +39,15 @@ namespace cyberway { namespace chaindb {
         static const string asc_order;
         static const string desc_order;
 
+        static const string decs_part_name;
+        static const string sym_part_name;
+
         static constexpr uint64_t primary_index = N(primary);
     }; // struct names
 
+    ///----
+
+    bool is_symbol_type(const type_name&);
 
     ///----
 

--- a/libraries/chain/include/cyberway/chaindb/object_value.hpp
+++ b/libraries/chain/include/cyberway/chaindb/object_value.hpp
@@ -14,28 +14,28 @@ namespace cyberway { namespace chaindb {
     }; // enum class undo_type
 
     struct service_state final {
-        primary_key_t pk       = unset_primary_key;
-        account_name  payer;
-        account_name  owner;
-        int           size     = 0;
-        bool          in_ram   = true;
+        primary_key_t  pk       = primary_key::Unset;
+        account_name_t payer    = 0;
+        account_name_t owner    = 0;
+        int            size     = 0;
+        bool           in_ram   = true;
 
-        account_name  code;
-        account_name  scope;
-        table_name    table;
+        account_name_t code     = 0;
+        scope_name_t   scope    = 0;
+        table_name_t   table    = 0;
 
-        revision_t    revision = impossible_revision;
+        revision_t     revision = impossible_revision;
 
         // the following fields are part of undo state,
         // TODO: refactor to move them into write_operation
-        primary_key_t undo_pk  = unset_primary_key;
-        undo_record   undo_rec = undo_record::Unknown;
+        primary_key_t  undo_pk  = primary_key::Unset;
+        undo_record    undo_rec = undo_record::Unknown;
 
-        revision_t    undo_revision = impossible_revision;
-        account_name  undo_payer;
-        account_name  undo_owner;
-        size_t        undo_size     = 0;
-        bool          undo_in_ram   = true;
+        revision_t     undo_revision = impossible_revision;
+        account_name_t undo_payer    = 0;
+        account_name_t undo_owner    = 0;
+        size_t         undo_size     = 0;
+        bool           undo_in_ram   = true;
 
         service_state(const table_info& table, primary_key_t pk)
         : pk(pk), code(table.code), scope(table.scope), table(table.table->name) {
@@ -58,7 +58,7 @@ namespace cyberway { namespace chaindb {
         }
 
         bool empty() const {
-            return scope.empty() && code.empty() && table.empty();
+            return 0 == scope && 0 == code && 0 == table;
         }
     }; // struct service_state
 

--- a/libraries/chain/include/cyberway/chaindb/table_object.hpp
+++ b/libraries/chain/include/cyberway/chaindb/table_object.hpp
@@ -29,15 +29,15 @@ namespace cyberway { namespace chaindb { namespace table_object {
             return info_;
         }
 
-        const table_name& table() const {
+        table_name_t table() const {
             return table_def_.name;
         }
 
-        const account_name& code() const {
+        account_name_t code() const {
             return info_.code;
         }
 
-        const account_name& scope() const {
+        scope_name_t scope() const {
             return info_.scope;
         }
 
@@ -56,9 +56,9 @@ namespace cyberway { namespace chaindb { namespace table_object {
             bmi::ordered_unique<
                 bmi::composite_key<
                     Object,
-                    bmi::const_mem_fun<object, const account_name&, &object::code>,
-                    bmi::const_mem_fun<object, const table_name&,   &object::table>,
-                    bmi::const_mem_fun<object, const account_name&, &object::scope>>>>>;
+                    bmi::const_mem_fun<object, account_name_t, &object::code>,
+                    bmi::const_mem_fun<object, table_name_t,   &object::table>,
+                    bmi::const_mem_fun<object, scope_name_t,   &object::scope>>>>>;
 
     template <typename Object>
     typename index<Object>::iterator find(index<Object>& idx, const table_info& table) {
@@ -72,12 +72,12 @@ namespace cyberway { namespace chaindb { namespace table_object {
 
     template <typename Object>
     typename index<Object>::iterator find_without_scope(index<Object>& idx, const table_info& table) {
-        return idx.find(std::make_tuple(table.code, table.table->name, account_name()));
+        return idx.find(std::make_tuple(table.code, table.table->name, 0));
     }
 
     template <typename Object>
     typename index<Object>::iterator find_without_scope(const index<Object>& idx, const table_info& table) {
-        return idx.find(std::make_tuple(table.code, table.table->name, account_name()));
+        return idx.find(std::make_tuple(table.code, table.table->name, 0));
     }
 
     template <typename Object, typename... Args>

--- a/libraries/chain/include/cyberway/chaindb/typed_name.hpp
+++ b/libraries/chain/include/cyberway/chaindb/typed_name.hpp
@@ -57,6 +57,8 @@ namespace cyberway { namespace chaindb {
         static typed_name from_value(value_kind, int64_t);
         static typed_name from_value(value_kind, const string&);
 
+        static typed_name from_string(value_kind, const string&);
+
     private:
         value_kind kind_  = Unknown;
         value_type value_ = 0;
@@ -83,6 +85,8 @@ namespace cyberway { namespace chaindb {
             return typed_name::from_value(kind_from_table(info), std::forward<Args>(args)...);
         }
 
+        static primary_key from_string(const table_info&, const string&);
+
         static primary_key from_table(const table_info&, value_type);
 
         variant to_variant(const table_info&) const;
@@ -102,6 +106,8 @@ namespace cyberway { namespace chaindb {
         static scope_name from_value(const table_info& info, Args&&... args) {
             return typed_name::from_value(kind_from_table(info), std::forward<Args>(args)...);
         }
+
+        static scope_name from_string(const table_info&, const string&);
 
         static scope_name from_table(const table_info&);
 

--- a/libraries/chain/include/cyberway/chaindb/typed_name.hpp
+++ b/libraries/chain/include/cyberway/chaindb/typed_name.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <string>
+
+#include <cyberway/chaindb/exception.hpp>
+
+namespace fc {
+    class variant;
+}
+
+namespace cyberway { namespace chaindb {
+
+    using std::string;
+    using fc::variant;
+
+    struct table_info;
+
+    struct typed_name {
+        using value_type = uint64_t;
+
+        enum value_kind {
+            Unknown,
+            Int64,
+            Uint64,
+            Name,
+            Symbol,
+            SymbolCode
+        };
+
+        typed_name(typed_name&&) = default;
+
+        value_type value() const { return value_; }
+        value_kind kind()  const { return kind_;  }
+
+        bool is_valid() const;
+
+        static bool is_valid_kind(const string&);
+
+        string  to_string()  const;
+        variant to_variant() const;
+
+        template <typename DataStream> friend DataStream& operator<<(DataStream& ds, const typed_name& s) {
+            return ds << s.to_string();
+        }
+
+    protected:
+        typed_name(value_kind, value_type);
+
+        static bool is_valid(value_kind, value_type);
+
+        static typed_name create(value_kind, value_type);
+
+        static value_kind kind_from_string(const string&);
+
+        static typed_name from_value(value_kind);
+        static typed_name from_value(value_kind, uint64_t);
+        static typed_name from_value(value_kind, int64_t);
+        static typed_name from_value(value_kind, const string&);
+
+    private:
+        value_kind kind_  = Unknown;
+        value_type value_ = 0;
+    }; // struct typed_name
+
+    struct primary_key final: public typed_name {
+        enum : value_type {
+            Unset = value_type(-2),
+            End   = value_type(-1),
+        }; // constants ...
+
+        primary_key(primary_key&&) = default;
+
+        static bool is_good(const value_type v) {
+            return v != Unset && v != End;
+        }
+
+        bool is_good() const {
+            return is_good(value());
+        }
+
+        template<typename... Args>
+        static primary_key from_value(const table_info& info, Args&&... args) {
+            return typed_name::from_value(kind_from_table(info), std::forward<Args>(args)...);
+        }
+
+        static primary_key from_table(const table_info&, value_type);
+
+        variant to_variant(const table_info&) const;
+        static variant to_variant(const table_info& info, value_type value);
+
+    private:
+        primary_key(typed_name&&);
+        using typed_name::typed_name;
+
+        static value_kind kind_from_table(const table_info&);
+    }; // struct primary_key
+
+    struct scope_name final: public typed_name {
+        scope_name(scope_name&&) = default;
+
+        template<typename... Args>
+        static scope_name from_value(const table_info& info, Args&&... args) {
+            return typed_name::from_value(kind_from_table(info), std::forward<Args>(args)...);
+        }
+
+        static scope_name from_table(const table_info&);
+
+        static bool is_valid_kind(const string&);
+
+    private:
+        scope_name(typed_name&&);
+        using typed_name::typed_name;
+
+        static value_kind kind_from_table(const table_info&);
+    }; // struct scope_name
+
+} } // namespace cyberway::chaindb

--- a/libraries/chain/include/eosio/chain/abi_def.hpp
+++ b/libraries/chain/include/eosio/chain/abi_def.hpp
@@ -100,9 +100,13 @@ struct table_def {
    table_def(const table_name& name, const type_name& type, const vector<index_def>& indexes)
    :name(name), type(type), indexes(indexes)
    {}
+   table_def(const table_name& name, const type_name& type, const type_name& scope, const vector<index_def>& indexes)
+   :name(name), type(type), scope_type(scope), indexes(indexes)
+   {}
 
    table_name         name;        // the name of the table
    type_name          type;        // type of binary data stored in this table
+   type_name          scope_type;  // type of scope
    vector<index_def>  indexes;     //
 
    // The following fields are service and set by chain code
@@ -193,7 +197,7 @@ FC_REFLECT( eosio::chain::action_def                       , (name)(type) )
 FC_REFLECT( eosio::chain::event_def                        , (name)(type) )
 FC_REFLECT( eosio::chain::order_def                        , (field)(order) )
 FC_REFLECT( eosio::chain::index_def                        , (name)(unique)(orders) )
-FC_REFLECT( eosio::chain::table_def                        , (name)(type)(indexes) )
+FC_REFLECT( eosio::chain::table_def                        , (name)(type)(scope_type)(indexes) )
 FC_REFLECT( eosio::chain::error_message                    , (error_code)(error_msg) )
 FC_REFLECT( eosio::chain::variant_def                      , (name)(types) )
 FC_REFLECT( eosio::chain::abi_def                          , (version)(types)(structs)(actions)(events)(tables)

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -34,7 +34,8 @@ namespace impl {
 struct abi_serializer {
    abi_serializer(){ configure_built_in_types(); }
    abi_serializer( const abi_def& abi, const fc::microseconds& max_serialization_time );
-   void disable_check_field_name();
+   bool is_check_field_name() const { return check_field_name_; }
+   void set_check_field_name(bool);
    void set_abi(const abi_def& abi, const fc::microseconds& max_serialization_time);
    void add_struct(struct_def st, const fc::microseconds& max_serialization_time);
 

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -32,7 +32,12 @@ namespace impl {
  *  be converted to and from JSON.
  */
 struct abi_serializer {
-   abi_serializer(){ configure_built_in_types(); }
+   enum mode {
+       DBMode,
+       PublicMode,
+   }; // enum mode
+
+   abi_serializer( mode m = PublicMode ){ configure_built_in_types(m); }
    abi_serializer( const abi_def& abi, const fc::microseconds& max_serialization_time );
    bool is_check_field_name() const { return check_field_name_; }
    void set_check_field_name(bool);
@@ -105,7 +110,7 @@ private:
    map<type_name, variant_def>   variants;
 
    map<type_name, pair<unpack_function, pack_function>> built_in_types;
-   void configure_built_in_types();
+   void configure_built_in_types(mode);
 
    fc::variant _binary_to_variant( const type_name& type, const bytes& binary, impl::binary_to_variant_context& ctx )const;
    fc::variant _binary_to_variant( const type_name& type, fc::datastream<const char*>& binary, impl::binary_to_variant_context& ctx )const;

--- a/libraries/chain/include/eosio/chain/asset.hpp
+++ b/libraries/chain/include/eosio/chain/asset.hpp
@@ -96,20 +96,20 @@ private:
 };
 
 struct asset_info final {
-    share_type  amount;
-    uint8_t     decs;
-    symbol_code sym;
+    share_type  _amount;
+    uint8_t     _decs;
+    symbol_code _sym;
 
     asset_info() = default;
 
     asset_info(const asset& src)
-    : amount(src.get_amount()),
-      decs(src.get_symbol().decimals()),
-      sym(src.get_symbol().to_symbol_code())
+    : _amount(src.get_amount()),
+      _decs(src.get_symbol().decimals()),
+      _sym(src.get_symbol().to_symbol_code())
     { }
 
     operator asset() const {
-       return asset(amount, symbol(sym.value << 8 | decs));
+       return asset(_amount, symbol(_sym.value << 8 | _decs));
     }
 
     static asset_info from_string(const string& from) {
@@ -122,7 +122,7 @@ bool  operator <= (const asset& a, const asset& b);
 
 }} // namespace eosio::chain
 
-FC_REFLECT(eosio::chain::asset_info, (amount)(decs)(sym))
+FC_REFLECT(eosio::chain::asset_info, (_amount)(_decs)(_sym))
 FC_REFLECT(eosio::chain::asset, (amount)(sym))
 
 namespace fc {

--- a/libraries/chain/include/eosio/chain/symbol.hpp
+++ b/libraries/chain/include/eosio/chain/symbol.hpp
@@ -165,29 +165,33 @@ namespace eosio {
       }
 
       struct symbol_info final {
-          uint8_t     decs;
-          symbol_code sym;
+          uint8_t     _decs;
+          symbol_code _sym;
 
           symbol_info() = default;
 
-          symbol_info(const symbol& src)
-          : decs(src.decimals()),
-            sym(src.to_symbol_code())
+          explicit symbol_info(const symbol& src)
+          : _decs(src.decimals()),
+            _sym(src.to_symbol_code())
           { }
 
+          explicit symbol_info(const uint64_t src)
+          : symbol_info(symbol(src)) {
+          }
+
           operator symbol() const {
-              return symbol(sym.value << 8 | decs);
+              return symbol(_sym.value << 8 | _decs);
           }
 
           static symbol_info from_string(const string& from) {
-              return symbol::from_string(from);
+              return symbol_info(symbol::from_string(from));
           }
       };
 
    } // namespace chain
 } // namespace eosio
 
-FC_REFLECT(eosio::chain::symbol_info, (decs)(sym))
+FC_REFLECT(eosio::chain::symbol_info, (_decs)(_sym))
 FC_REFLECT(eosio::chain::symbol_code, (value))
 FC_REFLECT(eosio::chain::symbol, (m_value))
 
@@ -207,7 +211,7 @@ namespace fc {
    inline void from_variant(const variant& var, eosio::chain::symbol_info& vo) {
       using namespace eosio::chain;
       if (var.get_type() == variant::type_id::string_type) {
-         vo = symbol::from_string(var.get_string());
+         vo = symbol_info::from_string(var.get_string());
       } else {
          reflector<symbol_info>::visit(from_variant_visitor<symbol_info>(var.get_object(), vo));
       }

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -541,8 +541,16 @@ get_transaction_id_result chain_api_plugin_impl::get_transaction_id( const get_t
 
 get_table_rows_result chain_api_plugin_impl::get_table_rows( const get_table_rows_params& p )const {
    auto& chaindb = chain_controller_.chaindb();
+   cyberway::chaindb::scope_name_t scope = 0;
 
-   const cyberway::chaindb::index_request request{p.code, p.scope, p.table, p.index};
+   try {
+       auto table = chaindb.table_by_request({p.code, scope, p.table});
+       scope = cyberway::chaindb::scope_name::from_string(table, p.scope).value();
+   } catch (...) {
+        return get_table_rows_result();
+   }
+
+   const cyberway::chaindb::index_request request{p.code, scope, p.table, p.index};
 
    if (p.reverse && *p.reverse) {
        // TODO: implement rbegin end rend methods in mongo driver https://github.com/GolosChain/cyberway/issues/446

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -393,7 +393,7 @@ fc::variant chain_api_plugin_impl::get_payout(chain::account_name account) const
     auto payouts_it = chain_db.lower_bound(request, fc::mutable_variant_object() ("token_code", chain::symbol(CORE_SYMBOL).to_symbol_code())
                                                                                  ("account", account));
 
-    if (payouts_it.pk != cyberway::chaindb::end_primary_key) {
+    if (payouts_it.pk != cyberway::chaindb::primary_key::End) {
         return chain_db.value_at_cursor({N(cyber.stake), payouts_it.cursor});
     }
     return fc::variant();
@@ -548,7 +548,7 @@ get_table_rows_result chain_api_plugin_impl::get_table_rows( const get_table_row
        EOS_THROW(cyberway::chaindb::driver_unsupported_operation_exception, "Backward iteration through table not supported yet");
    } else {
        auto begin = p.lower_bound.is_null() ? chaindb.begin(request) : chaindb.lower_bound(request, p.lower_bound);
-       const auto end_pk = p.upper_bound.is_null() ? cyberway::chaindb::end_primary_key : chaindb.upper_bound(request, p.upper_bound).pk;
+       const auto end_pk = p.upper_bound.is_null() ? cyberway::chaindb::primary_key::End : chaindb.upper_bound(request, p.upper_bound).pk;
        return walk_table_row_range(p, begin, end_pk);
    }
 
@@ -647,7 +647,7 @@ std::vector<chain::asset> chain_api_plugin_impl::get_currency_balance( const get
 
     const auto next_request = cyberway::chaindb::cursor_request{p.code, accounts_it.cursor};
 
-    for (; accounts_it.pk != cyberway::chaindb::end_primary_key; accounts_it.pk = chaindb.next(next_request)) {
+    for (; accounts_it.pk != cyberway::chaindb::primary_key::End; accounts_it.pk = chaindb.next(next_request)) {
 
         const auto value = chaindb.value_at_cursor({p.code, accounts_it.cursor});
 
@@ -674,7 +674,7 @@ fc::variant chain_api_plugin_impl::get_currency_stats( const get_currency_stats_
     auto& chaindb = chain_controller_.chaindb();
     auto itr = chaindb.begin({p.code, scope, N(stat), cyberway::chaindb::names::primary_index});
 
-    if (itr.pk == cyberway::chaindb::end_primary_key) {
+    if (itr.pk == cyberway::chaindb::primary_key::End) {
         return {};
     }
 
@@ -706,7 +706,7 @@ get_producers_result chain_api_plugin_impl::get_producers( const get_producers_p
     std::string next_producer;
     uint64_t total_votes = 0;
 
-    for (size_t count = 0; producers_it.pk != cyberway::chaindb::end_primary_key; producers_it.pk = chaindb.next(cursor_req)) {
+    for (size_t count = 0; producers_it.pk != cyberway::chaindb::primary_key::End; producers_it.pk = chaindb.next(cursor_req)) {
 
         const auto value = chaindb.value_at_cursor(cursor_req);
         const auto account = value["account"].as_string();
@@ -755,7 +755,7 @@ std::string chain_api_plugin_impl::get_agent_public_key(chain::account_name acco
 
     const auto it = chaindb.lower_bound(request, fc::mutable_variant_object()("token_code", chain::symbol(CORE_SYMBOL).to_symbol_code())("account", account));
 
-    if (it.pk != cyberway::chaindb::end_primary_key) {
+    if (it.pk != cyberway::chaindb::primary_key::End) {
         return chaindb.value_at_cursor({N(), it.cursor})["signing_key"].as_string();
     }
     return "";

--- a/plugins/chain_api_plugin/include/eosio/chain_api_plugin/chain_api_plugin_params.hpp
+++ b/plugins/chain_api_plugin/include/eosio/chain_api_plugin/chain_api_plugin_params.hpp
@@ -62,7 +62,7 @@ namespace eosio {
     struct get_table_rows_params {
         bool                json = false;
         chain::name         code;
-        chain::name         scope;
+        std::string         scope;
         chain::name         table;
         std::string         table_key;
         fc::variant         lower_bound;

--- a/unittests/identity_tests.cpp
+++ b/unittests/identity_tests.cpp
@@ -128,7 +128,7 @@ public:
          chaindb,
          {N(identity), identity, N( certs ), N(bytuple)},
          boost::make_tuple(string_to_name(property.c_str()), trusted, string_to_name(certifier.c_str())));
-      if (find.pk != cyberway::chaindb::end_primary_key) {
+      if (find.pk != cyberway::chaindb::primary_key::End) {
          auto val = chaindb.value_at_cursor({N(identity), find.cursor});
          auto& obj = val.get_object();
          if (obj["property"].as_string() == property && obj["trusted"].as_uint64() == trusted && obj["certifier"].as_string() == certifier) {


### PR DESCRIPTION
Resolve #114:
- Allow to set type of scope for tables. 
- Allow to use typed scope in API request and answers
- Default type is name

Resolve #130:
- Allow to use symbol as primary key and scope

Resolve #643:
- Round string size to 16. It allows to const size of symbols and names

Additional changes:
- assets and symbols in API now in EOS format: '100.000 GOLOS' and '3,GOLOS'
- binary fields can't be emulated from contracts
- undo service fields are stored as numbers, not as names
