### PR TITLE
Fix EE-genesis data end message #734

### DIFF
--- a/plugins/event_engine_plugin/event_engine_plugin.cpp
+++ b/plugins/event_engine_plugin/event_engine_plugin.cpp
@@ -359,7 +359,8 @@ void event_engine_plugin::plugin_startup() {
        for(const auto& file: my->genesis_files) {
            my->send_genesis_file(file);
        }
-       my->send_message(GenesisEndMessage(BaseMessage::GenesisEnd));
+       GenesisDataMessage msg(BaseMessage::GenesisData, core_genesis_code, N(dataend), fc::variant_object());
+       my->send_message(msg);
    }
 }
 

--- a/plugins/event_engine_plugin/include/eosio/event_engine_plugin/messages.hpp
+++ b/plugins/event_engine_plugin/include/eosio/event_engine_plugin/messages.hpp
@@ -91,12 +91,7 @@ namespace eosio {
        {}
    };
 
-   struct GenesisEndMessage : public BaseMessage {
-
-       GenesisEndMessage(BaseMessage::MsgType msg_type)
-       : BaseMessage(msg_type)
-       {}
-   };
+   const auto core_genesis_code = N(core);
 
    struct AcceptTrxMessage : public BaseMessage, TrxMetadata {
        AcceptTrxMessage(BaseMessage::MsgType msg_type, const chain::transaction_metadata_ptr &trx_meta)
@@ -173,10 +168,9 @@ FC_REFLECT(eosio::ActionData, (receiver)(code)(action)(data)(args)(events))
 FC_REFLECT(eosio::TrxMetadata, (id)(accepted)(implicit)(scheduled))
 FC_REFLECT(eosio::TrxReceipt, (id)(status)(cpu_usage_us)(net_usage_words)(ram_kbytes)(storage_kbytes))
 
-FC_REFLECT_ENUM(eosio::BaseMessage::MsgType, (Unknown)(GenesisData)(GenesisEnd)(AcceptBlock)(CommitBlock)(AcceptTrx)(ApplyTrx))
+FC_REFLECT_ENUM(eosio::BaseMessage::MsgType, (Unknown)(GenesisData)(AcceptBlock)(CommitBlock)(AcceptTrx)(ApplyTrx))
 FC_REFLECT(eosio::BaseMessage, (msg_type))
 FC_REFLECT_DERIVED(eosio::GenesisDataMessage, (eosio::BaseMessage), (code)(name)(data))
-FC_REFLECT_DERIVED(eosio::GenesisEndMessage, (eosio::BaseMessage), )
 FC_REFLECT_DERIVED(eosio::BlockMessage, (eosio::BaseMessage), (id)(previous)(block_num)(block_time)(validated)(in_current_chain))
 FC_REFLECT_DERIVED(eosio::AcceptedBlockMessage, (eosio::BlockMessage), (trxs)(events))
 FC_REFLECT_DERIVED(eosio::AcceptTrxMessage, (eosio::BaseMessage)(eosio::TrxMetadata), )


### PR DESCRIPTION
Resolves #734

Usual data event:
```
{
    "msg_type": "GenesisData",
    "code": "cyber.token",
    "name": "balance",
    "data": {
        "account": "gls.posting",
        "balance": "249427.023 GOLOS",
        "payments": "0.000 GOLOS"
    }
}
```
Core (non-contract) event `dataend`:
```
{
    "msg_type": "GenesisData",
    "code": "core",
    "name": "dataend",
    "data": {}
}
```