### PR TITLE
Fix duplicate uniques on undo #755

### DIFF
--- a/libraries/chain/include/cyberway/chaindb/journal.hpp
+++ b/libraries/chain/include/cyberway/chaindb/journal.hpp
@@ -146,7 +146,6 @@ namespace cyberway { namespace chaindb {
         void apply_range_changes(Ctx&& ctx, index_t_::iterator begin, index_t_::iterator end) {
             if (begin == end) return;
 
-            ctx.init();
             for (auto itr = begin; end != itr; ++itr) {
                 auto& table = *itr;
                 if (table.info_map.empty()) continue;


### PR DESCRIPTION
Resolve #755:

An example.
- Table A has unique primary key P, and unique key U. 
- Object in table A: {P, U}

Steps
- Create an object {Pa, Ua}
- Remove the object {Pa, Ua}
- Create an object {Pb, Ua}

For the correct restoring of the state in the table A, steps should be done in the following order:
- Remove {Pb, Ua}
- Create {Pa, Ua}

The following steps will fail, because the table A can't have two objects with the same value Ua:
- Create {Pa, Ua}
- Remove {Pb, Ua}

This PR implements the order of db-operations:
- Remove NEW 
- Update OLD
- Insert REMOVED

And in this PR 