### PR TITLE
Fix operation_dump account_name_type bug #726

### DIFF
--- a/programs/create-genesis/ee_genesis/genesis_ee_builder.cpp
+++ b/programs/create-genesis/ee_genesis/genesis_ee_builder.cpp
@@ -46,6 +46,7 @@ golos_dump_header genesis_ee_builder::read_header(bfs::ifstream& in) {
 template<typename Operation>
 bool genesis_ee_builder::read_operation(bfs::ifstream& in, Operation& op) {
     auto op_offset = in.tellg();
+    op = Operation(); // Some types unpacking without clearing
     fc::raw::unpack(in, op);
     op.offset = op_offset;
 


### PR DESCRIPTION
Resolves #726

`fc::fixed_string` in Cyberway fc has problem - it unpacking without clearing.
1. Unpack string with all 16 bytes length.
2. Unpack another - e.g. 8 bytes. It rewrites only first 8 bytes:
https://github.com/GolosChain/cyberway.fc/blob/master/include/fc/fixed_string.hpp#L141
3. But since it was be filled in 1, it hasn't `\0` at end. And, if it hasn't `\0`, it thinks its length is 16 bytes:
https://github.com/GolosChain/cyberway.fc/blob/master/include/fc/fixed_string.hpp#L50

**Golos fc hasn't such problem.** It uses `std::string` buffer when unpacking `fc::fixed_string`.

Another types can have similar problems too. Therefore it is better to recreate struct before unpacking. **It almost don't affect performance.**

Also, we can fix `fixed_string` in fc-library if it is useful.