### PR TITLE
Update genesis golos state file reader to v2 #780

### DIFF
--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -29,6 +29,8 @@ template<typename T> void unpack(T& s, cyberway::golos::comment_object& c) {
     fc::raw::unpack(s, c.parent_permlink);
     fc::raw::unpack(s, c.author);
     fc::raw::unpack(s, c.permlink);
+    fc::raw::unpack(s, c.depth);
+    fc::raw::unpack(s, c.children);
     fc::raw::unpack(s, c.mode);
     if (c.mode != cyberway::golos::comment_mode::archived) {
         fc::raw::unpack(s, c.active);

--- a/programs/create-genesis/golos_objects.hpp
+++ b/programs/create-genesis/golos_objects.hpp
@@ -209,8 +209,6 @@ struct block_summary_object {
 struct active_comment_data {
     time_point_sec created;
     time_point_sec last_payout;
-    uint16_t depth;
-    uint32_t children;
     uint128_t children_rshares2;
     share_type net_rshares;
     share_type abs_rshares;
@@ -239,7 +237,9 @@ struct comment_object {
     shared_permlink parent_permlink;
     account_name_type author;
     shared_permlink permlink;
-    comment_mode mode;
+    fc::unsigned_int depth;
+    fc::unsigned_int children;
+    uint8_t mode;                   // comment_mode
     active_comment_data active;
 };
 struct comment_vote_object {
@@ -447,9 +447,9 @@ FC_REFLECT(cyberway::golos::witness_vote_object, (id)(witness)(account))
 FC_REFLECT(cyberway::golos::block_summary_object, (id)(block_id))
 
 // comment must be unpacked manually
-// FC_REFLECT(cyberway::golos::comment_object, (id)(parent_author)(parent_permlink)(author)(permlink)(mode))
+// FC_REFLECT(cyberway::golos::comment_object, (id)(parent_author)(parent_permlink)(author)(permlink)(depth)(children)(mode))
 FC_REFLECT(cyberway::golos::active_comment_data,
-    (created)(last_payout)(depth)(children)
+    (created)(last_payout)
     (children_rshares2)(net_rshares)(abs_rshares)(vote_rshares)(children_abs_rshares)(cashout_time)(max_cashout_time)
     (reward_weight)(net_votes)(total_votes)(root_comment)
     (curation_reward_curve)(auction_window_reward_destination)(auction_window_size)(max_accepted_payout)

--- a/programs/create-genesis/golos_state_container.hpp
+++ b/programs/create-genesis/golos_state_container.hpp
@@ -6,6 +6,7 @@ namespace cyberway { namespace genesis {
 struct golos_state_header {
     char magic[12];
     uint32_t version;
+    uint32_t block_num;
 
     static constexpr auto expected_magic = "Golos\astatE";
 };

--- a/programs/create-genesis/state_reader.hpp
+++ b/programs/create-genesis/state_reader.hpp
@@ -206,8 +206,8 @@ struct state_object_visitor {
                 .permlink = c.permlink.id,
                 .parent_author = c.parent_author.id,
                 .parent_permlink = c.parent_permlink.id,
-                .depth = c.active.depth,      // TODO: should be in consensus part of golos state GolosChain/golos#1302
-                .children = c.active.children
+                .depth = static_cast<uint16_t>(c.depth.value),
+                .children = c.children.value
             });
         }
     }
@@ -273,10 +273,13 @@ public:
         read_maps();
 
         bfs::ifstream in(_state_file);
-        golos_state_header h{"", 0};
+        golos_state_header h{"", 0, 0};
         in.read((char*)&h, sizeof(h));
-        EOS_ASSERT(string(h.magic) == golos_state_header::expected_magic && h.version == 1, genesis_exception,
-            "Unknown format of the Genesis state file.");
+        EOS_ASSERT(string(h.magic) == golos_state_header::expected_magic, genesis_exception,
+            "Unknown format of the Golos state file.");
+        EOS_ASSERT(h.version == 2, genesis_exception,
+            "Can only open Golos state file version 2, but version ${v} provided.", ("v", h.version));
+        EOS_ASSERT(h.block_num > 0, genesis_exception, "Golos state file block_num should be greater than 0.");
 
         while (in && !visitor.early_exit) {
             golos_table_header t;


### PR DESCRIPTION
**Note:** this will require to use new `golos_state.dat` & `golos_state.dat.map` files.

+ `block_number` of the dump is in state header now
+ better checks of state header
+ `children` and `depth` comment fields moved to all comments (was active only)
+ comment structure is more compact now
