### PR TITLE
More flexible create-genesis setup (reduce hardcode) #737

### DIFF
--- a/programs/create-genesis/genesis_info.hpp
+++ b/programs/create-genesis/genesis_info.hpp
@@ -144,9 +144,15 @@ struct genesis_info {
 
         int64_t max_supply;
         int64_t sys_max_supply;
+
+        struct posts_trx_params {
+            uint16_t expiration_hours = 48;     // allows close-post transaction to live longer
+            fc::optional<time_point_sec> initial_from;  // set to time of golos_state creation to shift transactions delay relatively (offset between initial_time and this value will be added to trxs)
+        } posts_trx;
     } golos;
 
     struct stake_params {
+        bool enabled = false;
         std::vector<uint8_t> max_proxies;
         int64_t payout_step_length;
         uint16_t payout_steps_num;
@@ -174,9 +180,10 @@ FC_REFLECT(cyberway::genesis::genesis_info::table::row, (scope)(payer)(pk)(data)
 FC_REFLECT(cyberway::genesis::genesis_info::table, (code)(table)(abi_type)(rows))
 FC_REFLECT(cyberway::genesis::genesis_info::golos_config::golos_names, (issuer)(control)(vesting)(posting)(social)(charge))
 FC_REFLECT(cyberway::genesis::genesis_info::golos_config::recovery_params, (wait_days))
-FC_REFLECT(cyberway::genesis::genesis_info::golos_config, (domain)(names)(recovery)(max_supply)(sys_max_supply))
+FC_REFLECT(cyberway::genesis::genesis_info::golos_config::posts_trx_params, (expiration_hours)(initial_from))
+FC_REFLECT(cyberway::genesis::genesis_info::golos_config, (domain)(names)(recovery)(max_supply)(sys_max_supply)(posts_trx))
 FC_REFLECT(cyberway::genesis::genesis_info::stake_params,
-    (max_proxies)(payout_step_length)(payout_steps_num)(min_own_staked_for_election))
+    (enabled)(max_proxies)(payout_step_length)(payout_steps_num)(min_own_staked_for_election))
 FC_REFLECT(cyberway::genesis::genesis_info::hardfork_info, (version)(time))
 FC_REFLECT(cyberway::genesis::genesis_info::parameters, (stake)(posting_rules)(require_hardfork))
 FC_REFLECT(cyberway::genesis::genesis_info, (state_file)(genesis_json)(accounts)(auth_links)(tables)(golos)(params))

--- a/programs/create-genesis/serializer.hpp
+++ b/programs/create-genesis/serializer.hpp
@@ -22,6 +22,8 @@ const fc::microseconds abi_serializer_max_time = fc::seconds(10);
 
 
 enum class stored_contract_tables: int {
+    system_account, system_acc_seq, system_res_usage, system_permission, system_perm_usage,
+    import_account, import_acc_seq, import_res_usage, import_permission, import_perm_usage,
     domains,        usernames,
     permissionlink, sys_permissionlink,
     token_stats,    vesting_stats,
@@ -29,7 +31,7 @@ enum class stored_contract_tables: int {
     delegation,     rdelegation,
     withdrawal,
     witness_vote,   witness_info,
-    reward_pool,    post_limits,
+    reward_pool,    //post_limits,
     gtransaction,   bandwidths,
     messages,       permlinks,
     votes,


### PR DESCRIPTION
+ removed posting contracts limits table, it can be set with custom tables feature in genesis-info.json
+ add option to enable staking
+ add options to setup deferred transactions delay and expiration
+ remove some magic numbers
+ simplify some code

***
deferred trx params are the following:
```json
{
    "golos": {
        "posts_trx": {
            "expiration_hours": 2,
            "initial_from": "2019-02-20T11:38:15"
        }
}
```
* `expiration_hours` allows to set `closemssg` transaction expiration time. that transactions are fast enough now, so value can be several hours. default is 48 hours (if not exists in genesis-info.json)
* `initial_from` is optional value. if set, then deferred transactions delayed by value = `genesis.initial_timestamp – initial_from – 7days`, so setting `initial_from` to time of golos_state creation will delay transactions so they close posts relative to `genesis.initial_timestamp`