### PR TITLE
ABI from account. #642

### DIFF
--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library( eosio_chain
              chaindb/storage_calculator.cpp
              chaindb/typed_name.cpp
              chaindb/account_abi_info.cpp
+             chaindb/value_verifier.cpp
 
              cyberway/domain_name.cpp
              cyberway/cyberway_contract.cpp

--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -54,6 +54,7 @@ add_library( eosio_chain
              chaindb/abi_info.cpp
              chaindb/storage_calculator.cpp
              chaindb/typed_name.cpp
+             chaindb/account_abi_info.cpp
 
              cyberway/domain_name.cpp
              cyberway/cyberway_contract.cpp

--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -570,19 +570,11 @@ namespace eosio { namespace chain {
          return var.as<bytes>();
       }
 
-#ifdef __APPLE__
       char temp[1024*1024];
       char* pt = temp;
       fc::datastream<char*> ds(pt, sizeof(temp));
       _variant_to_binary(type, var, ds, ctx);
       return bytes{pt, pt + ds.tellp()};
-#else
-      bytes temp( 1024*1024 );
-      fc::datastream<char*> ds(temp.data(), temp.size() );
-      _variant_to_binary(type, var, ds, ctx);
-      temp.resize(ds.tellp());
-      return temp;
-#endif
    } FC_CAPTURE_AND_RETHROW( (type)(var) ) }
 
    bytes abi_serializer::variant_to_binary( const type_name& type, const fc::variant& var, const fc::microseconds& max_serialization_time, bool short_path )const {

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -87,7 +87,7 @@ void apply_context::exec_one( action_trace& trace )
    r.global_sequence  = next_global_sequence();
    r.recv_sequence    = next_recv_sequence( receiver );
 
-   const auto& account_sequence = chaindb.get<account_sequence_object, by_name>(act.account);
+   const auto& account_sequence = chaindb.get<account_sequence_object>(act.account);
    r.code_sequence    = account_sequence.code_sequence; // could be modified by action execution above
    r.abi_sequence     = account_sequence.abi_sequence;  // could be modified by action execution above
 
@@ -163,7 +163,7 @@ account_name apply_context::resolve_username(const account_name& scope, const us
 
 
 bool apply_context::is_account( const account_name& account )const {
-   return nullptr != chaindb.find<account_object,by_name>( account );
+   return nullptr != chaindb.find<account_object>( account );
 }
 
 void apply_context::require_authorization( const account_name& account ) {
@@ -248,7 +248,7 @@ void apply_context::require_recipient( account_name recipient ) {
  *   can better understand the security risk.
  */
 void apply_context::execute_inline( action&& a ) {
-   auto* code = chaindb.find<account_object, by_name>(a.account);
+   auto* code = chaindb.find<account_object>(a.account);
    EOS_ASSERT( code != nullptr, action_validate_exception,
                "inline action's code account ${account} does not exist", ("account", a.account) );
 
@@ -264,7 +264,7 @@ void apply_context::execute_inline( action&& a ) {
    }
 
    for( const auto& auth : a.authorization ) {
-      auto* actor = chaindb.find<account_object, by_name>(auth.actor);
+      auto* actor = chaindb.find<account_object>(auth.actor);
       EOS_ASSERT( actor != nullptr, action_validate_exception,
                   "inline action's authorizing actor ${account} does not exist", ("account", auth.actor) );
       EOS_ASSERT( control.get_authorization_manager().find_permission(auth) != nullptr, action_validate_exception,
@@ -315,7 +315,7 @@ void apply_context::execute_inline( action&& a ) {
 }
 
 void apply_context::execute_context_free_inline( action&& a ) {
-   auto* code = chaindb.find<account_object, by_name>(a.account);
+   auto* code = chaindb.find<account_object>(a.account);
    EOS_ASSERT( code != nullptr, action_validate_exception,
                "inline action's code account ${account} does not exist", ("account", a.account) );
 
@@ -771,14 +771,14 @@ uint64_t apply_context::next_global_sequence() {
 }
 
 uint64_t apply_context::next_recv_sequence( account_name receiver ) {
-   const auto& rs = chaindb.get<account_sequence_object,by_name>( receiver );
+   const auto& rs = chaindb.get<account_sequence_object>( receiver );
    chaindb.modify( rs, [&]( auto& mrs ) {
       ++mrs.recv_sequence;
    });
    return rs.recv_sequence;
 }
 uint64_t apply_context::next_auth_sequence( account_name actor ) {
-   const auto& rs = chaindb.get<account_sequence_object,by_name>( actor );
+   const auto& rs = chaindb.get<account_sequence_object>( actor );
    chaindb.modify( rs, [&](auto& mrs ){
       ++mrs.auth_sequence;
    });

--- a/libraries/chain/authorization_manager.cpp
+++ b/libraries/chain/authorization_manager.cpp
@@ -80,7 +80,7 @@ namespace eosio { namespace chain {
 
    void authorization_manager::remove_permission( const permission_object& permission, const storage_payer_info& payer ) {
       auto parent_idx = _chaindb.get_index<permission_object, by_parent>();
-      auto range = parent_idx.equal_range(permission.id._id);
+      auto range = parent_idx.equal_range(permission.id);
       EOS_ASSERT( range.first == range.second, action_validate_exception,
                   "Cannot remove a permission which has children. Remove the children first.");
 

--- a/libraries/chain/chaindb/abi_info.cpp
+++ b/libraries/chain/chaindb/abi_info.cpp
@@ -270,7 +270,7 @@ namespace cyberway { namespace chaindb {
         return to_bytes_("index", [&]{return type;}, type, value);
     }
 
-    void abi_info::verify_tables_structure(driver_interface& driver) const {
+    void abi_info::verify_tables_structure(const driver_interface& driver) const {
         fc::flat_map<table_name, const table_def*> tables;
         fc::flat_map<index_name, const index_def*> indexes;
         tables.reserve(tables.size());

--- a/libraries/chain/chaindb/abi_info.cpp
+++ b/libraries/chain/chaindb/abi_info.cpp
@@ -131,7 +131,7 @@ namespace cyberway { namespace chaindb {
             _detail::struct_def_map_type dst_struct_map;
             std::vector<struct_def*> dst_structs;
 
-            auto max_size = index.orders.size() * abi_info::max_path_depth();
+            auto max_size = index.orders.size() * abi_info::MaxPathDepth;
             dst_struct_map.reserve(max_size);
             dst_structs.reserve(max_size);
             auto struct_name = get_root_index_name(table, index);
@@ -144,7 +144,7 @@ namespace cyberway { namespace chaindb {
                     ("type", order.order)("index", root_struct.name));
 
                 boost::split(order.path, order.field, [](char c){return c == '.';});
-                CYBERWAY_ASSERT(order.path.size() <= abi_info::max_path_depth(), invalid_index_description_exception,
+                CYBERWAY_ASSERT(order.path.size() <= abi_info::MaxPathDepth, invalid_index_description_exception,
                     "Path for index is too long in the index ${index}", ("index", root_struct.name));
 
                 auto dst_struct = &root_struct;
@@ -230,16 +230,16 @@ namespace cyberway { namespace chaindb {
         }
         serializer_.set_abi(abi, max_abi_time_);
 
-        CYBERWAY_ASSERT(abi.tables.size() <= max_table_cnt(), max_table_count_exception,
+        CYBERWAY_ASSERT(abi.tables.size() <= MaxTableCnt, max_table_count_exception,
             "The account '${code}' can't create more than ${max} tables",
-            ("code", get_code_name(code_))("max", max_table_cnt()));
+            ("code", get_code_name(code_))("max", size_t(MaxTableCnt)));
 
 
         table_map_.reserve(abi.tables.size());
         for (auto& table: abi.tables) {
-            CYBERWAY_ASSERT(table.indexes.size() <= max_index_cnt(), max_index_count_exception,
+            CYBERWAY_ASSERT(table.indexes.size() <= MaxIndexCnt, max_index_count_exception,
                 "The table '${table}' can't has more than ${max} indexes",
-                ("table", get_full_table_name(code_, table))("max", max_index_cnt()));
+                ("table", get_full_table_name(code_, table))("max", size_t(MaxIndexCnt)));
             auto id = table.name;
             table_map_.emplace(id, std::move(table));
         }
@@ -261,7 +261,7 @@ namespace cyberway { namespace chaindb {
         fc::flat_set<std::string> paths;
 
         auto db_tables = driver.db_tables(code_);
-        const auto max_db_index_cnt = db_tables.size() * max_index_cnt();
+        const auto max_db_index_cnt = db_tables.size() * MaxIndexCnt;
         drop_tables.reserve(    db_tables.size());
         drop_indexes.reserve(   max_db_index_cnt);
         create_indexes.reserve( max_db_index_cnt);

--- a/libraries/chain/chaindb/abi_info.cpp
+++ b/libraries/chain/chaindb/abi_info.cpp
@@ -225,8 +225,8 @@ namespace cyberway { namespace chaindb {
     abi_info::abi_info(const account_name& code, abi_def abi)
     : code_(code),
       serializer_() {
-        if (is_system_code(code)) {
-            serializer_.set_check_field_name(false);
+        if (!is_system_code(code)) {
+            serializer_.set_check_field_name(true);
         }
         serializer_.set_abi(abi, max_abi_time_);
 

--- a/libraries/chain/chaindb/abi_info.cpp
+++ b/libraries/chain/chaindb/abi_info.cpp
@@ -224,7 +224,7 @@ namespace cyberway { namespace chaindb {
 
     abi_info::abi_info(const account_name& code, abi_def abi)
     : code_(code),
-      serializer_(eosio::chain::abi_serializer::DBMode) {
+      serializer_() {
         if (is_system_code(code)) {
             serializer_.set_check_field_name(false);
         }

--- a/libraries/chain/chaindb/account_abi_info.cpp
+++ b/libraries/chain/chaindb/account_abi_info.cpp
@@ -1,5 +1,6 @@
 #include <cyberway/chaindb/account_abi_info.hpp>
-#include <cyberway/chaindb/undo_state.hpp>
+#include <cyberway/chaindb/table_info.hpp>
+#include <cyberway/chaindb/driver_interface.hpp>
 
 namespace eosio { namespace chain {
     namespace chaindb = cyberway::chaindb;
@@ -18,8 +19,6 @@ namespace eosio { namespace chain {
 
 namespace cyberway { namespace  chaindb {
 
-    namespace config = eosio::chain::config;
-
     account_abi_info::account_abi_info(cache_object_ptr account_ptr)
     : account_ptr_(std::move(account_ptr)) {
         if (!account_ptr_) {
@@ -37,26 +36,70 @@ namespace cyberway { namespace  chaindb {
         const_cast<account_object&>(a).generate_abi_info();
     }
 
-    const account_abi_info& account_abi_info::system_abi_info() {
-        static account_abi_info system_abi_info([&]() {
+    struct system_abi_info_impl final {
+        account_abi_info info;
+        index_info       index;
+
+        system_abi_info_impl(const driver_interface& driver)
+        : driver_(driver) {
+            init_info();
+        }
+
+        void init_info() {
+            init_info(eosio::chain::eosio_contract_abi());
+
+            auto obj = driver_.object_by_pk(index, config::system_account_name);
+            if (obj.value.is_object()) {
+                auto& abi = obj.value["abi"];
+                if (abi.is_blob() && !abi.get_blob().data.empty()) {
+                    init_info(abi.get_blob().data);
+                }
+            }
+        }
+
+        template <typename Abi> void init_info(Abi&& def) {
             service_state service;
 
             service.table = chaindb::tag<account_object>::get_code();
             service.pk    = config::system_account_name;
 
-            auto obj_ptr  = std::make_unique<cache_object>(std::move(service));
-
-            obj_ptr->set_data<account_item_data>(config::system_account_name, [&](auto& a) {
-                auto def = eosio::chain::eosio_contract_abi();
-                undo_stack::add_abi_tables(def);
-                a.set_abi(def);
-                a.generate_abi_info();
+            auto cache_ptr  = std::make_unique<cache_object>(std::move(service));
+            cache_ptr->set_data<multi_index_item_data<account_object>>(config::system_account_name, [&](auto& a) {
+                a.set_abi(std::forward<Abi>(def));
             });
 
-            return cache_object_ptr(obj_ptr.release());
-        }());
+            info = account_abi_info(cache_ptr.release());
 
-        return system_abi_info;
+            init_index();
+        }
+
+    private:
+        const driver_interface& driver_;
+
+        void init_index() {
+            auto& abi   = info.abi();
+            auto  table = abi.find_table(chaindb::tag<account_object>::get_code());
+            index.table    = table;
+            index.index    = abi.find_pk_index(*table);
+            index.pk_order = abi.find_pk_order(*table);
+        }
+    }; // struct system_abi_info_impl
+
+    system_abi_info::system_abi_info(const driver_interface& driver)
+    : impl_(std::make_unique<system_abi_info_impl>(driver)),
+      info_(impl_->info),
+      index_(impl_->index) {
+    }
+
+    system_abi_info::~system_abi_info() = default;
+
+    void system_abi_info::init_abi() const {
+        impl_->init_info();
+    }
+
+    void system_abi_info::set_abi(blob a) const {
+        assert(!a.data.empty());
+        impl_->init_info(std::move(a.data));
     }
 
 } } // namespace cyberway::chaindb

--- a/libraries/chain/chaindb/account_abi_info.cpp
+++ b/libraries/chain/chaindb/account_abi_info.cpp
@@ -1,0 +1,60 @@
+#include <cyberway/chaindb/account_abi_info.hpp>
+#include <cyberway/chaindb/undo_state.hpp>
+
+namespace eosio { namespace chain {
+    namespace chaindb = cyberway::chaindb;
+
+    void account_object::generate_abi_info() {
+        abi_info_ = std::make_unique<chaindb::abi_info>(name, get_abi());
+    }
+
+    const chaindb::abi_info& account_object::get_abi_info() const {
+        return *abi_info_.get();
+    }
+
+} } // namespace eosio::chain
+
+namespace cyberway { namespace  chaindb {
+
+    namespace config = eosio::chain::config;
+
+    account_abi_info::account_abi_info(cache_object_ptr account_ptr)
+    : account_ptr_(std::move(account_ptr)) {
+        if (!account_ptr_) {
+            return;
+        }
+
+        assert(account_ptr_->service().table == chaindb::tag<account_object>::get_code());
+
+        auto& a = account();
+        if (a.abi.empty()) {
+            account_ptr_.reset();
+            return;
+        }
+
+        const_cast<account_object&>(a).generate_abi_info();
+    }
+
+    const account_abi_info& account_abi_info::system_abi_info() {
+        static account_abi_info system_abi_info([&]() {
+            service_state service;
+
+            service.table = chaindb::tag<account_object>::get_code();
+            service.pk    = config::system_account_name;
+
+            auto obj_ptr  = std::make_unique<cache_object>(std::move(service));
+
+            obj_ptr->set_data<account_item_data>(config::system_account_name, [&](auto& a) {
+                auto def = eosio::chain::eosio_contract_abi();
+                undo_stack::add_abi_tables(def);
+                a.set_abi(def);
+                a.generate_abi_info();
+            });
+
+            return cache_object_ptr(obj_ptr.release());
+        }());
+
+        return system_abi_info;
+    }
+
+} } // namespace cyberway::chaindb

--- a/libraries/chain/chaindb/account_abi_info.cpp
+++ b/libraries/chain/chaindb/account_abi_info.cpp
@@ -5,7 +5,9 @@ namespace eosio { namespace chain {
     namespace chaindb = cyberway::chaindb;
 
     void account_object::generate_abi_info() {
-        abi_info_ = std::make_unique<chaindb::abi_info>(name, get_abi());
+        if (!abi_info_) {
+            abi_info_ = std::make_unique<chaindb::abi_info>(name, get_abi());
+        }
     }
 
     const chaindb::abi_info& account_object::get_abi_info() const {

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -910,7 +910,10 @@ namespace cyberway { namespace chaindb {
             }
 
             if (!cache_obj_ptr) {
-                cache_obj_ptr = cache_object_ptr(new cache_object(value.service));
+                object_value obj;
+                obj.service = value.service;
+                obj.service.size = 0;
+                cache_obj_ptr = cache_object_ptr(new cache_object(std::move(obj)));
                 is_new_ptr = true;
             }
 
@@ -959,8 +962,7 @@ namespace cyberway { namespace chaindb {
 
             if (is_new_ptr) {
                 // create object, but don't add it to RAM
-                obj_ptr = cache_object_ptr(new cache_object(value.service));
-                obj_ptr->object_ = std::move(value);
+                obj_ptr = cache_object_ptr(new cache_object(std::move(value)));
             }
 
             auto service_ptr = find_cache_service(value);
@@ -999,8 +1001,8 @@ namespace cyberway { namespace chaindb {
 
     //---------------------------------------
 
-    cache_object::cache_object(service_state service) {
-        object_.service = std::move(service);
+    cache_object::cache_object(object_value obj) {
+        object_ = std::move(obj);
     }
 
     bool cache_object::is_valid_cell() const {

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -846,10 +846,9 @@ namespace cyberway { namespace chaindb {
             for (auto& i: ttr->indexes) if (i.unique && i.name != names::primary_index) {
                 info.index = &i;
 
-                auto big_blob = abi.to_bytes(info, object.value); // size of this object is 1 Mb
-                if (big_blob.empty()) continue;
+                auto blob = abi.to_bytes(info, object.value);
+                if (blob.empty()) continue;
 
-                auto blob = bytes(big_blob.begin(), big_blob.end()); // minize memory usage
                 indicies.emplace_back(i.name, std::move(blob), obj);
                 CYBERWAY_ASSERT(cache_index_tree_.end() == cache_index_tree_.find(indicies.back()),
                     driver_duplicate_exception, "Cache duplicate unique records in the index ${index}",

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -268,7 +268,7 @@ namespace cyberway { namespace chaindb {
     
             auto delta = state.prev_state ?
                 std::max(eosio::chain::int_arithmetic::safe_prop<uint64_t>(object_size, pos - state.prev_state->cell->pos, max_distance_), uint64_t(1)) : 
-                object_size * eosio::chain::config::ram_load_multiplier;
+                object_size * config::ram_load_multiplier;
                 
             CYBERWAY_CACHE_ASSERT(UINT64_MAX - size >= delta, "Pending delta would overflow UINT64_MAX");
             size += delta;
@@ -729,8 +729,8 @@ namespace cyberway { namespace chaindb {
         uint64_t               ram_used_  = 0;
 
         static uint64_t get_ram_limit(
-            const uint64_t limit   = eosio::chain::config::default_ram_size,
-            const uint64_t reserve = eosio::chain::config::default_reserved_ram_size
+            const uint64_t limit   = config::default_ram_size,
+            const uint64_t reserve = config::default_reserved_ram_size
         ) {
             // reserve for system objects (transactions, blocks, ...)
             //     and for pending caches (pending_cell_list_, ...)

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -1100,10 +1100,17 @@ namespace cyberway { namespace chaindb {
 
     cache_object_ptr cache_map::create(const table_info& info, const storage_payer_info& storage) const {
         auto pk = impl_->get_next_pk(info);
-        if (BOOST_UNLIKELY(primary_key::Unset == pk)) {
-            return {};
+        if (BOOST_LIKELY(primary_key::Unset != pk)) {
+            return create(info, pk, storage);
         }
+        return {};
+    }
 
+    cache_object_ptr cache_map::create(
+        const table_info& info, const primary_key_t pk, const storage_payer_info& storage
+    ) const {
+        CYBERWAY_ASSERT(primary_key::Unset != pk && primary_key::End != pk, cache_primary_key_exception,
+            "Value ${pk} can't be used as primary key", ("pk", pk));
         auto obj = object_value{info.to_service(pk), {}};
         obj.service.payer  = storage.owner;
         obj.service.in_ram = true;

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -96,23 +96,24 @@ namespace cyberway { namespace chaindb {
     }
 
     struct cache_index_key final {
-        const index_info& info;
-        const char*       blob;
-        const size_t      size;
+        const service_state& service;
+        const index_name_t   index;
+        const char*          blob;
+        const size_t         size;
     }; // struct cache_index_key
 
     struct cache_index_compare {
         index_name_t   index(const cache_index_value& v) const { return v.index;                   }
-        index_name_t   index(const cache_index_key& v  ) const { return v.info.index_name();       }
+        index_name_t   index(const cache_index_key& v  ) const { return v.index;                   }
 
         table_name_t   table(const cache_index_value& v) const { return v.object->service().table; }
-        table_name_t   table(const cache_index_key& v  ) const { return v.info.table_name();       }
+        table_name_t   table(const cache_index_key& v  ) const { return v.service.table;           }
 
         account_name_t code (const cache_index_value& v) const { return v.object->service().code;  }
-        account_name_t code (const cache_index_key& v  ) const { return v.info.code;               }
+        account_name_t code (const cache_index_key& v  ) const { return v.service.code;            }
 
         scope_name_t   scope(const cache_index_value& v) const { return v.object->service().scope; }
-        scope_name_t   scope(const cache_index_key& v  ) const { return v.info.scope;              }
+        scope_name_t   scope(const cache_index_key& v  ) const { return v.service.scope;           }
 
         size_t         size (const cache_index_value& v) const { return v.blob.size();             }
         size_t         size (const cache_index_key& v  ) const { return v.size;                    }
@@ -1114,12 +1115,14 @@ namespace cyberway { namespace chaindb {
         impl_->set_next_pk(table, pk);
     }
 
-    cache_object_ptr cache_map::find(const table_info& table, const primary_key_t pk) const {
-        return impl_->find(table.to_service(pk));
+    cache_object_ptr cache_map::find(const service_state& service) const {
+        return impl_->find(service);
     }
 
-    cache_object_ptr cache_map::find(const index_info& info, const char* value, const size_t size) const {
-        return impl_->find({info, value, size});
+    cache_object_ptr cache_map::find(
+        const service_state& service, const index_name_t index, const char* value, const size_t size
+    ) const {
+        return impl_->find({service, index, value, size});
     }
 
     cache_object_ptr cache_map::emplace(const table_info& table, object_value obj) const {

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -2,6 +2,7 @@
 #include <cyberway/chaindb/controller.hpp>
 #include <cyberway/chaindb/abi_info.hpp>
 #include <cyberway/chaindb/exception.hpp>
+#include <cyberway/chaindb/table_info.hpp>
 
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/resource_limits_private.hpp>
@@ -102,7 +103,7 @@ namespace cyberway { namespace chaindb {
 
     struct cache_index_compare {
         index_name_t   index(const cache_index_value& v) const { return v.index;                   }
-        index_name_t   index(const cache_index_key& v  ) const { return v.info.index->name;        }
+        index_name_t   index(const cache_index_key& v  ) const { return v.info.index_name();       }
 
         table_name_t   table(const cache_index_value& v) const { return v.object->service().table; }
         table_name_t   table(const cache_index_key& v  ) const { return v.info.table_name();       }
@@ -463,9 +464,8 @@ namespace cyberway { namespace chaindb {
 
     class cache_map_impl final {
     public:
-        cache_map_impl(abi_map& map)
-        : abi_map_(map),
-          system_cell_(*this) {
+        cache_map_impl()
+        : system_cell_(*this) {
         }
 
         ~cache_map_impl() {
@@ -491,11 +491,11 @@ namespace cyberway { namespace chaindb {
             return obj_ptr;
         }
 
-        cache_object_ptr emplace(object_value value) {
+        cache_object_ptr emplace(const table_info& table, object_value value) {
             if (!value.service.in_ram) {
-                return create_cache_object(std::move(value));
+                return create_cache_object(table, std::move(value));
             } else {
-                return emplace_in_ram(std::move(value));
+                return emplace_in_ram(table, std::move(value));
             }
         }
 
@@ -506,10 +506,49 @@ namespace cyberway { namespace chaindb {
             }
         }
 
+        void set_object(const table_info& table, cache_object& cache_obj, object_value value) {
+            assert(cache_obj.service().empty() || cache_obj.is_valid_table(value.service));
+
+            int delta = value.service.size - cache_obj.service().size;
+            cache_obj.object_ = std::move(value);
+            cache_obj.blob_.clear();
+
+            if (!cache_obj.has_cell()) {
+                return;
+            }
+
+            add_ram_usage(cache_obj.cell(), delta);
+
+            if (is_system_code(cache_obj.service().code)) {
+                using state_object = eosio::chain::resource_limits::resource_limits_state_object;
+                if (cache_obj.has_data() && cache_obj.service().table == chaindb::tag<state_object>::get_code()) {
+                    auto& state = multi_index_item_data<state_object>::get_T(cache_obj);
+                    ram_limit_ = get_ram_limit(state.ram_size, state.reserved_ram_size);
+                }
+
+                // don't rebuild indicies for interchain objects
+                if (cache_obj.indicies_.capacity()) {
+                    return;
+                }
+            }
+
+            delete_cache_indicies(cache_obj.indicies_);
+            build_cache_indicies(table, cache_obj);
+        }
+
+        void set_service(const table_info&, cache_object& cache_obj, service_state service) {
+            assert(cache_obj.is_valid_table(service));
+
+            cache_obj.object_.service = std::move(service);
+            if (!cache_obj.service().in_ram && cache_obj.has_cell()) {
+                cache_obj.mark_deleted();
+            }
+        }
+
         void set_revision(const service_state& key, const revision_t rev) {
             auto obj_ptr = find(key);
             if (obj_ptr) {
-                obj_ptr->set_revision(rev);
+                obj_ptr->object_.service.revision = rev;
             }
         }
 
@@ -669,34 +708,12 @@ namespace cyberway { namespace chaindb {
             return false;
         }
 
-        void change_cache_object(cache_object& obj, const int delta) {
-            add_ram_usage(obj.cell(), delta);
-
-            if (is_system_code(obj.service().code)) {
-                using state_object = eosio::chain::resource_limits::resource_limits_state_object;
-                if (obj.has_data() && obj.service().table == chaindb::tag<state_object>::get_code()) {
-                    auto& state = multi_index_item_data<state_object>::get_T(obj);
-                    ram_limit_ = get_ram_limit(state.ram_size, state.reserved_ram_size);
-                }
-
-                // don't rebuild indicies for interchain objects
-                if (obj.indicies_.capacity()) {
-                    return;
-                }
-            }
-
-            delete_cache_indicies(obj.indicies_);
-            build_cache_indicies(obj);
-        }
-
     private:
         using cache_object_tree_type = intr::set<cache_object, intr::constant_time_size<false>>;
         using cache_index_tree_type  = intr::set<cache_index_value, intr::constant_time_size<false>>;
         using lru_cell_list_type     = std::deque<lru_cache_cell>;
         using pending_cell_list_type = std::deque<pending_cache_cell>;
         using service_tree_type      = fc::flat_map<cache_service_key, cache_service_info>;
-
-        abi_map&               abi_map_;
 
         cache_object_tree_type cache_object_tree_;
         cache_object_tree_type deleted_object_tree_;
@@ -824,37 +841,35 @@ namespace cyberway { namespace chaindb {
             return nullptr;
         }
 
-        void build_cache_indicies(cache_object& obj) {
-            auto& object  = obj.object();
-            if (object.is_null()) return;
-
-            auto& service = obj.service();
-            auto  ctr = abi_map_.find(service.code);
-            if (abi_map_.end() == ctr) return;
-
-            auto& abi = ctr->second;
-            auto  ttr = abi.find_table(service.table);
-            if (!ttr) return;
-
-            auto& indicies = obj.indicies_;
-            indicies.reserve(ttr->indexes.size() - 1 /* skip primary */);
-            auto info = index_info(service.code, service.scope);
-            info.table = ttr;
-
-            for (auto& i: ttr->indexes) if (i.unique && i.name != names::primary_index) {
-                info.index = &i;
-
-                auto blob = abi.to_bytes(info, object.value);
-                if (blob.empty()) continue;
-
-                indicies.emplace_back(i.name, std::move(blob), obj);
-                CYBERWAY_ASSERT(cache_index_tree_.end() == cache_index_tree_.find(indicies.back()),
-                    driver_duplicate_exception, "Cache duplicate unique records in the index ${index}",
-                    ("index", get_full_index_name(info)));
+        void build_cache_indicies(const table_info& table, cache_object& cache_obj) {
+            if (cache_obj.object_.is_null()) {
+                return;
             }
 
-            for (auto& i: indicies) {
-                cache_index_tree_.insert(i);
+            auto& object   = cache_obj.object_;
+            auto& service  = object.service;
+            auto& indicies = cache_obj.indicies_;
+            indicies.reserve(table.table->indexes.size() - 1 /* skip primary */);
+
+            auto index = index_info(service.code, service.scope);
+            index.table = table.table;
+
+            for (auto& idx: table.table->indexes) if (idx.unique && idx.name != names::primary_index) {
+                index.index = &idx;
+
+                auto blob = table.abi().to_bytes(index, object.value);
+                if (blob.empty()) {
+                    continue;
+                }
+
+                indicies.emplace_back(idx.name, std::move(blob), cache_obj);
+                CYBERWAY_ASSERT(cache_index_tree_.end() == cache_index_tree_.find(indicies.back()),
+                    driver_duplicate_exception, "Cache duplicate unique records in the index ${index}",
+                    ("index", get_full_index_name(index)));
+            }
+
+            for (auto& idx: indicies) {
+                cache_index_tree_.insert(idx);
             }
         }
 
@@ -884,53 +899,52 @@ namespace cyberway { namespace chaindb {
             return obj_ptr;
         }
 
-        cache_object_ptr emplace_in_ram(object_value value) {
-            auto obj_ptr = find_in_cache(value.service);
+        cache_object_ptr emplace_in_ram(const table_info& table, object_value value) {
+            auto cache_obj_ptr = find_in_cache(value.service);
             bool is_new_ptr = false;
             bool is_del_ptr = false;
 
-            if (!obj_ptr && has_pending_cell()) {
-                obj_ptr = find_in_deleted(value.service);
-                is_del_ptr = !!obj_ptr;
+            if (!cache_obj_ptr && has_pending_cell()) {
+                cache_obj_ptr = find_in_deleted(value.service);
+                is_del_ptr = !!cache_obj_ptr;
             }
 
-            if (!obj_ptr) {
-                obj_ptr = cache_object_ptr(new cache_object());
+            if (!cache_obj_ptr) {
+                cache_obj_ptr = cache_object_ptr(new cache_object(value.service));
                 is_new_ptr = true;
             }
 
             assert(!is_new_ptr || !is_del_ptr);
 
+            auto& cache_obj = *cache_obj_ptr.get();
             auto& service = get_cache_service(value);
-            set_cache_value(&service, *obj_ptr.get(), std::move(value));
+            convert_value(&service, cache_obj, std::move(value));
 
             if (is_del_ptr) {
-                auto itr = deleted_object_tree_.iterator_to(*obj_ptr.get());
+                auto itr = deleted_object_tree_.iterator_to(cache_obj);
                 deleted_object_tree_.erase(itr);
-                add_pending_object(obj_ptr, false);
+                add_pending_object(cache_obj_ptr, false);
             } else if (is_new_ptr) {
                 if (!value.service.payer) {
-                    add_system_object(obj_ptr);
+                    add_system_object(cache_obj_ptr);
                 } else if (has_pending_cell()) {
-                    add_pending_object(obj_ptr);
+                    add_pending_object(cache_obj_ptr);
                 } else {
-                    add_lru_object(obj_ptr);
+                    add_lru_object(cache_obj_ptr);
                 }
             }
 
             if (is_new_ptr || is_del_ptr) {
-                cache_object_tree_.insert(*obj_ptr.get());
+                cache_object_tree_.insert(cache_obj);
                 service.cache_object_cnt++;
             }
 
-            if (is_new_ptr) {
-                build_cache_indicies(*obj_ptr.get());
-            }
+            set_object(table, cache_obj, std::move(value));
 
-            return obj_ptr;
+            return cache_obj_ptr;
         }
 
-        cache_object_ptr create_cache_object(object_value value) {
+        cache_object_ptr create_cache_object(const table_info& table, object_value value) {
             auto obj_ptr = find_in_cache(value.service);
             bool is_new_ptr = !obj_ptr;
 
@@ -945,24 +959,23 @@ namespace cyberway { namespace chaindb {
 
             if (is_new_ptr) {
                 // create object, but don't add it to RAM
-                obj_ptr = cache_object_ptr(new cache_object());
+                obj_ptr = cache_object_ptr(new cache_object(value.service));
+                obj_ptr->object_ = std::move(value);
             }
 
             auto service_ptr = find_cache_service(value);
-            set_cache_value(service_ptr, *obj_ptr.get(), std::move(value));
+            convert_value(service_ptr, *obj_ptr.get(), std::move(value));
             return obj_ptr;
         }
 
-        void set_cache_value(cache_service_info* service_ptr, cache_object& obj, object_value value) const {
+        void convert_value(cache_service_info* service_ptr, cache_object& cache_obj, const object_value& value) const {
             // set_cache_value happens in three cases:
             //   1. create object for interchain tables ->  value.is_null()
             //   2. loading object from chaindb         -> !value.is_null()
             //   3. restore from undo state             -> !value.is_null()
             if (service_ptr && service_ptr->converter && !value.is_null()) {
-                service_ptr->converter->convert_variant(obj, value);
+                service_ptr->converter->convert_variant(cache_obj, value);
             }
-
-            obj.set_object(std::move(value));
         }
 
         void add_ram_usage(cache_cell& cell, const int64_t delta) {
@@ -985,6 +998,10 @@ namespace cyberway { namespace chaindb {
     }; // struct table_cache_map
 
     //---------------------------------------
+
+    cache_object::cache_object(service_state service) {
+        object_.service = std::move(service);
+    }
 
     bool cache_object::is_valid_cell() const {
         return !state_ || (state_->cell && state_->cell->map);
@@ -1010,11 +1027,6 @@ namespace cyberway { namespace chaindb {
         return *state_->cell;
     }
 
-    const cache_cell& cache_object::cell() const {
-        assert(has_cell());
-        return *state_->cell;
-    }
-
     cache_map_impl& cache_object::map() {
         assert(has_cell());
         return *state_->cell->map;
@@ -1026,27 +1038,6 @@ namespace cyberway { namespace chaindb {
         auto tmp = state_;
         state_ = &state;
         return tmp;
-    }
-
-    void cache_object::set_object(object_value obj) {
-        assert(object_.service.empty() || is_valid_table(obj.service));
-
-        int delta = obj.service.size - object_.service.size;
-        object_ = std::move(obj);
-        blob_.clear();
-
-        if (has_cell()) {
-            map().change_cache_object(*this, delta);
-        }
-    }
-
-    void cache_object::set_service(service_state service) {
-        assert(is_valid_table(service));
-
-        object_.service = std::move(service);
-        if (!object_.service.in_ram && has_cell()) {
-            mark_deleted();
-        }
     }
 
     void cache_object::mark_deleted() {
@@ -1088,8 +1079,8 @@ namespace cyberway { namespace chaindb {
 
     //---------------------------------------
 
-    cache_map::cache_map(abi_map& map)
-    : impl_(new cache_map_impl(map)) {
+    cache_map::cache_map()
+    : impl_(std::make_unique<cache_map_impl>()) {
     }
 
     cache_map::~cache_map() = default;
@@ -1109,12 +1100,12 @@ namespace cyberway { namespace chaindb {
     cache_object_ptr cache_map::create(
         const table_info& info, const primary_key_t pk, const storage_payer_info& storage
     ) const {
-        CYBERWAY_ASSERT(primary_key::Unset != pk && primary_key::End != pk, cache_primary_key_exception,
+        CYBERWAY_ASSERT(primary_key::is_good(pk), cache_primary_key_exception,
             "Value ${pk} can't be used as primary key", ("pk", pk));
         auto obj = object_value{info.to_service(pk), {}};
         obj.service.payer  = storage.owner;
         obj.service.in_ram = true;
-        return impl_->emplace(std::move(obj));
+        return impl_->emplace(info, std::move(obj));
     }
 
     void cache_map::set_next_pk(const table_info& table, const primary_key_t pk) const {
@@ -1131,12 +1122,20 @@ namespace cyberway { namespace chaindb {
 
     cache_object_ptr cache_map::emplace(const table_info& table, object_value obj) const {
         assert(obj.pk() != primary_key::Unset && !obj.is_null());
-        return impl_->emplace(std::move(obj));
+        return impl_->emplace(table, std::move(obj));
     }
 
     void cache_map::remove(const table_info& table, const primary_key_t pk) const {
         assert(pk != primary_key::Unset);
         impl_->remove_cache_object(table.to_service(pk));
+    }
+
+    void cache_map::set_object(const table_info& table, cache_object& cache_obj, object_value value) const {
+        impl_->set_object(table, cache_obj, std::move(value));
+    }
+
+    void cache_map::set_service(const table_info& table, cache_object& cache_obj, service_state service) const {
+        impl_->set_service(table, cache_obj, std::move(service));
     }
 
     void cache_map::set_revision(const object_value& obj, const revision_t rev) const {

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -299,8 +299,7 @@ namespace cyberway { namespace chaindb {
 
             if (item && with_blob && !item->has_blob()) {
                 auto& table  = static_cast<const table_info&>(cursor.index);
-                auto  buffer = cursor.index.abi->to_bytes(table, item->object().value); // 1 Mb
-                item->set_blob(bytes(buffer.begin(), buffer.end()));                    // Minimize memory usage
+                item->set_blob(cursor.index.abi->to_bytes(table, item->object().value));
             }
 
             return item;

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -293,6 +293,13 @@ namespace cyberway { namespace chaindb {
             return item;
         }
 
+        cache_object_ptr create_cache_object(
+            const table_request& req, const primary_key_t pk, const storage_payer_info& storage
+        ) {
+            auto table = get_table(req);
+            return cache_.create(table, pk, storage);
+        }
+
         cache_object_ptr get_cache_object(const cursor_request& req, const bool with_blob) {
             auto& cursor = current(req);
 
@@ -511,7 +518,7 @@ namespace cyberway { namespace chaindb {
         }
 
         std::vector<char> load_abi(account_name abi_code) {
-            index_request request{N(), N(), N(account), N(name)};
+            index_request request{N(), N(), N(account), N(primary)};
             const auto abi_cursor = lower_bound(request, fc::mutable_variant_object()("name", abi_code));
 
             if (abi_cursor.pk == primary_key::End) {
@@ -755,6 +762,12 @@ namespace cyberway { namespace chaindb {
         const table_request& table, const storage_payer_info& storage
     ) const {
         return impl_->create_cache_object(table, storage);
+    }
+
+    cache_object_ptr chaindb_controller::create_cache_object(
+        const table_request& table, const primary_key_t pk, const storage_payer_info& storage
+    ) const {
+        return impl_->create_cache_object(table, pk, storage);
     }
 
     cache_object_ptr chaindb_controller::get_cache_object(const cursor_request& cursor, const bool with_blob) const {

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -502,9 +502,6 @@ namespace cyberway { namespace chaindb {
             return info;
         }
 
-        cache_object_ptr get_account_object(account_name code) {
-        }
-
         abi_map::iterator recache_chaindb_abi(account_name code) {
            const auto& abi = load_abi(code);
            if (!abi.empty()) {

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -539,7 +539,7 @@ namespace cyberway { namespace chaindb {
         int insert(const table_info& table, storage_payer_info charge, object_value& obj) {
             validate_object(table, obj, obj.pk());
 
-            charge.calc_usage(table, obj);
+            charge.size   = calc_storage_usage(table, obj.value);
             charge.in_ram = true;
             charge.delta += charge.size;
 
@@ -561,7 +561,7 @@ namespace cyberway { namespace chaindb {
             validate_object(table, obj, obj.pk());
 
             charge.get_payer_from(orig_obj);
-            charge.calc_usage(table, obj);
+            charge.size   = calc_storage_usage(table, obj.value);
             charge.delta += charge.size - orig_obj.service.size;
 
             // don't charge on genesis

--- a/libraries/chain/chaindb/journal.cpp
+++ b/libraries/chain/chaindb/journal.cpp
@@ -141,7 +141,8 @@ namespace cyberway { namespace chaindb {
         auto& info = ctx.info(data.object.pk());
         _detail::write(std::move(data), info.data);
     } FC_CAPTURE_LOG_AND_RETHROW(
-        (data.object.service)
+       (data.object.service.code)(data.object.service.scope)(data.object.service.table)
+       (data.object.service.pk)(data.object.service)
     )
 
     void journal::write_data(const table_info& table, write_operation data) {

--- a/libraries/chain/chaindb/mongo_driver.cpp
+++ b/libraries/chain/chaindb/mongo_driver.cpp
@@ -239,7 +239,7 @@ namespace cyberway { namespace chaindb {
                 object_.service.pk    = pk;
                 object_.service.code  = index.code;
                 object_.service.scope = index.scope;
-                object_.service.table = index.table->name;
+                object_.service.table = index.table_name();
             } else {
                 auto& view = *source_->begin();
                 object_ = build_object(index, view, with_decors);
@@ -670,7 +670,7 @@ namespace cyberway { namespace chaindb {
                 obj.service.pk    = primary_key::End;
                 obj.service.code  = table.code;
                 obj.service.scope = table.scope;
-                obj.service.table = table.table->name;
+                obj.service.table = table.table_name();
                 return obj;
             }
         }
@@ -773,7 +773,7 @@ namespace cyberway { namespace chaindb {
                 if (BOOST_LIKELY(
                         old_table != nullptr &&
                         table.code == old_table->code &&
-                        table.table->name == old_table->table->name))
+                        table.table_name() == old_table->table_name()))
                     return;
 
                 auto db_table = impl_.get_db_table(table);

--- a/libraries/chain/chaindb/mongo_driver.cpp
+++ b/libraries/chain/chaindb/mongo_driver.cpp
@@ -473,7 +473,7 @@ namespace cyberway { namespace chaindb {
             std::vector<index_def> result;
             auto indexes = db_table.list_indexes();
 
-            result.reserve(abi_info::max_index_cnt() * 2);
+            result.reserve(abi_info::MaxIndexCnt * 2);
             for (auto& info: indexes) {
                 index_def index;
 
@@ -528,7 +528,7 @@ namespace cyberway { namespace chaindb {
             static constexpr std::chrono::milliseconds max_time(10);
             std::vector<table_def> tables;
 
-            tables.reserve(abi_info::max_table_cnt() * 2);
+            tables.reserve(abi_info::MaxTableCnt * 2);
             _detail::auto_reconnect([&]() {
                 tables.clear();
                 auto db = mongo_conn_.database(get_code_name(sys_code_name_, code));

--- a/libraries/chain/chaindb/mongo_driver.cpp
+++ b/libraries/chain/chaindb/mongo_driver.cpp
@@ -6,6 +6,8 @@
 #include <cyberway/chaindb/names.hpp>
 #include <cyberway/chaindb/table_object.hpp>
 #include <cyberway/chaindb/mongo_driver_utils.hpp>
+#include <cyberway/chaindb/journal.hpp>
+#include <cyberway/chaindb/abi_info.hpp>
 
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/builder/basic/document.hpp>
@@ -17,7 +19,6 @@
 #include <mongocxx/exception/bulk_write_exception.hpp>
 #include <mongocxx/exception/logic_error.hpp>
 #include <mongocxx/exception/query_exception.hpp>
-#include <cyberway/chaindb/abi_info.hpp>
 
 namespace cyberway { namespace chaindb {
 
@@ -900,7 +901,7 @@ namespace cyberway { namespace chaindb {
     ///----
 
     mongodb_driver::mongodb_driver(journal& jrnl, string address, string sys_name)
-    : impl_(new mongodb_impl_(jrnl, std::move(address), std::move(sys_name))) {
+    : impl_(std::make_unique<mongodb_impl_>(jrnl, std::move(address), std::move(sys_name))) {
     }
 
     mongodb_driver::~mongodb_driver() = default;

--- a/libraries/chain/chaindb/mongo_driver_utils.cpp
+++ b/libraries/chain/chaindb/mongo_driver_utils.cpp
@@ -30,11 +30,7 @@ namespace cyberway { namespace chaindb {
     using eosio::chain::symbol;
     using eosio::chain::symbol_info;
 
-    using std::string;
-
-    using fc::blob;
     using fc::__uint128;
-    using fc::variant;
     using fc::variants;
     using fc::variant_object;
     using fc::mutable_variant_object;

--- a/libraries/chain/chaindb/mongo_driver_utils.cpp
+++ b/libraries/chain/chaindb/mongo_driver_utils.cpp
@@ -511,7 +511,7 @@ namespace cyberway { namespace chaindb {
             obj.service.pk    = get_pk_value(info, src);
             obj.service.code  = info.code;
             obj.service.scope = info.scope;
-            obj.service.table = info.table->name;
+            obj.service.table = info.table_name();
         }
         return obj;
     }

--- a/libraries/chain/chaindb/storage_calculator.cpp
+++ b/libraries/chain/chaindb/storage_calculator.cpp
@@ -20,9 +20,6 @@ namespace cyberway { namespace chaindb {
 
     using eosio::chain::table_def;
 
-    using std::string;
-
-    using fc::variant;
     using fc::variants;
     using fc::variant_object;
 

--- a/libraries/chain/chaindb/typed_name.cpp
+++ b/libraries/chain/chaindb/typed_name.cpp
@@ -2,6 +2,7 @@
 #include <cyberway/chaindb/exception.hpp>
 #include <cyberway/chaindb/common.hpp>
 #include <cyberway/chaindb/names.hpp>
+#include <cyberway/chaindb/table_info.hpp>
 
 #include <eosio/chain/symbol.hpp>
 #include <eosio/chain/name.hpp>

--- a/libraries/chain/chaindb/undo_state.cpp
+++ b/libraries/chain/chaindb/undo_state.cpp
@@ -456,7 +456,7 @@ namespace cyberway { namespace chaindb {
                 return;
             }
 
-            auto account_idx = controller_.get_index<eosio::chain::account_object, eosio::chain::by_name>();
+            auto account_idx = controller_.get_index<eosio::chain::account_object,by_id>();
             auto& abi_map = controller_.get_abi_map();
 
             auto get_system_table_def = [&](const auto& service) -> table_def {

--- a/libraries/chain/chaindb/undo_state.cpp
+++ b/libraries/chain/chaindb/undo_state.cpp
@@ -272,8 +272,15 @@ namespace cyberway { namespace chaindb {
         undo_next_pk_ = primary_key::Unset;
     }
 
-    object_value undo_state::next_pk_object(variant val) const {
-        return object_value{{table_.info(), undo_next_pk_, undo_record::NextPk, revision_}, std::move(val)};
+    object_value undo_state::next_pk_object(variant value) const {
+        auto& info = table_.info();
+        auto  obj  = object_value{info.to_service(), std::move(value)};
+
+        obj.service.revision = revision_;
+        obj.service.undo_pk  = undo_next_pk_;
+        obj.service.undo_rec = undo_record::NextPk;
+
+        return obj;
     }
 
     struct undo_stack::undo_stack_impl_ final {

--- a/libraries/chain/chaindb/value_verifier.cpp
+++ b/libraries/chain/chaindb/value_verifier.cpp
@@ -31,12 +31,11 @@ namespace cyberway { namespace chaindb {
                 auto& blob = abi_value.get_blob();
 
                 if (!blob.data.empty()) {
-                    fc::datastream<const char*> ds(blob.data.data(), blob.data.size());
-                    fc::raw::unpack(ds, def);
+                    abi_serializer::to_abi(blob.data, def);
                 }
 
                 if (obj.pk() == config::system_account_name) {
-                    info_.set_abi(blob);
+                    info_.set_abi(def);
                 }
             }
 

--- a/libraries/chain/chaindb/value_verifier.cpp
+++ b/libraries/chain/chaindb/value_verifier.cpp
@@ -1,0 +1,62 @@
+#include <cyberway/chaindb/value_verifier.hpp>
+#include <cyberway/chaindb/table_info.hpp>
+#include <cyberway/chaindb/driver_interface.hpp>
+#include <cyberway/chaindb/account_abi_info.hpp>
+
+namespace cyberway { namespace chaindb {
+
+    struct value_verifier_impl final {
+
+        value_verifier_impl(driver_interface& driver)
+        : driver_(driver) {
+        }
+
+        void verify(const table_info& table, const object_value& obj) {
+            if (is_system_code(table.code)) switch (table.table_name()) {
+                case tag<account_object>::get_code():
+                    verify_account(obj);
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+    private:
+        void verify_account(const object_value& obj) {
+            if (is_system_code(obj.pk())) {
+                account_abi_info::system_abi_info().abi().verify_tables_structure(driver_);
+                return;
+            }
+
+            eosio::chain::abi_def def;
+            auto& abi_value = obj.value["abi"];
+            if (abi_value.is_blob()) {
+                auto& blob = abi_value.get_blob().data;
+
+                if (!blob.empty()) {
+                    fc::datastream<const char*> ds(blob.data(), blob.size());
+                    fc::raw::unpack(ds, def);
+                }
+            }
+
+            abi_info info(obj.pk(), def);
+            info.verify_tables_structure(driver_);
+        }
+
+        driver_interface& driver_;
+    }; // struct value_verifier_impl
+
+    value_verifier::value_verifier(driver_interface& driver)
+    : impl_(std::make_unique<value_verifier_impl>(driver)) {
+    }
+
+    value_verifier::~value_verifier() = default;
+
+    void value_verifier::verify(const table_info& table, const object_value& obj) const {
+        impl_->verify(table, obj);
+    }
+
+}} // namespace cyberway::chaindb
+
+

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -270,10 +270,6 @@ struct controller_impl {
                                  on_irreversible(b);
                                  });
 
-   self.setabi.connect( [&]( auto b ) {
-       chaindb.add_abi( std::get<0>(b), std::get<1>(b) );
-   });
-
    }
 
    /**
@@ -504,8 +500,6 @@ struct controller_impl {
    }
 
    void add_indices() {
-      chaindb.add_abi(0, eosio_contract_abi());
-
       reversible_blocks.add_index<reversible_block_index>();
 
       controller_index_set::add_indices(chaindb);

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -27,6 +27,7 @@
 
 
 #include <cyberway/chaindb/controller.hpp>
+#include <cyberway/chaindb/account_abi_info.hpp>
 #include <cyberway/genesis/genesis_import.hpp>
 #include <cyberway/chain/cyberway_contract_types.hpp>
 #include <cyberway/chain/cyberway_contract.hpp>
@@ -2011,6 +2012,16 @@ const apply_handler* controller::find_apply_handler( account_name receiver, acco
 }
 wasm_interface& controller::get_wasm_interface() {
    return my->wasmif;
+}
+
+optional_ptr<abi_serializer> controller::get_abi_serializer( account_name n, const fc::microseconds& max_serialization_time )const {
+    if( n.good() ) {
+        auto a = my->chaindb.get_account_abi_info(n);
+        if( a.has_abi_info() ) {
+           return optional_ptr<abi_serializer>( a.abi().serializer() );
+        }
+    }
+    return optional_ptr<abi_serializer>();
 }
 
 const account_object& controller::get_account( account_name name )const

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -589,8 +589,7 @@ struct controller_impl {
    }
 
    void create_native_account( account_name name, const authority& owner, const authority& active, bool is_privileged = false ) {
-      chaindb.emplace<account_object>([&](auto& a) {
-         a.name = name;
+      chaindb.emplace<account_object>(name.value, [&](auto& a) {
          a.creation_date = conf.genesis.initial_timestamp;
          a.privileged = is_privileged;
 
@@ -600,10 +599,7 @@ struct controller_impl {
             a.set_abi(domain_contract_abi());
          }
       });
-
-      chaindb.emplace<account_sequence_object>([&](auto & a) {
-        a.name = name;
-      });
+      chaindb.emplace<account_sequence_object>(name.value, [&](auto & a) { });
 
       const auto& owner_permission  = authorization.create_permission({}, name, config::owner_name, 0,
                                                                       owner, conf.genesis.initial_timestamp );
@@ -2025,7 +2021,7 @@ wasm_interface& controller::get_wasm_interface() {
 
 const account_object& controller::get_account( account_name name )const
 { try {
-   return my->chaindb.get<account_object, by_name>(name);
+   return my->chaindb.get<account_object>(name);
 } FC_CAPTURE_AND_RETHROW( (name) ) }
 
 const domain_object& controller::get_domain(const domain_name& name) const { try {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -181,10 +181,6 @@ struct controller_impl {
     */
    map<digest_type, transaction_metadata_ptr>     unapplied_transactions;
 
-   void set_abi(name account, const abi_def& abi) {
-       emit(self.setabi, std::make_tuple(account, std::ref(abi)));
-   }
-
    void pop_block() {
       auto prev = fork_db.get_block( head->header.previous );
       EOS_ASSERT( prev, block_validate_exception, "attempt to pop beyond last irreversible block" );
@@ -1994,10 +1990,6 @@ db_read_mode controller::get_read_mode()const {
 
 validation_mode controller::get_validation_mode()const {
    return my->conf.block_validation_mode;
-}
-
-void controller::set_abi(name account, const abi_def &abi) {
-    my->set_abi(account, abi);
 }
 
 const apply_handler* controller::find_apply_handler( account_name receiver, account_name scope, action_name act ) const

--- a/libraries/chain/cyberway/cyberway_contract.cpp
+++ b/libraries/chain/cyberway/cyberway_contract.cpp
@@ -95,7 +95,7 @@ void apply_cyber_domain_newusername(apply_context& context) {
         auto exists = chaindb.find<username_object, by_scope_name>(boost::make_tuple(op.creator, op.name));
         EOS_ASSERT(exists == nullptr, eosio::chain::username_exists_exception,
             "Cannot create username ${n} in scope ${s}, as it's already taken", ("n", op.name)("s", op.creator));
-        auto owner = chaindb.find<eosio::chain::account_object, by_name>(op.owner);
+        auto owner = chaindb.find<eosio::chain::account_object>(op.owner);
         EOS_ASSERT(owner, eosio::chain::account_name_exists_exception, "Username owner (${o}) must exist", ("o", op.owner));
         chaindb.emplace<username_object>(context.get_storage_payer(op.creator), [&](auto& d) {
             d.owner = op.owner;

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -261,9 +261,7 @@ void apply_cyber_setabi(apply_context& context) {
    EOS_ASSERT( account.abi_version != hash, set_exact_abi, "contract is already has this version of abi" );
    chaindb.modify( account, storage_payer, [&]( auto& a ) {
       a.abi_version = hash;
-      a.abi.resize( abi_size );
-      if( abi_size > 0 )
-         memcpy( const_cast<char*>(a.abi.data()), act.abi.data(), abi_size );
+      a.set_abi( std::move(act.abi) );
    });
 
    chaindb.modify( account_sequence, storage_payer, [&]( auto& aso ) {

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -268,12 +268,6 @@ void apply_cyber_setabi(apply_context& context) {
       aso.abi_sequence += 1;
    });
 
-   context.control.set_abi(act.account, account.get_abi());
-
-   if (act.account == chain::config::system_account_name) {
-       context.control.set_abi(0, account.get_abi());
-   }
-
 // TODO: Removed by CyberWay
 //   if (new_size != old_size) {
 //      context.add_ram_usage( act.account, new_size - old_size );

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -562,6 +562,22 @@ abi_def eosio_contract_abi(abi_def eos_abi)
          }
    });
 
+   eos_abi.structs.emplace_back(struct_def{
+        "_SERVICE_", "",
+        {{"upk", "uint64"}}
+   });
+
+   eos_abi.structs.emplace_back(struct_def{
+        "undo", "",
+        {{"_SERVICE_", "_SERVICE_"}}
+   });
+
+   eos_abi.tables.emplace_back(table_def{
+       "undo", "undo", "uint64", {
+           {cyberway::chaindb::tag<by_id>::get_code(), true, {{"_SERVICE_.upk", "asc"}}}
+       },
+   });
+
     ////////////////////////
    // ACTION PAYLOADS
 

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -158,7 +158,6 @@ abi_def eosio_contract_abi(abi_def eos_abi)
 
    eos_abi.structs.emplace_back( eosio::chain::struct_def{
       "account_object", "", {
-         {"id", "uint64"},
          {"name", "name"},
          {"vm_type", "uint8"},
          {"vm_version", "uint8"},
@@ -174,14 +173,12 @@ abi_def eosio_contract_abi(abi_def eos_abi)
 
    eos_abi.tables.emplace_back( eosio::chain::table_def {
       cyberway::chaindb::tag<account_object>::get_code(), "account_object", {
-         {cyberway::chaindb::tag<by_id>::get_code(), true, {{"id", "asc"}}},
-         {cyberway::chaindb::tag<by_name>::get_code(), true, {{"name", "asc"}}}
+         {cyberway::chaindb::tag<by_id>::get_code(), true, {{"name", "asc"}}}
       }
    });
 
    eos_abi.structs.emplace_back( eosio::chain::struct_def{
       "account_sequence_object", "", {
-         {"id", "uint64"},
          {"name", "name"},
          {"recv_sequence", "uint64"},
          {"auth_sequence", "uint64"},
@@ -192,8 +189,7 @@ abi_def eosio_contract_abi(abi_def eos_abi)
 
    eos_abi.tables.emplace_back( eosio::chain::table_def {
       cyberway::chaindb::tag<account_sequence_object>::get_code(), "account_sequence_object", {
-         {cyberway::chaindb::tag<by_id>::get_code(), true, {{"id", "asc"}}},
-         {cyberway::chaindb::tag<by_name>::get_code(), true, {{"name", "asc"}}}
+         {cyberway::chaindb::tag<by_id>::get_code(), true, {{"name", "asc"}}}
       }
    });
    
@@ -417,7 +413,6 @@ abi_def eosio_contract_abi(abi_def eos_abi)
 
    eos_abi.structs.emplace_back( eosio::chain::struct_def{
       "resource_usage_object", "", {
-         {"id", "uint64"},
          {"owner", "name"},
          {"accumulators", "usage_accumulator[]"}
       }
@@ -425,8 +420,7 @@ abi_def eosio_contract_abi(abi_def eos_abi)
 
    eos_abi.tables.emplace_back( eosio::chain::table_def {
       cyberway::chaindb::tag<rl::resource_usage_object>::get_code(), "resource_usage_object", {
-         {cyberway::chaindb::tag<by_id>::get_code(), true, {{"id", "asc"}}},
-         {cyberway::chaindb::tag<by_owner>::get_code(), true, {{"owner", "asc"}}}
+         {cyberway::chaindb::tag<by_id>::get_code(), true, {{"owner", "asc"}}}
       }
    });
 

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -563,8 +563,10 @@ abi_def eosio_contract_abi(abi_def eos_abi)
    });
 
    eos_abi.structs.emplace_back(struct_def{
-        "_SERVICE_", "",
-        {{"upk", "uint64"}}
+      "_SERVICE_", "", {
+         {"upk", "uint64"},
+         {"code", "uint64"},
+         {"table", "uint64"}}
    });
 
    eos_abi.structs.emplace_back(struct_def{
@@ -574,7 +576,10 @@ abi_def eosio_contract_abi(abi_def eos_abi)
 
    eos_abi.tables.emplace_back(table_def{
        "undo", "undo", "uint64", {
-           {cyberway::chaindb::tag<by_id>::get_code(), true, {{"_SERVICE_.upk", "asc"}}}
+           {cyberway::chaindb::tag<by_id>::get_code(), true, {{"_SERVICE_.upk", "asc"}}},
+           {cyberway::chaindb::tag<by_table>::get_code(), false, {
+               {"_SERVICE_.code", "asc"},
+               {"_SERVICE_.table", "asc"}}},
        },
    });
 

--- a/libraries/chain/genesis/genesis_import.cpp
+++ b/libraries/chain/genesis/genesis_import.cpp
@@ -112,7 +112,7 @@ struct genesis_import::impl final {
                             auto n = acc["name"].as<account_name>();
                             abi_def abi;
                             if (abi_serializer::to_abi(abi_bytes, abi) ) {
-                                db.add_abi(n, abi);
+                                // db.add_abi(n, abi); // TOOD: is it needed?
                                 std::cout << "  add " << n << " abi" << std::endl;
                             } else {
                                 elog("Failed to read abi provided in ${a} contract", ("a",n));

--- a/libraries/chain/genesis/genesis_import.cpp
+++ b/libraries/chain/genesis/genesis_import.cpp
@@ -47,11 +47,11 @@ struct genesis_import::impl final {
         // we need primary key for update, but it depends on table. add this hacky shortcut for accounts
         primary_key_t pk = ((primary_key_t*)r.data.data())[1];
         const name n(pk);
-        const auto& old = db.get<account_object,by_name>(n);  // vm_type/vm_version/privileged not set in genesis, copy
+        const auto& old = db.get<account_object>(n);  // vm_type/vm_version/privileged not set in genesis, copy
         fc::datastream<const char*> ds(r.data.data(), r.data.size());
-        auto acc = account_object([&](auto& a){
+        auto acc = account_object(primary_key::Unset, [&](auto& a){
             fc::raw::unpack(ds, a);
-        }, 0);
+        });
         db.modify(old, [&](auto& a) {
             a.last_code_update = acc.last_code_update;
             a.code_version = acc.code_version;

--- a/libraries/chain/include/cyberway/chain/domain_object.hpp
+++ b/libraries/chain/include/cyberway/chain/domain_object.hpp
@@ -14,7 +14,7 @@ using eosio::chain::account_name;
 using eosio::chain::block_timestamp_type;
 
 class domain_object : public cyberway::chaindb::object<eosio::chain::domain_object_type, domain_object> {
-   OBJECT_CTOR(domain_object)
+   CHAINDB_OBJECT_ID_CTOR(domain_object)
 
    id_type              id;
    account_name         owner;
@@ -42,7 +42,7 @@ using domain_table = cyberway::chaindb::table_container<
 >;
 
 class username_object : public cyberway::chaindb::object<eosio::chain::username_object_type, username_object> {
-   OBJECT_CTOR(username_object)
+   CHAINDB_OBJECT_ID_CTOR(username_object)
 
    id_type              id;
    account_name         owner;

--- a/libraries/chain/include/cyberway/chaindb/abi_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/abi_info.hpp
@@ -4,7 +4,7 @@
 
 #include <eosio/chain/abi_serializer.hpp>
 
-#include <cyberway/chaindb/common.hpp>
+#include <cyberway/chaindb/table_info.hpp>
 #include <cyberway/chaindb/controller.hpp>
 #include <cyberway/chaindb/driver_interface.hpp>
 #include <cyberway/chaindb/exception.hpp>
@@ -15,7 +15,6 @@ namespace cyberway { namespace chaindb {
     using eosio::chain::abi_serializer;
     using eosio::chain::bytes;
 
-    using fc::time_point;
     using fc::variant;
 
     template <typename Info>
@@ -78,17 +77,11 @@ namespace cyberway { namespace chaindb {
             return code_;
         }
 
-        static constexpr size_t max_table_cnt() {
-            return 64;
-        }
-
-        static constexpr size_t max_index_cnt() {
-            return 16;
-        }
-
-        static constexpr size_t max_path_depth() {
-            return 4;
-        }
+        enum : size_t {
+            MaxTableCnt  = 64,
+            MaxIndexCnt  = 16,
+            MaxPathDepth = 4,
+        }; // constants
 
     private:
         const account_name code_;

--- a/libraries/chain/include/cyberway/chaindb/abi_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/abi_info.hpp
@@ -99,7 +99,7 @@ namespace cyberway { namespace chaindb {
             if (nullptr == data || 0 == size) return fc::variant_object();
 
             fc::datastream<const char*> ds(static_cast<const char*>(data), size);
-            auto value = serializer_.binary_to_variant(type, ds, max_abi_time_);
+            auto value = serializer_.binary_to_variant(type, ds, max_abi_time_, abi_serializer::DBMode);
 
 //            dlog(
 //                "The ${value_type} '${type}': ${value}",

--- a/libraries/chain/include/cyberway/chaindb/abi_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/abi_info.hpp
@@ -58,6 +58,10 @@ namespace cyberway { namespace chaindb {
             return code_;
         }
 
+        const abi_serializer& serializer() const {
+            return serializer_;
+        }
+
         enum : size_t {
             MaxTableCnt  = 64,
             MaxIndexCnt  = 16,

--- a/libraries/chain/include/cyberway/chaindb/abi_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/abi_info.hpp
@@ -19,6 +19,8 @@ namespace cyberway { namespace chaindb {
 
     template <typename Info>
     const index_def& get_pk_index(const Info& info) {
+        assert(info.table);
+        assert(info.table->indexes.size());
         // abi structure is already validated by abi_serializer
         return info.table->indexes.front();
     }
@@ -29,31 +31,30 @@ namespace cyberway { namespace chaindb {
         return get_pk_index(info).orders.front();
     }
 
-    class abi_info final {
-    public:
+    struct abi_info final {
         abi_info() = default;
         abi_info(const account_name& code, abi_def);
 
         void verify_tables_structure(driver_interface&) const;
 
         variant to_object(const table_info& info, const void* data, const size_t size) const {
-            CYBERWAY_ASSERT(info.table, unknown_table_exception, "NULL table");
+            assert(info.table);
             return to_object_("table", [&]{return get_full_table_name(info);}, info.table->type, data, size);
         }
 
         variant to_object(const index_info& info, const void* data, const size_t size) const {
-            CYBERWAY_ASSERT(info.index, unknown_index_exception, "NULL index");
+            assert(info.index);
             auto type = get_full_index_name(info);
             return to_object_("index", [&](){return type;}, type, data, size);
         }
 
         bytes to_bytes(const table_info& info, const variant& value) const {
-            CYBERWAY_ASSERT(info.table, unknown_table_exception, "NULL table");
+            assert(info.table);
             return to_bytes_("table", [&]{return get_full_table_name(info);}, info.table->type, value);
         }
 
         bytes to_bytes(const index_info& info, const variant& value) const {
-            CYBERWAY_ASSERT(info.index, unknown_index_exception, "NULL index");
+            assert(info.index);
             auto type = get_full_index_name(info);
             return to_bytes_("index", [&]{return type;}, type, value);
         }

--- a/libraries/chain/include/cyberway/chaindb/abi_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/abi_info.hpp
@@ -12,18 +12,12 @@ namespace cyberway { namespace chaindb {
 
     using eosio::chain::abi_def;
     using eosio::chain::abi_serializer;
-    using eosio::chain::bytes;
-
-    using fc::variant;
-
-    class driver_interface;
-
 
     struct abi_info final {
         abi_info() = default;
         abi_info(const account_name& code, abi_def);
 
-        void verify_tables_structure(driver_interface&) const;
+        void verify_tables_structure(const driver_interface&) const;
 
         variant to_object(const table_info&, const void*, size_t) const;
         variant to_object(const index_info&, const void*, size_t) const;

--- a/libraries/chain/include/cyberway/chaindb/abi_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/abi_info.hpp
@@ -16,6 +16,7 @@ namespace cyberway { namespace chaindb {
     struct abi_info final {
         abi_info() = default;
         abi_info(const account_name& code, abi_def);
+        abi_info(const account_name& code, blob);
 
         void verify_tables_structure(const driver_interface&) const;
 
@@ -73,6 +74,8 @@ namespace cyberway { namespace chaindb {
         abi_serializer serializer_;
         fc::flat_map<table_name_t, table_def> table_map_;
         static const fc::microseconds max_abi_time_;
+
+        void init(abi_def);
 
         template<typename Type>
         variant to_object_(

--- a/libraries/chain/include/cyberway/chaindb/abi_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/abi_info.hpp
@@ -22,8 +22,17 @@ namespace cyberway { namespace chaindb {
 
         variant to_object(const table_info&, const void*, size_t) const;
         variant to_object(const index_info&, const void*, size_t) const;
+        variant to_object(const string&, const void*, size_t) const;
         bytes to_bytes(const table_info&, const variant&) const;
         bytes to_bytes(const index_info& info, const variant& value) const;
+
+        string get_event_type(const event_name& n) const {
+            return serializer_.get_event_type(n);
+        }
+
+        string get_action_type(const event_name& n) const {
+            return serializer_.get_action_type(n);
+        }
 
         const table_def* find_table(table_name_t table) const {
             auto itr = table_map_.find(table);
@@ -77,40 +86,8 @@ namespace cyberway { namespace chaindb {
 
         void init(abi_def);
 
-        template<typename Type>
-        variant to_object_(
-            const char* value_type, Type&& db_type, const string& type, const void* data, const size_t size
-        ) const {
-            // begin()
-            if (nullptr == data || 0 == size) return fc::variant_object();
-
-            fc::datastream<const char*> ds(static_cast<const char*>(data), size);
-            auto value = serializer_.binary_to_variant(type, ds, max_abi_time_, abi_serializer::DBMode);
-
-//            dlog(
-//                "The ${value_type} '${type}': ${value}",
-//                ("value_type", value_type)("type", db_type())("value", value));
-
-            CYBERWAY_ASSERT(value.is_object(), invalid_abi_store_type_exception,
-                "ABI serializer returns bad type for the ${value_type} for ${type}: ${value}",
-                ("value_type", value_type)("type", db_type())("value", value));
-
-            return value;
-        }
-
-        template<typename Type>
-        bytes to_bytes_(const char* value_type, Type&& db_type, const string& type, const variant& value) const {
-
-//            dlog(
-//                "The ${value_type} '${type}': ${value}",
-//                ("value", value_type)("type", db_type())("value", value));
-
-            CYBERWAY_ASSERT(value.is_object(), invalid_abi_store_type_exception,
-                "ABI serializer receive wrong type for the ${value_type} for '${type}': ${value}",
-                ("value_type", value_type)("type", db_type())("value", value));
-
-            return serializer_.variant_to_binary(type, value, max_abi_time_);
-        }
+        template<typename Type> variant to_object_(abi_serializer::mode, const char*, Type&&, const string&, const void*, size_t) const;
+        template<typename Type> bytes to_bytes_(const char*, Type&&, const string&, const variant&) const;
     }; // struct abi_info
 
     //-------------------------------------------------------------------

--- a/libraries/chain/include/cyberway/chaindb/account_abi_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/account_abi_info.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cyberway/chaindb/cache_item.hpp>
+#include <cyberway/chaindb/abi_info.hpp>
+
+#include <eosio/chain/account_object.hpp>
+
+namespace cyberway { namespace chaindb {
+
+    using account_object = eosio::chain::account_object;
+
+    struct account_abi_info final {
+        account_abi_info() = default;
+        account_abi_info(cache_object_ptr);
+
+        static const account_abi_info& system_abi_info();
+
+        bool has_abi_info() const {
+            return !!account_ptr_;
+        }
+
+        const abi_info& abi() const {
+            return account().get_abi_info();
+        }
+
+    private:
+        cache_object_ptr account_ptr_;
+
+        using account_item_data = multi_index_item_data<account_object>;
+
+        const account_object& account() const {
+            assert(has_abi_info());
+            return account_item_data::get_T(account_ptr_);
+        }
+    }; // struct account_abi_info
+
+} } // namespace cyberway::chaindb

--- a/libraries/chain/include/cyberway/chaindb/account_abi_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/account_abi_info.hpp
@@ -13,8 +13,6 @@ namespace cyberway { namespace chaindb {
         account_abi_info() = default;
         account_abi_info(cache_object_ptr);
 
-        static const account_abi_info& system_abi_info();
-
         bool has_abi_info() const {
             return !!account_ptr_;
         }
@@ -24,14 +22,39 @@ namespace cyberway { namespace chaindb {
         }
 
     private:
+        friend struct system_abi_info_impl;
         cache_object_ptr account_ptr_;
-
-        using account_item_data = multi_index_item_data<account_object>;
 
         const account_object& account() const {
             assert(has_abi_info());
-            return account_item_data::get_T(account_ptr_);
+            return multi_index_item_data<account_object>::get_T(account_ptr_);
         }
     }; // struct account_abi_info
+
+    struct system_abi_info final {
+        system_abi_info() = delete;
+        system_abi_info(const driver_interface&);
+        ~system_abi_info();
+
+        void init_abi() const;
+        void set_abi(blob) const;
+
+        const abi_info& abi() const {
+            return info_.abi();
+        }
+
+        const index_info& account_index() const {
+            return index_;
+        }
+
+        account_abi_info info() const {
+            return info_;
+        }
+
+    private:
+        std::unique_ptr<system_abi_info_impl> impl_;
+        const account_abi_info& info_;
+        const index_info& index_;
+    }; // struct system_abi_info
 
 } } // namespace cyberway::chaindb

--- a/libraries/chain/include/cyberway/chaindb/account_abi_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/account_abi_info.hpp
@@ -15,6 +15,13 @@ namespace cyberway { namespace chaindb {
         account_abi_info(account_name_t, abi_def);
         account_abi_info(account_name_t, blob);
 
+        account_name code() const {
+            if (has_abi_info()) {
+                return account().name;
+            }
+            return account_name();
+        }
+
         bool has_abi_info() const {
             return !!account_ptr_;
         }
@@ -54,6 +61,15 @@ namespace cyberway { namespace chaindb {
 
         account_abi_info info() const {
             return info_;
+        }
+
+        service_state to_service(const primary_key_t code) const {
+            service_state service;
+
+            service.table = tag<account_object>::get_code();
+            service.pk = code;
+
+            return service;
         }
 
     private:

--- a/libraries/chain/include/cyberway/chaindb/account_abi_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/account_abi_info.hpp
@@ -12,6 +12,8 @@ namespace cyberway { namespace chaindb {
     struct account_abi_info final {
         account_abi_info() = default;
         account_abi_info(cache_object_ptr);
+        account_abi_info(account_name_t, abi_def);
+        account_abi_info(account_name_t, blob);
 
         bool has_abi_info() const {
             return !!account_ptr_;
@@ -22,8 +24,11 @@ namespace cyberway { namespace chaindb {
         }
 
     private:
-        friend struct system_abi_info_impl;
         cache_object_ptr account_ptr_;
+
+        template<typename Abi> void init(account_name_t, Abi&&);
+
+        void init(cache_object_ptr);
 
         const account_object& account() const {
             assert(has_abi_info());
@@ -37,7 +42,7 @@ namespace cyberway { namespace chaindb {
         ~system_abi_info();
 
         void init_abi() const;
-        void set_abi(blob) const;
+        void set_abi(abi_def) const;
 
         const abi_info& abi() const {
             return info_.abi();

--- a/libraries/chain/include/cyberway/chaindb/cache_item.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_item.hpp
@@ -95,7 +95,7 @@ namespace cyberway { namespace chaindb {
         cache_object_state* swap_state(cache_object_state& state);
 
     public:
-        cache_object(service_state);
+        cache_object(object_value);
 
         cache_object(cache_object&&) = delete;
         cache_object(const cache_object&) = delete;

--- a/libraries/chain/include/cyberway/chaindb/cache_item.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_item.hpp
@@ -14,8 +14,6 @@
 
 namespace cyberway { namespace chaindb {
 
-    using  eosio::chain::bytes;
-
     class cache_map_impl;
 
     struct cache_data {

--- a/libraries/chain/include/cyberway/chaindb/cache_item.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_item.hpp
@@ -7,9 +7,6 @@
 #include <cyberway/chaindb/common.hpp>
 #include <cyberway/chaindb/object_value.hpp>
 
-#include <boost/smart_ptr/intrusive_ptr.hpp>
-#include <boost/smart_ptr/intrusive_ref_counter.hpp>
-
 #include <boost/intrusive/set.hpp>
 #include <boost/intrusive/list.hpp>
 
@@ -18,8 +15,6 @@ namespace cyberway { namespace chaindb {
     using  eosio::chain::bytes;
 
     class cache_map_impl;
-    class cache_object;
-    using cache_object_ptr = boost::intrusive_ptr<cache_object>;
 
     struct cache_data {
         virtual ~cache_data() = default;

--- a/libraries/chain/include/cyberway/chaindb/cache_item.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_item.hpp
@@ -10,6 +10,8 @@
 #include <boost/intrusive/set.hpp>
 #include <boost/intrusive/list.hpp>
 
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
+
 namespace cyberway { namespace chaindb {
 
     using  eosio::chain::bytes;
@@ -89,15 +91,16 @@ namespace cyberway { namespace chaindb {
         friend struct pending_cache_cell;
         friend struct pending_cache_object_state;
 
-        const cache_cell&   cell() const;
         cache_cell&         cell();
         cache_map_impl&     map();
         cache_object_state& state();
         cache_object_state* swap_state(cache_object_state& state);
 
     public:
-        cache_object() = default;
-        cache_object(cache_object&&) = default;
+        cache_object(service_state);
+
+        cache_object(cache_object&&) = delete;
+        cache_object(const cache_object&) = delete;
 
         ~cache_object() = default;
 
@@ -117,13 +120,6 @@ namespace cyberway { namespace chaindb {
 
         void mark_deleted();
         void release();
-
-        void set_object(object_value);
-        void set_service(service_state service);
-
-        void set_revision(const revision_t rev) {
-            object_.service.revision = rev;
-        }
 
         template <typename T, typename... Args> void set_data(Args&&... args) {
             data_ = std::make_unique<T>(*this, std::forward<Args>(args)...);

--- a/libraries/chain/include/cyberway/chaindb/cache_map.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_map.hpp
@@ -16,8 +16,8 @@ namespace cyberway { namespace chaindb {
 
         cache_object_ptr create(const table_info&, primary_key_t, const storage_payer_info&) const;
         cache_object_ptr create(const table_info&, const storage_payer_info&) const;
-        cache_object_ptr find(const table_info&, primary_key_t) const;
-        cache_object_ptr find(const index_info&, const char*, size_t) const;
+        cache_object_ptr find(const service_state&) const;
+        cache_object_ptr find(const service_state&, index_name_t, const char*, size_t) const;
 
         cache_object_ptr emplace(const table_info&, object_value) const;
         void remove(const table_info&, primary_key_t) const;

--- a/libraries/chain/include/cyberway/chaindb/cache_map.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_map.hpp
@@ -5,6 +5,10 @@
 
 namespace cyberway { namespace chaindb {
 
+    struct table_info;
+    struct index_info;
+    struct object_value;
+
     class cache_map final {
     public:
         cache_map(abi_map&);

--- a/libraries/chain/include/cyberway/chaindb/cache_map.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_map.hpp
@@ -5,9 +5,6 @@
 
 namespace cyberway { namespace chaindb {
 
-    struct table_info;
-    struct index_info;
-
     class cache_map final {
     public:
         cache_map();

--- a/libraries/chain/include/cyberway/chaindb/cache_map.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_map.hpp
@@ -18,6 +18,7 @@ namespace cyberway { namespace chaindb {
 
         void set_next_pk(const table_info&, primary_key_t) const;
 
+        cache_object_ptr create(const table_info&, primary_key_t, const storage_payer_info&) const;
         cache_object_ptr create(const table_info&, const storage_payer_info&) const;
         cache_object_ptr find(const table_info&, primary_key_t) const;
         cache_object_ptr find(const index_info&, const char*, size_t) const;

--- a/libraries/chain/include/cyberway/chaindb/cache_map.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_map.hpp
@@ -7,11 +7,10 @@ namespace cyberway { namespace chaindb {
 
     struct table_info;
     struct index_info;
-    struct object_value;
 
     class cache_map final {
     public:
-        cache_map(abi_map&);
+        cache_map();
         ~cache_map();
 
         void set_cache_converter(const table_info&, const cache_converter_interface&) const;
@@ -25,6 +24,9 @@ namespace cyberway { namespace chaindb {
 
         cache_object_ptr emplace(const table_info&, object_value) const;
         void remove(const table_info&, primary_key_t) const;
+
+        void set_object(const table_info&, cache_object&, object_value) const;
+        void set_service(const table_info&, cache_object&, service_state) const;
         void set_revision(const object_value&, revision_t) const;
 
         uint64_t calc_ram_bytes(revision_t) const;

--- a/libraries/chain/include/cyberway/chaindb/common.hpp
+++ b/libraries/chain/include/cyberway/chaindb/common.hpp
@@ -64,10 +64,10 @@ namespace cyberway { namespace chaindb {
         // TODO: RocksDB
     };
 
-    class chaindb_controller;
-    class abi_info;
-    class cache_object;
-    using cache_object_ptr = boost::intrusive_ptr<cache_object>;
+    class  chaindb_controller;
+    struct abi_info;
+    class  cache_object;
+    using  cache_object_ptr = boost::intrusive_ptr<cache_object>;
 
     using abi_map = std::map<account_name /* code */, abi_info>;
 

--- a/libraries/chain/include/cyberway/chaindb/common.hpp
+++ b/libraries/chain/include/cyberway/chaindb/common.hpp
@@ -5,6 +5,9 @@
 #include <eosio/chain/types.hpp>
 #include <eosio/chain/abi_def.hpp>
 
+#include <boost/smart_ptr/intrusive_ptr.hpp>
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
+
 #include <cyberway/chaindb/typed_name.hpp>
 
 namespace cyberway { namespace chaindb {
@@ -63,30 +66,10 @@ namespace cyberway { namespace chaindb {
 
     class chaindb_controller;
     class abi_info;
+    class cache_object;
+    using cache_object_ptr = boost::intrusive_ptr<cache_object>;
 
     using abi_map = std::map<account_name /* code */, abi_info>;
-
-    struct table_info {
-        const account_name_t code     = 0;
-        const scope_name_t   scope    = 0;
-        const table_def*     table    = nullptr;
-        const order_def*     pk_order = nullptr;
-        const abi_info*      abi      = nullptr;
-
-        table_info(account_name_t c, scope_name_t s)
-        : code(c), scope(s) {
-        }
-    }; // struct table_info
-
-    struct index_info: public table_info {
-        const index_def* index = nullptr;
-
-        using table_info::table_info;
-
-        index_info(const table_info& src)
-        : table_info(src) {
-        }
-    }; // struct index_info
 
     struct find_info final {
         cursor_t      cursor = invalid_cursor;
@@ -118,7 +101,7 @@ namespace cyberway { namespace chaindb {
         }
 
     private:
-        friend class chaindb_controller;
+        friend struct chaindb_controller_impl;
 
         chaindb_session(chaindb_controller&, revision_t);
 

--- a/libraries/chain/include/cyberway/chaindb/common.hpp
+++ b/libraries/chain/include/cyberway/chaindb/common.hpp
@@ -4,12 +4,15 @@
 
 #include <eosio/chain/types.hpp>
 #include <eosio/chain/abi_def.hpp>
+#include <eosio/chain/config.hpp>
 
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 
 #include <cyberway/chaindb/typed_name.hpp>
 
 namespace cyberway { namespace chaindb {
+
+    namespace config = eosio::chain::config;
 
     using revision_t = int64_t;
     static constexpr revision_t impossible_revision = (-1);
@@ -21,6 +24,9 @@ namespace cyberway { namespace chaindb {
 
     using std::string;
 
+    using fc::blob;
+    using fc::variant;
+
     using eosio::chain::account_name;
     using eosio::chain::table_name;
     using eosio::chain::index_name;
@@ -29,6 +35,7 @@ namespace cyberway { namespace chaindb {
     using eosio::chain::order_def;
     using eosio::chain::field_name;
     using eosio::chain::type_name;
+    using eosio::chain::bytes;
 
     using primary_key_t  = primary_key::value_type;
     using table_name_t   = table_name::value_type;
@@ -63,12 +70,21 @@ namespace cyberway { namespace chaindb {
         // TODO: RocksDB
     };
 
-    class chaindb_controller;
-    class cache_object;
-    using cache_object_ptr = boost::intrusive_ptr<cache_object>;
-
+    class  chaindb_controller;
+    class  cache_object;
+    class  cache_map;
+    class  driver_interface;
+    class  journal;
+    class  value_verifier;
+    class  undo_stack;
     struct table_info;
     struct index_info;
+    struct undo_stack_impl;
+    struct account_abi_info;
+    struct system_abi_info;
+    struct system_abi_info_impl;
+
+    using cache_object_ptr = boost::intrusive_ptr<cache_object>;
 
     struct find_info final {
         cursor_t      cursor = invalid_cursor;

--- a/libraries/chain/include/cyberway/chaindb/common.hpp
+++ b/libraries/chain/include/cyberway/chaindb/common.hpp
@@ -6,7 +6,6 @@
 #include <eosio/chain/abi_def.hpp>
 
 #include <boost/smart_ptr/intrusive_ptr.hpp>
-#include <boost/smart_ptr/intrusive_ref_counter.hpp>
 
 #include <cyberway/chaindb/typed_name.hpp>
 
@@ -64,12 +63,12 @@ namespace cyberway { namespace chaindb {
         // TODO: RocksDB
     };
 
-    class  chaindb_controller;
-    struct abi_info;
-    class  cache_object;
-    using  cache_object_ptr = boost::intrusive_ptr<cache_object>;
+    class chaindb_controller;
+    class cache_object;
+    using cache_object_ptr = boost::intrusive_ptr<cache_object>;
 
-    using abi_map = std::map<account_name /* code */, abi_info>;
+    struct table_info;
+    struct index_info;
 
     struct find_info final {
         cursor_t      cursor = invalid_cursor;

--- a/libraries/chain/include/cyberway/chaindb/common.hpp
+++ b/libraries/chain/include/cyberway/chaindb/common.hpp
@@ -35,6 +35,7 @@ namespace cyberway { namespace chaindb {
     using eosio::chain::order_def;
     using eosio::chain::field_name;
     using eosio::chain::type_name;
+    using eosio::chain::event_name;
     using eosio::chain::bytes;
 
     using primary_key_t  = primary_key::value_type;
@@ -43,10 +44,14 @@ namespace cyberway { namespace chaindb {
     using account_name_t = account_name::value_type;
     using scope_name_t   = scope_name::value_type;
 
+    struct service_state;
+
     struct table_request final {
         const account_name_t code  = 0;
         const scope_name_t   scope = 0;
         const table_name_t   table = 0;
+
+        service_state to_service(primary_key_t pk = primary_key::Unset) const;
     }; // struct table_request
 
     struct index_request final {
@@ -58,6 +63,8 @@ namespace cyberway { namespace chaindb {
         operator table_request() const {
             return {code, scope, table};
         }
+
+        service_state to_service(primary_key_t pk = primary_key::Unset) const;
     }; // struct index_request
 
     struct cursor_request final {

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -14,8 +14,6 @@ namespace cyberway { namespace chaindb {
     using eosio::chain::abi_def;
 
     template<class> struct object_to_table;
-    struct storage_payer_info;
-    struct account_abi_info;
     struct chaindb_controller_impl;
 
     class chaindb_controller final {
@@ -112,6 +110,11 @@ namespace cyberway { namespace chaindb {
         int64_t erase(const oid<Object>& id, const storage_payer_info& payer = {}) const {
             return erase<Object>(id._id, payer);
         }
+
+        const system_abi_info& get_system_abi_info() const;
+        const driver_interface& get_driver() const;
+        const cache_map& get_cache_map() const;
+        const undo_stack& get_undo_stack() const;
 
         void restore_db() const;
         void drop_db() const;

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -86,17 +86,10 @@ namespace cyberway { namespace chaindb {
             return idx.get(std::forward<Key>(key));
         }
 
-        template<typename Object, typename Lambda>
-        const Object& emplace(Lambda&& constructor) const {
-            return emplace<Object>({}, std::forward<Lambda>(constructor));
-        }
-
-        template<typename Object, typename Lambda>
-        const Object& emplace(const storage_payer_info& payer, Lambda&& constructor) const {
+        template<typename Object, typename... Args>
+        const Object& emplace(Args&&... args) const {
             auto midx = get_table<Object>();
-            auto res = midx.emplace(payer, std::forward<Lambda>(constructor));
-            // should not be critical - object is stored in cache map
-            return res.obj;
+            return midx.emplace(std::forward<Args>(args)...).obj;
         }
 
         template<typename Object, typename Lambda>
@@ -169,6 +162,7 @@ namespace cyberway { namespace chaindb {
 
         void set_cache_converter(const table_request&, const cache_converter_interface&) const;
         cache_object_ptr create_cache_object(const table_request&, const storage_payer_info&) const;
+        cache_object_ptr create_cache_object(const table_request&, const primary_key_t, const storage_payer_info&) const;
         cache_object_ptr get_cache_object(const cursor_request&, bool with_blob) const;
 
         primary_key_t available_pk(const table_request&) const;

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -6,18 +6,16 @@
 
 #include <cyberway/chaindb/common.hpp>
 #include <cyberway/chaindb/cache_item.hpp>
-#include <cyberway/chaindb/table_info.hpp>
 #include <cyberway/chaindb/storage_payer_info.hpp>
 
 namespace cyberway { namespace chaindb {
-    using fc::microseconds;
     using fc::variant;
 
     using eosio::chain::abi_def;
 
     template<class> struct object_to_table;
     struct storage_payer_info;
-
+    struct account_abi_info;
     struct chaindb_controller_impl;
 
     class chaindb_controller final {
@@ -92,16 +90,10 @@ namespace cyberway { namespace chaindb {
             return midx.emplace(std::forward<Args>(args)...).obj;
         }
 
-        template<typename Object, typename Lambda>
-        int64_t modify(const Object& obj, Lambda&& updater) const {
+        template<typename Object, typename... Args>
+        int64_t modify(const Object& obj, Args&&... args) const {
             auto midx = get_table<Object>();
-            return midx.modify(obj, std::forward<Lambda>(updater));
-        }
-
-        template<typename Object, typename Lambda>
-        int64_t modify(const Object& obj, const storage_payer_info& payer, Lambda&& updater) const {
-            auto midx = get_table<Object>();
-            return midx.modify(obj, payer, std::forward<Lambda>(updater));
+            return midx.modify(obj, std::forward<Args>(args)...);
         }
 
         template<typename Object>
@@ -124,10 +116,6 @@ namespace cyberway { namespace chaindb {
         void restore_db() const;
         void drop_db() const;
         void clear_cache() const;
-
-        void add_abi(const account_name&, abi_def) const;
-
-        const abi_map& get_abi_map() const;
 
         void close(const cursor_request&) const;
         void close_code_cursors(const account_name&) const;
@@ -164,6 +152,7 @@ namespace cyberway { namespace chaindb {
         cache_object_ptr create_cache_object(const table_request&, const storage_payer_info&) const;
         cache_object_ptr create_cache_object(const table_request&, const primary_key_t, const storage_payer_info&) const;
         cache_object_ptr get_cache_object(const cursor_request&, bool with_blob) const;
+        account_abi_info get_account_abi_info(account_name_t) const;
 
         primary_key_t available_pk(const table_request&) const;
 

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -6,6 +6,7 @@
 
 #include <cyberway/chaindb/common.hpp>
 #include <cyberway/chaindb/cache_item.hpp>
+#include <cyberway/chaindb/table_info.hpp>
 #include <cyberway/chaindb/storage_payer_info.hpp>
 
 namespace cyberway { namespace chaindb {
@@ -16,6 +17,8 @@ namespace cyberway { namespace chaindb {
 
     template<class> struct object_to_table;
     struct storage_payer_info;
+
+    struct chaindb_controller_impl;
 
     class chaindb_controller final {
     public:
@@ -191,8 +194,7 @@ namespace cyberway { namespace chaindb {
     private:
         friend class chaindb_session;
 
-        struct controller_impl_;
-        std::unique_ptr<controller_impl_> impl_;
+        std::unique_ptr<chaindb_controller_impl> impl_;
     }; // class chaindb_controller
 
     class chaindb_guard final {

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -132,9 +132,7 @@ namespace cyberway { namespace chaindb {
         void drop_db() const;
         void clear_cache() const;
 
-        bool has_abi(const account_name&) const;
         void add_abi(const account_name&, abi_def) const;
-        void remove_abi(const account_name&) const;
 
         const abi_map& get_abi_map() const;
 

--- a/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
+++ b/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
@@ -7,8 +7,6 @@
 
 namespace cyberway { namespace chaindb {
 
-    struct object_value;
-
     struct cursor_info {
         cursor_t      id = invalid_cursor;
         index_info    index;

--- a/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
+++ b/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
@@ -1,15 +1,13 @@
 #pragma once
 
-#include <fc/variant.hpp>
+#include <cyberway/chaindb/common.hpp>
+#include <cyberway/chaindb/table_info.hpp>
 
-#include <cyberway/chaindb/controller.hpp>
-#include <cyberway/chaindb/object_value.hpp>
+#include <fc/variant.hpp>
 
 namespace cyberway { namespace chaindb {
 
-    using fc::variant;
-
-    using eosio::chain::bytes;
+    struct object_value;
 
     struct cursor_info {
         cursor_t      id = invalid_cursor;

--- a/libraries/chain/include/cyberway/chaindb/exception.hpp
+++ b/libraries/chain/include/cyberway/chaindb/exception.hpp
@@ -106,6 +106,9 @@ namespace cyberway { namespace chaindb {
         FC_DECLARE_DERIVED_EXCEPTION(driver_scope_exception, chaindb_internal_exception,
                                      3710020, "ChainDB driver returns bad scope")
 
+        FC_DECLARE_DERIVED_EXCEPTION(cache_primary_key_exception, chaindb_internal_exception,
+                                     3710021, "ChainDB cache return bad primary key")
+
     FC_DECLARE_DERIVED_EXCEPTION(chaindb_abi_exception, chaindb_exception,
                                  3720000, "ChainDB ABI exception")
 

--- a/libraries/chain/include/cyberway/chaindb/index_object.hpp
+++ b/libraries/chain/include/cyberway/chaindb/index_object.hpp
@@ -63,8 +63,16 @@ namespace cyberway { namespace chaindb {
             return a._id == b._id;
         }
 
+        friend bool operator == (const oid& a, const int b) {
+            return a._id == primary_key_t(b);
+        }
+
         friend bool operator != (const oid& a, const oid& b) {
             return a._id != b._id;
+        }
+
+        friend bool operator != (const oid& a, const primary_key_t b) {
+            return a._id != b;
         }
 
         friend std::ostream& operator<<(std::ostream& s, const oid& id) {

--- a/libraries/chain/include/cyberway/chaindb/index_object.hpp
+++ b/libraries/chain/include/cyberway/chaindb/index_object.hpp
@@ -2,18 +2,47 @@
 
 #include <ostream>
 
+namespace cyberway { namespace chaindb {
+    using primary_key_t = uint64_t;
+} }
+
 #define OBJECT_CTOR(NAME) \
-    NAME() = delete; \
+       NAME() = delete; \
     public: \
-    template<typename Constructor> \
-    NAME(Constructor&& c, int) \
-    { c(*this); }
+       template<typename Constructor> \
+       NAME(Constructor&& c, int) { \
+          c(*this); \
+       }
+
+#define CHAINDB_OBJECT_ID_CTOR(NAME) \
+       NAME() = delete; \
+    public: \
+       template<typename Constructor> \
+       NAME(cyberway::chaindb::primary_key_t v, Constructor&& c) { \
+          id._id = v; \
+          c(*this); \
+       } \
+       cyberway::chaindb::primary_key_t pk() const { \
+          return id._id; \
+       }
+
+#define CHAINDB_OBJECT_CTOR(NAME, PK) \
+       NAME() = delete; \
+    public: \
+       template<typename Constructor> \
+       NAME(cyberway::chaindb::primary_key_t v, Constructor&& c) { \
+           PK = v; \
+           c(*this); \
+       } \
+       cyberway::chaindb::primary_key_t pk() const { \
+           return PK; \
+       }
 
 namespace cyberway { namespace chaindb {
 
     template<typename Object> class oid {
     public:
-        oid(uint64_t i = 0)
+        oid(primary_key_t i = 0)
         : _id(i) {
         }
 
@@ -42,7 +71,11 @@ namespace cyberway { namespace chaindb {
             s << boost::core::demangle(typeid(oid).name()) << '(' << id._id << ')'; return s;
         }
 
-        uint64_t _id = 0;
+        operator primary_key_t() const {
+            return _id;
+        }
+
+        primary_key_t _id = 0;
     }; // class oid
 
     template<uint16_t TypeNumber, typename Derived> struct object {

--- a/libraries/chain/include/cyberway/chaindb/journal.hpp
+++ b/libraries/chain/include/cyberway/chaindb/journal.hpp
@@ -2,6 +2,7 @@
 
 #include <cyberway/chaindb/controller.hpp>
 #include <cyberway/chaindb/object_value.hpp>
+#include <cyberway/chaindb/table_info.hpp>
 #include <cyberway/chaindb/table_object.hpp>
 
 namespace cyberway { namespace chaindb {

--- a/libraries/chain/include/cyberway/chaindb/journal.hpp
+++ b/libraries/chain/include/cyberway/chaindb/journal.hpp
@@ -99,8 +99,8 @@ namespace cyberway { namespace chaindb {
 
         template <typename Ctx>
         void apply_table_changes(Ctx&& ctx, const table_info& table) {
-            auto begin_itr = index_.lower_bound(std::make_tuple(table.code, table.table->name));
-            auto end_itr = index_.upper_bound(std::make_tuple(table.code, table.table->name));
+            auto begin_itr = index_.lower_bound(std::make_tuple(table.code, table.table_name()));
+            auto end_itr = index_.upper_bound(std::make_tuple(table.code, table.table_name()));
 
             apply_range_changes(std::forward<Ctx>(ctx), begin_itr, end_itr);
         }

--- a/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
+++ b/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
@@ -4,9 +4,10 @@
 #include <memory>
 
 #include <cyberway/chaindb/driver_interface.hpp>
-#include <cyberway/chaindb/journal.hpp>
 
 namespace cyberway { namespace chaindb {
+
+    class journal;
 
     class mongodb_driver final: public driver_interface {
     public:

--- a/libraries/chain/include/cyberway/chaindb/names.hpp
+++ b/libraries/chain/include/cyberway/chaindb/names.hpp
@@ -56,7 +56,7 @@ namespace cyberway { namespace chaindb {
     }
 
     inline bool is_system_code(const account_name& code) {
-        return (code.empty()) || (code.value == eosio::chain::config::system_account_name);
+        return (code.empty()) || (code.value == config::system_account_name);
     }
 
     inline string get_code_name(string name, const account_name& code) {

--- a/libraries/chain/include/cyberway/chaindb/names.hpp
+++ b/libraries/chain/include/cyberway/chaindb/names.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <cyberway/chaindb/common.hpp>
-#include <algorithm>
+
+#include <eosio/chain/config.hpp>
 
 namespace cyberway { namespace chaindb {
 
@@ -55,7 +56,7 @@ namespace cyberway { namespace chaindb {
     }
 
     inline bool is_system_code(const account_name& code) {
-        return (code.empty());
+        return (code.empty()) || (code.value == eosio::chain::config::system_account_name);
     }
 
     inline string get_code_name(string name, const account_name& code) {

--- a/libraries/chain/include/cyberway/chaindb/object_value.hpp
+++ b/libraries/chain/include/cyberway/chaindb/object_value.hpp
@@ -35,15 +35,6 @@ namespace cyberway { namespace chaindb {
         size_t         undo_size     = 0;
         bool           undo_in_ram   = true;
 
-        service_state(const table_info& table, primary_key_t pk)
-        : pk(pk), code(table.code), scope(table.scope), table(table.table->name) {
-        }
-
-        service_state(const table_info& table, primary_key_t undo_pk, undo_record rec, revision_t rev)
-        : code(table.code), scope(table.scope), table(table.table->name),
-          revision(rev), undo_pk(undo_pk), undo_rec(rec) {
-        }
-
         service_state() = default;
         service_state(service_state&&) = default;
         service_state(const service_state&) = default;

--- a/libraries/chain/include/cyberway/chaindb/object_value.hpp
+++ b/libraries/chain/include/cyberway/chaindb/object_value.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <cyberway/chaindb/common.hpp>
-#include <cyberway/chaindb/storage_payer_info.hpp>
+#include <cyberway/chaindb/typed_name.hpp>
+
+#include <fc/variant.hpp>
 
 namespace cyberway { namespace chaindb {
 

--- a/libraries/chain/include/cyberway/chaindb/storage_calculator.hpp
+++ b/libraries/chain/include/cyberway/chaindb/storage_calculator.hpp
@@ -4,10 +4,7 @@ namespace fc{
     class variant;
 } // namespace fc
 
-namespace eosio { namespace chain {
-    struct table_def;
-} } // namespace eosio::chain
-
 namespace cyberway { namespace chaindb {
-    int calc_storage_usage(const eosio::chain::table_def&, const fc::variant&);
+    struct table_info;
+    int calc_storage_usage(const table_info&, const fc::variant&);
 } } // namespace cyberway::chaindb

--- a/libraries/chain/include/cyberway/chaindb/storage_payer_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/storage_payer_info.hpp
@@ -46,7 +46,6 @@ namespace cyberway { namespace chaindb {
         : transaction_ctx(&t), owner(std::move(o)), payer(std::move(p)) {
         }
 
-        void calc_usage(const table_info&, const object_value&);
         void add_usage();
 
         void get_payer_from(const object_value&);

--- a/libraries/chain/include/cyberway/chaindb/table_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/table_info.hpp
@@ -2,6 +2,7 @@
 
 #include <cyberway/chaindb/common.hpp>
 #include <cyberway/chaindb/cache_item.hpp>
+#include <cyberway/chaindb/account_abi_info.hpp>
 
 namespace cyberway { namespace chaindb {
 
@@ -10,9 +11,10 @@ namespace cyberway { namespace chaindb {
         const scope_name_t   scope    = 0;
         const table_def*     table    = nullptr;
         const order_def*     pk_order = nullptr;
-        const abi_info*      abi      = nullptr;
 
-        cache_object_ptr     account_ptr; // ptr to account with abi
+        account_abi_info     account_abi;
+
+        table_info() = default;
 
         table_info(account_name_t c, scope_name_t s)
         : code(c), scope(s) {
@@ -25,6 +27,11 @@ namespace cyberway { namespace chaindb {
         table_name_t table_name() const {
             assert(is_valid());
             return table->name.value;
+        }
+
+        const abi_info& abi() const {
+            assert(is_valid() && account_abi.has_abi_info());
+            return account_abi.abi();
         }
 
         service_state to_service(const primary_key_t pk = primary_key::Unset) const {

--- a/libraries/chain/include/cyberway/chaindb/table_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/table_info.hpp
@@ -19,7 +19,6 @@ namespace cyberway { namespace chaindb {
         }
 
         bool is_valid() const {
-            assert((nullptr == table) == (!account_ptr) == (nullptr == pk_order) == (nullptr == abi));
             return nullptr != table;
         }
 

--- a/libraries/chain/include/cyberway/chaindb/table_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/table_info.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <cyberway/chaindb/common.hpp>
+#include <cyberway/chaindb/cache_item.hpp>
+
+namespace cyberway { namespace chaindb {
+
+    struct table_info {
+        const account_name_t code     = 0;
+        const scope_name_t   scope    = 0;
+        const table_def*     table    = nullptr;
+        const order_def*     pk_order = nullptr;
+        const abi_info*      abi      = nullptr;
+
+        cache_object_ptr     account_ptr; // ptr to account with abi
+
+        table_info(account_name_t c, scope_name_t s)
+        : code(c), scope(s) {
+        }
+
+        bool is_valid() const {
+            assert((nullptr == table) == (!account_ptr) == (nullptr == pk_order) == (nullptr == abi));
+            return nullptr != table;
+        }
+
+        table_name_t table_name() const {
+            assert(is_valid());
+            return table->name.value;
+        }
+
+        service_state to_service(const primary_key_t pk = primary_key::Unset) const {
+            service_state service;
+
+            service.code  = code;
+            service.scope = scope;
+            service.table = table_name();
+            service.pk    = pk;
+
+            return service;
+        }
+    }; // struct table_info
+
+    struct index_info: public table_info {
+        const index_def* index = nullptr;
+
+        using table_info::table_info;
+
+        index_info(const table_info& src)
+        : table_info(src) {
+        }
+
+        bool is_valid() const {
+            return table_info::is_valid() && nullptr != index;
+        }
+
+        index_name_t index_name() const {
+            assert(is_valid());
+            return index->name.value;
+        }
+    }; // struct index_info
+
+} } // namespace cyberway::chaindb

--- a/libraries/chain/include/cyberway/chaindb/table_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/table_info.hpp
@@ -30,7 +30,7 @@ namespace cyberway { namespace chaindb {
         }
 
         const abi_info& abi() const {
-            assert(is_valid() && account_abi.has_abi_info());
+            assert(account_abi.has_abi_info());
             return account_abi.abi();
         }
 

--- a/libraries/chain/include/cyberway/chaindb/table_object.hpp
+++ b/libraries/chain/include/cyberway/chaindb/table_object.hpp
@@ -62,22 +62,22 @@ namespace cyberway { namespace chaindb { namespace table_object {
 
     template <typename Object>
     typename index<Object>::iterator find(index<Object>& idx, const table_info& table) {
-        return idx.find(std::make_tuple(table.code, table.table->name, table.scope));
+        return idx.find(std::make_tuple(table.code, table.table_name(), table.scope));
     }
 
     template <typename Object>
     typename index<Object>::iterator find(const index<Object>& idx, const table_info& table) {
-        return idx.find(std::make_tuple(table.code, table.table->name, table.scope));
+        return idx.find(std::make_tuple(table.code, table.table_name(), table.scope));
     }
 
     template <typename Object>
     typename index<Object>::iterator find_without_scope(index<Object>& idx, const table_info& table) {
-        return idx.find(std::make_tuple(table.code, table.table->name, 0));
+        return idx.find(std::make_tuple(table.code, table.table_name(), 0));
     }
 
     template <typename Object>
     typename index<Object>::iterator find_without_scope(const index<Object>& idx, const table_info& table) {
-        return idx.find(std::make_tuple(table.code, table.table->name, 0));
+        return idx.find(std::make_tuple(table.code, table.table_name(), 0));
     }
 
     template <typename Object, typename... Args>

--- a/libraries/chain/include/cyberway/chaindb/undo_state.hpp
+++ b/libraries/chain/include/cyberway/chaindb/undo_state.hpp
@@ -8,11 +8,13 @@ namespace cyberway { namespace chaindb {
     class cache_map;
     class driver_interface;
     class journal;
+    class value_verifier;
     struct table_info;
+    struct undo_stack_impl;
 
     class undo_stack final {
     public:
-        undo_stack(chaindb_controller&, driver_interface&, journal&, cache_map&);
+        undo_stack(chaindb_controller&, value_verifier&, driver_interface&, journal&, cache_map&);
 
         undo_stack(const undo_stack&) = delete;
         undo_stack(undo_stack&&) = delete;
@@ -68,8 +70,7 @@ namespace cyberway { namespace chaindb {
         void remove(const table_info&, object_value orig_obj) const;
 
     private:
-        struct undo_stack_impl_;
-        std::unique_ptr<undo_stack_impl_> impl_;
+        std::unique_ptr<undo_stack_impl> impl_;
         revision_t revision_;
     }; // class table_undo_stack
 

--- a/libraries/chain/include/cyberway/chaindb/undo_state.hpp
+++ b/libraries/chain/include/cyberway/chaindb/undo_state.hpp
@@ -19,7 +19,7 @@ namespace cyberway { namespace chaindb {
 
         ~undo_stack();
 
-        void add_abi_tables(eosio::chain::abi_def&) const;
+        static void add_abi_tables(eosio::chain::abi_def&);
 
         void restore() const;
 

--- a/libraries/chain/include/cyberway/chaindb/undo_state.hpp
+++ b/libraries/chain/include/cyberway/chaindb/undo_state.hpp
@@ -5,23 +5,12 @@
 
 namespace cyberway { namespace chaindb {
 
-    class cache_map;
-    class driver_interface;
-    class journal;
-    class value_verifier;
-    struct table_info;
-    struct undo_stack_impl;
-
     class undo_stack final {
     public:
-        undo_stack(chaindb_controller&, value_verifier&, driver_interface&, journal&, cache_map&);
-
         undo_stack(const undo_stack&) = delete;
         undo_stack(undo_stack&&) = delete;
 
         ~undo_stack();
-
-        static void add_abi_tables(eosio::chain::abi_def&);
 
         void restore() const;
 
@@ -70,6 +59,13 @@ namespace cyberway { namespace chaindb {
         void remove(const table_info&, object_value orig_obj) const;
 
     private:
+        friend class  chaindb_controller;
+        friend struct chaindb_controller_impl;
+
+        undo_stack();
+
+        void init(chaindb_controller&, journal&);
+
         std::unique_ptr<undo_stack_impl> impl_;
         revision_t revision_;
     }; // class table_undo_stack

--- a/libraries/chain/include/cyberway/chaindb/value_verifier.hpp
+++ b/libraries/chain/include/cyberway/chaindb/value_verifier.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <memory>
+
+namespace cyberway { namespace chaindb {
+
+    class driver_interface;
+
+    struct value_verifier_impl;
+    struct table_info;
+    struct object_value;
+
+    class value_verifier final {
+    public:
+        value_verifier(driver_interface&);
+        ~value_verifier();
+
+        void verify(const table_info&, const object_value&) const;
+
+    private:
+        std::unique_ptr<value_verifier_impl> impl_;
+    }; // struct value_verifier;
+
+}} // namespace cyberway::chaindb

--- a/libraries/chain/include/cyberway/chaindb/value_verifier.hpp
+++ b/libraries/chain/include/cyberway/chaindb/value_verifier.hpp
@@ -4,15 +4,14 @@
 
 namespace cyberway { namespace chaindb {
 
-    class driver_interface;
-
+    class  chaindb_controller;
     struct value_verifier_impl;
     struct table_info;
     struct object_value;
 
     class value_verifier final {
     public:
-        value_verifier(driver_interface&);
+        value_verifier(const chaindb_controller&);
         ~value_verifier();
 
         void verify(const table_info&, const object_value&) const;

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -100,7 +100,7 @@ struct abi_serializer {
    static const size_t max_recursion_depth = 32; // arbitrary depth to prevent infinite recursion
 
 private:
-   bool check_field_name_ = true;
+   bool check_field_name_ = false;
 
    map<type_name, type_name>     typedefs;
    map<type_name, struct_def>    structs;

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -37,7 +37,7 @@ struct abi_serializer {
        PublicMode,
    }; // enum mode
 
-   abi_serializer( mode m = PublicMode ){ configure_built_in_types(m); }
+   abi_serializer( ){ configure_built_in_types(); }
    abi_serializer( const abi_def& abi, const fc::microseconds& max_serialization_time );
    bool is_check_field_name() const { return check_field_name_; }
    void set_check_field_name(bool);
@@ -64,6 +64,7 @@ struct abi_serializer {
 
    fc::variant binary_to_variant( const type_name& type, const bytes& binary, const fc::microseconds& max_serialization_time, bool short_path = false )const;
    fc::variant binary_to_variant( const type_name& type, fc::datastream<const char*>& binary, const fc::microseconds& max_serialization_time, bool short_path = false )const;
+   fc::variant binary_to_variant( const type_name& type, fc::datastream<const char*>& binary, const fc::microseconds& max_serialization_time, mode)const;
 
    bytes       variant_to_binary( const type_name& type, const fc::variant& var, const fc::microseconds& max_serialization_time, bool short_path = false )const;
    void        variant_to_binary( const type_name& type, const fc::variant& var, fc::datastream<char*>& ds, const fc::microseconds& max_serialization_time, bool short_path = false )const;
@@ -110,7 +111,8 @@ private:
    map<type_name, variant_def>   variants;
 
    map<type_name, pair<unpack_function, pack_function>> built_in_types;
-   void configure_built_in_types(mode);
+   map<type_name, pair<unpack_function, pack_function>> db_built_in_types;
+   void configure_built_in_types();
 
    fc::variant _binary_to_variant( const type_name& type, const bytes& binary, impl::binary_to_variant_context& ctx )const;
    fc::variant _binary_to_variant( const type_name& type, fc::datastream<const char*>& binary, impl::binary_to_variant_context& ctx )const;
@@ -230,6 +232,7 @@ namespace impl {
 
    struct binary_to_variant_context : public abi_traverse_context_with_path {
       using abi_traverse_context_with_path::abi_traverse_context_with_path;
+      abi_serializer::mode mode = abi_serializer::PublicMode;
    };
 
    struct variant_to_binary_context : public abi_traverse_context_with_path {

--- a/libraries/chain/include/eosio/chain/account_object.hpp
+++ b/libraries/chain/include/eosio/chain/account_object.hpp
@@ -9,6 +9,8 @@
 #include <eosio/chain/abi_def.hpp>
 #include <eosio/chain/multi_index_includes.hpp>
 
+#include <cyberway/chaindb/abi_info.hpp>
+
 namespace eosio { namespace chain {
 
    class account_object : public cyberway::chaindb::object<account_object_type, account_object> {
@@ -42,6 +44,11 @@ namespace eosio { namespace chain {
          fc::raw::unpack( ds, a );
          return a;
       }
+
+      cyberway::chaindb::abi_info& get_abi_info();
+
+   private:
+      std::unique_ptr<cyberway::chaindb::abi_info> abi_info_;
    };
    using account_id_type = account_object::id_type;
 

--- a/libraries/chain/include/eosio/chain/account_object.hpp
+++ b/libraries/chain/include/eosio/chain/account_object.hpp
@@ -44,7 +44,8 @@ namespace eosio { namespace chain {
          return a;
       }
 
-      cyberway::chaindb::abi_info& get_abi_info();
+      void generate_abi_info();
+      const cyberway::chaindb::abi_info& get_abi_info() const;
 
    private:
       std::unique_ptr<cyberway::chaindb::abi_info> abi_info_;

--- a/libraries/chain/include/eosio/chain/account_object.hpp
+++ b/libraries/chain/include/eosio/chain/account_object.hpp
@@ -29,10 +29,16 @@ namespace eosio { namespace chain {
       string               code;
       bytes                abi;
 
+      void set_abi( bytes a ) {
+         abi = std::move(a);
+         abi_info_.reset();
+      }
+
       void set_abi( const eosio::chain::abi_def& a ) {
          abi.resize( fc::raw::pack_size( a ) );
          fc::datastream<char*> ds( const_cast<char*>(abi.data()), abi.size() );
          fc::raw::pack( ds, a );
+         abi_info_.reset();
       }
 
       eosio::chain::abi_def get_abi()const {

--- a/libraries/chain/include/eosio/chain/account_object.hpp
+++ b/libraries/chain/include/eosio/chain/account_object.hpp
@@ -14,9 +14,8 @@
 namespace eosio { namespace chain {
 
    class account_object : public cyberway::chaindb::object<account_object_type, account_object> {
-      OBJECT_CTOR(account_object)
+      CHAINDB_OBJECT_CTOR(account_object, name.value)
 
-      id_type              id;
       account_name         name;
       uint8_t              vm_type      = 0;
       uint8_t              vm_version   = 0;
@@ -50,22 +49,18 @@ namespace eosio { namespace chain {
    private:
       std::unique_ptr<cyberway::chaindb::abi_info> abi_info_;
    };
-   using account_id_type = account_object::id_type;
 
    struct by_name;
    using account_table = cyberway::chaindb::table_container<
       account_object,
       cyberway::chaindb::indexed_by<
-         cyberway::chaindb::ordered_unique<cyberway::chaindb::tag<by_id>, BOOST_MULTI_INDEX_MEMBER(account_object, account_object::id_type, id)>,
-         cyberway::chaindb::ordered_unique<cyberway::chaindb::tag<by_name>, BOOST_MULTI_INDEX_MEMBER(account_object, account_name, name)>
+         cyberway::chaindb::ordered_unique<cyberway::chaindb::tag<by_id>, BOOST_MULTI_INDEX_MEMBER(account_object, account_name, name)>
       >
    >;
 
-   class account_sequence_object : public cyberway::chaindb::object<account_sequence_object_type, account_sequence_object>
-   {
-      OBJECT_CTOR(account_sequence_object);
+   class account_sequence_object : public cyberway::chaindb::object<account_sequence_object_type, account_sequence_object> {
+      CHAINDB_OBJECT_CTOR(account_sequence_object, name.value)
 
-      id_type      id;
       account_name name;
       uint64_t     recv_sequence = 0;
       uint64_t     auth_sequence = 0;
@@ -77,8 +72,7 @@ namespace eosio { namespace chain {
    using account_sequence_table = cyberway::chaindb::table_container<
       account_sequence_object,
       cyberway::chaindb::indexed_by<
-         cyberway::chaindb::ordered_unique<cyberway::chaindb::tag<by_id>, BOOST_MULTI_INDEX_MEMBER(account_sequence_object, account_sequence_object::id_type, id)>,
-         cyberway::chaindb::ordered_unique<cyberway::chaindb::tag<by_name>, BOOST_MULTI_INDEX_MEMBER(account_sequence_object, account_name, name)>
+         cyberway::chaindb::ordered_unique<cyberway::chaindb::tag<by_id>, BOOST_MULTI_INDEX_MEMBER(account_sequence_object, account_name, name)>
       >
    >;
 
@@ -89,5 +83,5 @@ CHAINDB_TAG(eosio::chain::account_object, account)
 CHAINDB_SET_TABLE_TYPE(eosio::chain::account_sequence_object, eosio::chain::account_sequence_table)
 CHAINDB_TAG(eosio::chain::account_sequence_object, accountseq)
 
-FC_REFLECT(eosio::chain::account_object, (id)(name)(vm_type)(vm_version)(privileged)(last_code_update)(code_version)(abi_version)(creation_date)(code)(abi))
-FC_REFLECT(eosio::chain::account_sequence_object, (id)(name)(recv_sequence)(auth_sequence)(code_sequence)(abi_sequence))
+FC_REFLECT(eosio::chain::account_object, (name)(vm_type)(vm_version)(privileged)(last_code_update)(code_version)(abi_version)(creation_date)(code)(abi))
+FC_REFLECT(eosio::chain::account_sequence_object, (name)(recv_sequence)(auth_sequence)(code_sequence)(abi_sequence))

--- a/libraries/chain/include/eosio/chain/block_summary_object.hpp
+++ b/libraries/chain/include/eosio/chain/block_summary_object.hpp
@@ -18,7 +18,7 @@ namespace eosio { namespace chain {
     */
    class block_summary_object : public cyberway::chaindb::object<block_summary_object_type, block_summary_object>
    {
-         OBJECT_CTOR(block_summary_object)
+         CHAINDB_OBJECT_ID_CTOR(block_summary_object)
 
          id_type        id;
          block_id_type  block_id;

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -308,8 +308,6 @@ namespace eosio { namespace chain {
          signal<void(const header_confirmation&)>      accepted_confirmation;
          signal<void(const int&)>                      bad_alloc;
 
-         signal<void(const std::tuple<name,const abi_def&>&)> setabi;
-
          /*
          signal<void()>                                  pre_apply_block;
          signal<void()>                                  post_apply_block;
@@ -320,7 +318,6 @@ namespace eosio { namespace chain {
          signal<void(const transaction_trace_ptr&)>  post_apply_action;
          */
 
-         void set_abi(name account, const abi_def& abi);
          const apply_handler* find_apply_handler( account_name contract, scope_name scope, action_name act )const;
          wasm_interface& get_wasm_interface();
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -87,6 +87,35 @@ namespace eosio { namespace chain {
        }
    };
 
+   template<typename T>
+   class optional_ptr final {
+   public:
+       optional_ptr(const T* t = nullptr)
+       : impl_(t) {
+       }
+
+       optional_ptr(const T& t)
+       : impl_(&t) {
+       }
+
+       bool valid() const {
+           return nullptr != impl_;
+       }
+
+       const T& operator*() const {
+           assert(valid());
+           return *impl_;
+       }
+
+       const T* operator->() const {
+           assert(valid());
+           return impl_;
+       }
+
+   private:
+       const T* impl_ = nullptr;
+   }; // class optional_ptr
+
    class controller {
       public:
 
@@ -296,17 +325,7 @@ namespace eosio { namespace chain {
          wasm_interface& get_wasm_interface();
 
 
-         optional<abi_serializer> get_abi_serializer( account_name n, const fc::microseconds& max_serialization_time )const {
-            if( n.good() ) {
-               try {
-                  const auto& a = get_account( n );
-                  abi_def abi;
-                  if( abi_serializer::to_abi( a.abi, abi ))
-                     return abi_serializer( abi, max_serialization_time );
-               } FC_CAPTURE_AND_LOG((n))
-            }
-            return optional<abi_serializer>();
-         }
+         optional_ptr<abi_serializer> get_abi_serializer( account_name n, const fc::microseconds& max_serialization_time )const;
 
          template<typename T>
          fc::variant to_variant_with_abi( const T& obj, const fc::microseconds& max_serialization_time ) {

--- a/libraries/chain/include/eosio/chain/generated_transaction_object.hpp
+++ b/libraries/chain/include/eosio/chain/generated_transaction_object.hpp
@@ -24,7 +24,7 @@ namespace eosio { namespace chain {
     */
    class generated_transaction_object : public cyberway::chaindb::object<generated_transaction_object_type, generated_transaction_object>
    {
-         OBJECT_CTOR(generated_transaction_object)
+         CHAINDB_OBJECT_ID_CTOR(generated_transaction_object)
 
          id_type                       id;
          transaction_id_type           trx_id;

--- a/libraries/chain/include/eosio/chain/global_property_object.hpp
+++ b/libraries/chain/include/eosio/chain/global_property_object.hpp
@@ -26,7 +26,7 @@ namespace eosio { namespace chain {
     */
    class global_property_object : public cyberway::chaindb::object<global_property_object_type, global_property_object>
    {
-      OBJECT_CTOR(global_property_object)
+      CHAINDB_OBJECT_ID_CTOR(global_property_object)
 
       id_type                           id;
       optional<block_num_type>          proposed_schedule_block_num;
@@ -47,7 +47,7 @@ namespace eosio { namespace chain {
     */
    class dynamic_global_property_object : public cyberway::chaindb::object<dynamic_global_property_object_type, dynamic_global_property_object>
    {
-        OBJECT_CTOR(dynamic_global_property_object)
+        CHAINDB_OBJECT_ID_CTOR(dynamic_global_property_object)
 
         id_type    id;
         uint64_t   global_action_sequence = 0;

--- a/libraries/chain/include/eosio/chain/multi_index_includes.hpp
+++ b/libraries/chain/include/eosio/chain/multi_index_includes.hpp
@@ -40,21 +40,21 @@ using bmi::const_mem_fun;
 using bmi::tag;
 using bmi::composite_key_compare;
 
-struct by_id {};
+struct by_id;
+struct by_table;
 
 namespace eosio { namespace chain {
 
-    struct by_parent {};
-    struct by_owner {};
-    struct by_name {};
-    struct by_action_name {};
-    struct by_permission_name {};
-    struct by_trx_id {};
-    struct by_expiration {};
-    struct by_delay {};
-    struct by_status {};
-    struct by_sender_id {};
-    struct by_scope_name {};
+    struct by_parent;
+    struct by_owner;
+    struct by_name;
+    struct by_action_name;
+    struct by_permission_name;
+    struct by_trx_id;
+    struct by_expiration;
+    struct by_delay;
+    struct by_sender_id;
+    struct by_scope_name;
 
 } } // namespace eosio::chain
 
@@ -65,6 +65,7 @@ namespace eosio { namespace chain { namespace resource_limits {
 } } } // namespace eosio::chain::resource_limits
 
 CHAINDB_TAG(by_id, primary) // "primary" for compatibility with contracts
+CHAINDB_TAG(by_table, table)
 CHAINDB_TAG(eosio::chain::by_parent, parent)
 CHAINDB_TAG(eosio::chain::by_owner, owner)
 CHAINDB_TAG(eosio::chain::by_name, name)

--- a/libraries/chain/include/eosio/chain/multi_index_includes.hpp
+++ b/libraries/chain/include/eosio/chain/multi_index_includes.hpp
@@ -111,8 +111,8 @@ namespace cyberway { namespace chaindb {
     struct table_container_impl;
 
     struct object_id_extractor {
-        template<typename T> uint64_t operator()(const T& o) const {
-            return o.id._id;
+        template<typename T> primary_key_t operator()(const T& o) const {
+            return o.pk();
         }
     }; // struct object_id_extractor
 

--- a/libraries/chain/include/eosio/chain/permission_link_object.hpp
+++ b/libraries/chain/include/eosio/chain/permission_link_object.hpp
@@ -27,7 +27,7 @@ namespace eosio { namespace chain {
     * account's active authority is used.
     */
    class permission_link_object : public cyberway::chaindb::object<permission_link_object_type, permission_link_object> {
-      OBJECT_CTOR(permission_link_object)
+      CHAINDB_OBJECT_ID_CTOR(permission_link_object)
 
       id_type        id;
       /// The account which is defining its permission requirements

--- a/libraries/chain/include/eosio/chain/permission_object.hpp
+++ b/libraries/chain/include/eosio/chain/permission_object.hpp
@@ -10,7 +10,7 @@
 namespace eosio { namespace chain {
 
    class permission_usage_object : public cyberway::chaindb::object<permission_usage_object_type, permission_usage_object> {
-      OBJECT_CTOR(permission_usage_object)
+      CHAINDB_OBJECT_ID_CTOR(permission_usage_object)
 
       id_type           id;
       time_point        last_used;   ///< when this permission was last used
@@ -26,7 +26,7 @@ namespace eosio { namespace chain {
 
 
    class permission_object : public cyberway::chaindb::object<permission_object_type, permission_object> {
-      OBJECT_CTOR(permission_object)
+      CHAINDB_OBJECT_ID_CTOR(permission_object)
 
       id_type                           id;
       permission_usage_object::id_type  usage_id;

--- a/libraries/chain/include/eosio/chain/resource_limits_private.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits_private.hpp
@@ -99,10 +99,9 @@ using namespace int_arithmetic;
    struct by_owner;
    struct by_dirty;
 
-   struct resource_usage_object : public chainbase::object<resource_usage_object_type, resource_usage_object> {
-      OBJECT_CTOR(resource_usage_object)
+   struct resource_usage_object {
+      CHAINDB_OBJECT_CTOR(resource_usage_object, owner.value)
 
-      id_type id;
       account_name owner;
        
       std::vector<usage_accumulator> accumulators;
@@ -111,13 +110,12 @@ using namespace int_arithmetic;
    using resource_usage_table = cyberway::chaindb::table_container<
       resource_usage_object,
        cyberway::chaindb::indexed_by<
-         cyberway::chaindb::ordered_unique<cyberway::chaindb::tag<by_id>, BOOST_MULTI_INDEX_MEMBER(resource_usage_object, resource_usage_object::id_type, id)>,
-         cyberway::chaindb::ordered_unique<cyberway::chaindb::tag<by_owner>, BOOST_MULTI_INDEX_MEMBER(resource_usage_object, account_name, owner) >
+         cyberway::chaindb::ordered_unique<cyberway::chaindb::tag<by_id>, BOOST_MULTI_INDEX_MEMBER(resource_usage_object, account_name, owner) >
       >
    >;
 
    class resource_limits_config_object : public cyberway::chaindb::object<resource_limits_config_object_type, resource_limits_config_object> {
-      OBJECT_CTOR(resource_limits_config_object);
+      CHAINDB_OBJECT_ID_CTOR(resource_limits_config_object);
       id_type id;
       std::vector<elastic_limit_parameters> limit_parameters;
       std::vector<uint32_t> account_usage_average_windows;
@@ -131,7 +129,7 @@ using namespace int_arithmetic;
    >;
 
    class resource_limits_state_object : public cyberway::chaindb::object<resource_limits_state_object_type, resource_limits_state_object> {
-      OBJECT_CTOR(resource_limits_state_object);
+      CHAINDB_OBJECT_ID_CTOR(resource_limits_state_object);
       id_type id;
       std::vector<usage_accumulator> block_usage_accumulators;
       std::vector<int64_t> pending_usage;
@@ -161,7 +159,7 @@ CHAINDB_TAG(eosio::chain::resource_limits::resource_limits_state_object,  ressta
 
 FC_REFLECT(eosio::chain::resource_limits::usage_accumulator, (last_ordinal)(value_ex)(consumed))
 
-FC_REFLECT(eosio::chain::resource_limits::resource_usage_object, (id)(owner)(accumulators))
+FC_REFLECT(eosio::chain::resource_limits::resource_usage_object, (owner)(accumulators))
 
 FC_REFLECT(eosio::chain::resource_limits::resource_limits_config_object, (id)(limit_parameters)(account_usage_average_windows))
 

--- a/libraries/chain/include/eosio/chain/stake_object.hpp
+++ b/libraries/chain/include/eosio/chain/stake_object.hpp
@@ -13,7 +13,7 @@
 namespace eosio { namespace chain {
 
 class stake_agent_object : public cyberway::chaindb::object<stake_agent_object_type, stake_agent_object> {
-    OBJECT_CTOR(stake_agent_object)
+    CHAINDB_OBJECT_ID_CTOR(stake_agent_object)
     id_type id;  
     symbol_code token_code;
     account_name account;
@@ -99,7 +99,7 @@ using stake_candidate_table = cyberway::chaindb::table_container<
 >;
 
 class stake_grant_object : public cyberway::chaindb::object<stake_grant_object_type, stake_grant_object> {
-    OBJECT_CTOR(stake_grant_object)
+    CHAINDB_OBJECT_ID_CTOR(stake_grant_object)
     id_type id;
     symbol_code token_code;
     account_name grantor_name;
@@ -127,7 +127,7 @@ using stake_grant_table = cyberway::chaindb::table_container<
 >;
 
 class stake_param_object : public cyberway::chaindb::object<stake_param_object_type, stake_param_object> {
-    OBJECT_CTOR(stake_param_object)
+    CHAINDB_OBJECT_ID_CTOR(stake_param_object)
     id_type id;
     symbol token_symbol;
     std::vector<uint8_t> max_proxies;
@@ -144,7 +144,7 @@ using stake_param_table = cyberway::chaindb::table_container<
 >;
     
 class stake_stat_object : public cyberway::chaindb::object<stake_stat_object_type, stake_stat_object> {
-    OBJECT_CTOR(stake_stat_object)
+    CHAINDB_OBJECT_ID_CTOR(stake_stat_object)
     id_type id;
     symbol_code token_code;
     int64_t total_staked;

--- a/libraries/chain/include/eosio/chain/stake_object.hpp
+++ b/libraries/chain/include/eosio/chain/stake_object.hpp
@@ -43,7 +43,7 @@ using stake_agent_table = cyberway::chaindb::table_container<
 >;
 
 class stake_candidate_object : public cyberway::chaindb::object<stake_candidate_object_type, stake_candidate_object> {
-    OBJECT_CTOR(stake_candidate_object)
+    CHAINDB_OBJECT_ID_CTOR(stake_candidate_object)
     id_type id;  
     symbol_code token_code;
     account_name account;

--- a/libraries/chain/include/eosio/chain/transaction_object.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_object.hpp
@@ -21,7 +21,7 @@ namespace eosio { namespace chain {
     */
    class transaction_object : public cyberway::chaindb::object<transaction_object_type, transaction_object>
    {
-         OBJECT_CTOR(transaction_object)
+         CHAINDB_OBJECT_ID_CTOR(transaction_object)
 
          id_type             id;
          time_point_sec      expiration;

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -185,9 +185,9 @@ void resource_limits_manager::add_storage_usage(const account_name& account, int
     const stake_param_object* param = nullptr;
     const stake_stat_object* stat = nullptr;
 
-    if (_chaindb.get<account_object, by_name>(account).privileged || //assignments:
-        !(_chaindb.find<stake_param_object, by_id>(token_code.value)) ||
-        !(stat  = _chaindb.find<stake_stat_object, by_id>(token_code.value)) ||
+    if (_chaindb.get<account_object>(account).privileged || //assignments:
+        !(_chaindb.find<stake_param_object>(token_code.value)) ||
+        !(stat  = _chaindb.find<stake_stat_object>(token_code.value)) ||
         !stat->enabled || stat->total_staked == 0) {
 
         return;
@@ -200,7 +200,7 @@ void resource_limits_manager::add_storage_usage(const account_name& account, int
       rls.add_pending_delta(delta, config, STORAGE);
    });
    
-   auto& usage = _chaindb.get<resource_usage_object, by_id>(account);
+   auto& usage = _chaindb.get<resource_usage_object>(account);
    _chaindb.modify( usage, [&]( auto& u ) {
       u.accumulators[STORAGE].add(delta, time_slot, config.account_usage_average_windows[STORAGE]);
    });
@@ -266,8 +266,8 @@ std::vector<ratio> resource_limits_manager::get_pricelist() const {
     const stake_param_object* param = nullptr;
     const stake_stat_object* stat = nullptr;
     
-    if ((param = _chaindb.find<stake_param_object, by_id>(token_code.value)) && 
-        (stat  = _chaindb.find<stake_stat_object, by_id>(token_code.value)) && stat->enabled && stat->total_staked != 0) {
+    if ((param = _chaindb.find<stake_param_object>(token_code.value)) &&
+        (stat  = _chaindb.find<stake_stat_object>(token_code.value)) && stat->enabled && stat->total_staked != 0) {
         EOS_ASSERT(stat->total_staked > 0, chain_exception, "SYSTEM: incorrect total_staked");
         
         for (size_t i = 0; i < resources_num; i++) {
@@ -304,8 +304,8 @@ ratio resource_limits_manager::get_account_stake_ratio(fc::time_point pending_bl
     const stake_stat_object* stat = nullptr;
 
     if (_chaindb.get<account_object>(account).privileged || //assignments:
-        !(param = _chaindb.find<stake_param_object, by_id>(token_code.value)) ||
-        !(stat  = _chaindb.find<stake_stat_object, by_id>(token_code.value)) ||
+        !(param = _chaindb.find<stake_param_object>(token_code.value)) ||
+        !(stat  = _chaindb.find<stake_stat_object>(token_code.value)) ||
         !stat->enabled || stat->total_staked == 0) {
 
         return {0,0};

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -92,8 +92,7 @@ storage_payer_info resource_limits_manager::get_storage_payer(uint32_t time_slot
 }
 
 void resource_limits_manager::initialize_account(const account_name& account, const storage_payer_info& payer) {
-   _chaindb.emplace<resource_usage_object>(payer, [&]( resource_usage_object& bu ) {
-      bu.owner = account;
+   _chaindb.emplace<resource_usage_object>(account.value, payer, [&]( resource_usage_object& bu ) {
       bu.accumulators.resize(resources_num);
    });
 }
@@ -119,7 +118,7 @@ void resource_limits_manager::set_limit_params(const chain_config& chain_cfg) {
 void resource_limits_manager::update_account_usage(const flat_set<account_name>& accounts, uint32_t time_slot) {
    const auto& config = _chaindb.get<resource_limits_config_object>();
    auto usage_table = _chaindb.get_table<resource_usage_object>();
-   auto owner_idx = usage_table.get_index<by_owner>();
+   auto owner_idx = usage_table.get_index<by_id>();
    for( const auto& a : accounts ) {
       const auto& usage = owner_idx.get( a );
       usage_table.modify( usage, [&]( auto& bu ) {
@@ -146,7 +145,7 @@ void resource_limits_manager::add_transaction_usage(const flat_set<account_name>
    const auto& state = state_table.get();
    const auto& config = _chaindb.get<resource_limits_config_object>();
    auto usage_table = _chaindb.get_table<resource_usage_object>();
-   auto owner_idx = usage_table.get_index<by_owner>();
+   auto owner_idx = usage_table.get_index<by_id>();
    const auto& prices = get_pricelist();
    auto time_slot = block_timestamp_type(pending_block_time).slot;
 
@@ -201,7 +200,7 @@ void resource_limits_manager::add_storage_usage(const account_name& account, int
       rls.add_pending_delta(delta, config, STORAGE);
    });
    
-   auto& usage = _chaindb.get<resource_usage_object, by_owner>(account);
+   auto& usage = _chaindb.get<resource_usage_object, by_id>(account);
    _chaindb.modify( usage, [&]( auto& u ) {
       u.accumulators[STORAGE].add(delta, time_slot, config.account_usage_average_windows[STORAGE]);
    });
@@ -209,7 +208,7 @@ void resource_limits_manager::add_storage_usage(const account_name& account, int
 
 std::vector<uint64_t> resource_limits_manager::get_account_usage(const account_name& account)const {
     const auto& config = _chaindb.get<resource_limits_config_object>();
-    auto usage_index = _chaindb.get_index<resource_usage_object,by_owner>();
+    auto usage_index = _chaindb.get_index<resource_usage_object, by_id>();
     const auto& usage = usage_index.get(account);
     std::vector<uint64_t> ret(resources_num);
     
@@ -304,7 +303,7 @@ ratio resource_limits_manager::get_account_stake_ratio(fc::time_point pending_bl
     const stake_param_object* param = nullptr;
     const stake_stat_object* stat = nullptr;
 
-    if (_chaindb.get<account_object, by_name>(account).privileged || //assignments:
+    if (_chaindb.get<account_object>(account).privileged || //assignments:
         !(param = _chaindb.find<stake_param_object, by_id>(token_code.value)) ||
         !(stat  = _chaindb.find<stake_stat_object, by_id>(token_code.value)) ||
         !stat->enabled || stat->total_staked == 0) {

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -701,7 +701,7 @@ namespace bacc = boost::accumulators;
       const auto& auth_manager = control.get_authorization_manager();
 
       for( const auto& a : trx.context_free_actions ) {
-         auto* code = chaindb.find<account_object, by_name>(a.account);
+         auto* code = chaindb.find<account_object>(a.account);
          EOS_ASSERT( code != nullptr, transaction_exception,
                      "action's code account '${account}' does not exist", ("account", a.account) );
          EOS_ASSERT( a.authorization.size() == 0, transaction_exception,
@@ -710,12 +710,12 @@ namespace bacc = boost::accumulators;
 
       bool one_auth = false;
       for( const auto& a : trx.actions ) {
-         auto* code = chaindb.find<account_object, by_name>(a.account);
+         auto* code = chaindb.find<account_object>(a.account);
          EOS_ASSERT( code != nullptr, transaction_exception,
                      "action's code account '${account}' does not exist", ("account", a.account) );
          for( const auto& auth : a.authorization ) {
             one_auth = true;
-            auto* actor = chaindb.find<account_object, by_name>(auth.actor);
+            auto* actor = chaindb.find<account_object>(auth.actor);
             EOS_ASSERT( actor  != nullptr, transaction_exception,
                         "action's authorizing actor '${account}' does not exist", ("account", auth.actor) );
             EOS_ASSERT( auth_manager.find_permission(auth) != nullptr, transaction_exception,

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -182,7 +182,7 @@ class privileged_api : public context_aware_api {
       }
 
       bool is_privileged( account_name n )const {
-         return context.chaindb.get<account_object, by_name>( n ).privileged;
+         return context.chaindb.get<account_object>( n ).privileged;
       }
 
 };
@@ -819,7 +819,7 @@ class permission_api : public context_aware_api {
       };
 
       int64_t get_account_creation_time( account_name account ) {
-         auto* acct = context.chaindb.find<account_object, by_name>(account);
+         auto* acct = context.chaindb.find<account_object>(account);
          EOS_ASSERT( acct != nullptr, action_validate_exception,
                      "account '${account}' does not exist", ("account", account) );
          return time_point(acct->creation_date).time_since_epoch().count();

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -254,7 +254,7 @@ namespace eosio { namespace testing {
          auto get_resolver() {
             return [this]( const account_name& name ) -> optional<abi_serializer> {
                try {
-                  const auto& accnt = control->chaindb().get<account_object, by_name>( name );
+                  const auto& accnt = control->chaindb().get<account_object>( name );
                   abi_def abi;
                   if( abi_serializer::to_abi( accnt.abi, abi )) {
                      return abi_serializer( abi, abi_serializer_max_time );

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -101,7 +101,7 @@ get_abi_results chain_api_plugin_impl::get_abi( const get_abi_params& params )co
    get_abi_results result;
    result.account_name = params.account_name;
    auto& d = chain_controller_.chaindb();
-   const auto& accnt  = d.get<chain::account_object, chain::by_name>( params.account_name );
+   const auto& accnt  = d.get<chain::account_object>( params.account_name );
 
    chain::abi_def abi;
    if( chain::abi_serializer::to_abi(accnt.abi, abi) ) {
@@ -115,7 +115,7 @@ get_code_results chain_api_plugin_impl::get_code( const get_code_params& params 
    get_code_results result;
    result.account_name = params.account_name;
    auto& d = chain_controller_.chaindb();
-   const auto& accnt  = d.get<chain::account_object,chain::by_name>( params.account_name );
+   const auto& accnt  = d.get<chain::account_object>( params.account_name );
 
    EOS_ASSERT( params.code_as_wasm, chain::unsupported_feature, "Returning WAST from get_code is no longer supported" );
 
@@ -136,7 +136,7 @@ get_code_hash_results chain_api_plugin_impl::get_code_hash( const get_code_hash_
    get_code_hash_results result;
    result.account_name = params.account_name;
    auto& d = chain_controller_.chaindb();
-   const auto& accnt  = d.get<chain::account_object, chain::by_name>( params.account_name );
+   const auto& accnt  = d.get<chain::account_object>( params.account_name );
 
    if( accnt.code.size() ) {
       result.code_hash = fc::sha256::hash( accnt.code.data(), accnt.code.size() );
@@ -150,7 +150,7 @@ get_raw_code_and_abi_results chain_api_plugin_impl::get_raw_code_and_abi( const 
    result.account_name = params.account_name;
 
    auto& d = chain_controller_.chaindb();
-   const auto& accnt = d.get<chain::account_object, chain::by_name>(params.account_name);
+   const auto& accnt = d.get<chain::account_object>(params.account_name);
    result.wasm = fc::base64_encode({accnt.code.begin(), accnt.code.end()});
    result.abi = fc::base64_encode({accnt.abi.begin(), accnt.abi.end()});
 
@@ -162,7 +162,7 @@ get_raw_abi_results chain_api_plugin_impl::get_raw_abi( const get_raw_abi_params
    result.account_name = params.account_name;
 
    auto& d = chain_controller_.chaindb();
-   const auto& accnt = d.get<chain::account_object, chain::by_name>(params.account_name);
+   const auto& accnt = d.get<chain::account_object>(params.account_name);
    result.abi_hash = fc::sha256::hash( accnt.abi.data(), accnt.abi.size() );
    result.code_hash = fc::sha256::hash( accnt.code.data(), accnt.code.size() );
    if( !params.abi_hash || *params.abi_hash != result.abi_hash )
@@ -499,7 +499,7 @@ static fc::variant action_abi_to_variant( const chain::abi_def& abi, chain::type
 
 abi_json_to_bin_result chain_api_plugin_impl::abi_json_to_bin( const abi_json_to_bin_params& params )const try {
    abi_json_to_bin_result result;
-   const auto code_account = chain_controller_.chaindb().find<chain::account_object, chain::by_name>( params.code );
+   const auto code_account = chain_controller_.chaindb().find<chain::account_object>( params.code );
    EOS_ASSERT(code_account != nullptr, chain::contract_query_exception, "Contract can't be found ${contract}", ("contract", params.code));
 
    chain::abi_def abi;
@@ -521,7 +521,7 @@ abi_json_to_bin_result chain_api_plugin_impl::abi_json_to_bin( const abi_json_to
 
 abi_bin_to_json_result chain_api_plugin_impl::abi_bin_to_json( const abi_bin_to_json_params& params )const {
    abi_bin_to_json_result result;
-   const auto& code_account = chain_controller_.chaindb().get<chain::account_object, chain::by_name>( params.code );
+   const auto& code_account = chain_controller_.chaindb().get<chain::account_object>( params.code );
    chain::abi_def abi;
    if( chain::abi_serializer::to_abi(code_account.abi, abi) ) {
       chain::abi_serializer abis( abi, abi_serializer_max_time_);

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -16,6 +16,7 @@
 #include <cyberway/chaindb/controller.hpp>
 #include <cyberway/chaindb/names.hpp>
 #include <cyberway/chaindb/typed_name.hpp>
+#include <cyberway/chaindb/table_info.hpp>
 
 #include <fc/io/json.hpp>
 

--- a/plugins/faucet_testnet_plugin/faucet_testnet_plugin.cpp
+++ b/plugins/faucet_testnet_plugin/faucet_testnet_plugin.cpp
@@ -176,7 +176,7 @@ struct faucet_testnet_plugin_impl {
                } catch (const fc::assert_exception& ) {
                   continue;
                }
-               const account_object* const obj = database().find<account_object, by_name>(alt);
+               const account_object* const obj = database().find<account_object>(alt);
                if (obj == nullptr) {
                   names.push_back(alt);
                }
@@ -193,11 +193,11 @@ struct faucet_testnet_plugin_impl {
 
    results_pair create_account(const std::string& new_account_name, const fc::crypto::public_key& owner_pub_key, const fc::crypto::public_key& active_pub_key) {
 
-      auto creating_account = database().find<account_object, by_name>(_create_account_name);
+      auto creating_account = database().find<account_object>(_create_account_name);
       EOS_ASSERT(creating_account != nullptr, transaction_exception,
                  "To create account using the faucet, must already have created account \"${a}\"",("a",_create_account_name));
 
-      auto existing_account = database().find<account_object, by_name>(new_account_name);
+      auto existing_account = database().find<account_object>(new_account_name);
       if (existing_account != nullptr)
       {
          return find_alternates(new_account_name);

--- a/plugins/plugins_common/chain_utils.cpp
+++ b/plugins/plugins_common/chain_utils.cpp
@@ -4,7 +4,7 @@ namespace eosio {
 
     std::function<fc::optional<chain::abi_serializer> (const chain::account_name&)> make_resolver(chain::chaindb_controller& chain_db, const fc::microseconds& max_serialization_time) {
        return [&](const chain::account_name &name) -> fc::optional<chain::abi_serializer> {
-           const auto* accnt = chain_db.find<chain::account_object, chain::by_name>(name);
+           const auto* accnt = chain_db.find<chain::account_object>(name);
            if (accnt != nullptr) {
               chain::abi_def abi;
               if (chain::abi_serializer::to_abi(accnt->abi, abi)) {

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -690,8 +690,8 @@ void print_result( const fc::variant& result ) { try {
 
          cerr << status << " transaction: " << transaction_id << "  ";
 
-         auto print_usage = [&]( const int64_t& value, const char* units ) {
-            cerr << "  ";
+         auto print_usage = [&]( const char* caption, const int64_t& value, const char* units ) {
+            cerr << ' ' << caption << ' ';
             if( !has_receipt ) {
                cerr << "<unknown>";
             } else {
@@ -700,10 +700,10 @@ void print_result( const fc::variant& result ) { try {
             cerr << " " << units;
          };
 
-         print_usage(net, "bytes");
-         print_usage(cpu, "us");
-         print_usage(ram, "bytes");
-         print_usage(storage, "bytes");
+         print_usage("NET", net, "bytes");
+         print_usage("CPU", cpu, "us");
+         print_usage("RAM", ram, "bytes");
+         print_usage("STORAGE", storage, "bytes");
 
          cerr << std::endl;
 

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -48,7 +48,7 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
 
    auto resolver = [&,this]( const account_name& name ) -> optional<abi_serializer> {
       try {
-         const auto& accnt  = this->control->db().get<account_object,by_name>( name );
+         const auto& accnt  = this->control->db().get<account_object>( name );
          abi_def abi;
          if (abi_serializer::to_abi(accnt.abi, abi)) {
             return abi_serializer(abi, abi_serializer_max_time);

--- a/unittests/auth_tests.cpp
+++ b/unittests/auth_tests.cpp
@@ -415,9 +415,9 @@ try {
 
    create_acc(acc2);
 
-   const auto &usage = chaindb.get<resource_usage_object,by_owner>(acc1);
+   const auto &usage = chaindb.get<resource_usage_object,by_id>(acc1);
 
-   const auto &usage2 = chaindb.get<resource_usage_object,by_owner>(acc1a);
+   const auto &usage2 = chaindb.get<resource_usage_object,by_id>(acc1a);
 
    BOOST_TEST(usage.accumulators[resource_limits::CPU].average() > 0);
    BOOST_TEST(usage.accumulators[resource_limits::NET].average() > 0);

--- a/unittests/bootseq_tests.cpp
+++ b/unittests/bootseq_tests.cpp
@@ -156,7 +156,7 @@ public:
         set_code(account, wast, signer);
         set_abi(account, abi, signer);
         if (account == config::system_account_name) {
-           const auto& accnt = control->chaindb().get<account_object,by_name>( account );
+           const auto& accnt = control->chaindb().get<account_object>( account );
            abi_def abi_definition;
            BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi_definition), true);
            abi_ser.set_abi(abi_definition, abi_serializer_max_time);
@@ -191,9 +191,9 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
       //   set_privileged(config::token_account_name);
 
         // Verify eosio.msig and eosio.token is privileged
-        const auto& eosio_msig_acc = get<account_object, by_name>(config::msig_account_name);
+        const auto& eosio_msig_acc = get<account_object>(config::msig_account_name);
         BOOST_TEST(eosio_msig_acc.privileged == true);
-        const auto& eosio_token_acc = get<account_object, by_name>(config::token_account_name);
+        const auto& eosio_token_acc = get<account_object>(config::token_account_name);
       //   BOOST_TEST(eosio_token_acc.privileged == true);
 
 

--- a/unittests/database_tests.cpp
+++ b/unittests/database_tests.cpp
@@ -32,9 +32,7 @@ BOOST_AUTO_TEST_SUITE(database_tests)
          auto ses = chaindb.start_undo_session(true);
 
          // Create an account
-         chaindb.emplace<account_object>([](account_object &a) {
-            a.name = "billy";
-         });
+         chaindb.emplace<account_object>(N(billy), [](account_object &a) {});
 
          // Make sure we can retrieve that account by name
          auto ptr = chaindb.find<account_object, by_name, std::string>("billy");

--- a/unittests/database_tests.cpp
+++ b/unittests/database_tests.cpp
@@ -35,14 +35,14 @@ BOOST_AUTO_TEST_SUITE(database_tests)
          chaindb.emplace<account_object>(N(billy), [](account_object &a) {});
 
          // Make sure we can retrieve that account by name
-         auto ptr = chaindb.find<account_object, by_name, std::string>("billy");
+         auto ptr = chaindb.find<account_object, by_id, std::string>("billy");
          BOOST_TEST(ptr != nullptr);
 
          // Undo creation of the account
          ses.undo();
 
          // Make sure we can no longer find the account
-         ptr = chaindb.find<account_object, by_name, std::string>("billy");
+         ptr = chaindb.find<account_object, by_id, std::string>("billy");
          BOOST_TEST(ptr == nullptr);
       } FC_LOG_AND_RETHROW()
    }

--- a/unittests/delay_tests.cpp
+++ b/unittests/delay_tests.cpp
@@ -1683,10 +1683,10 @@ BOOST_AUTO_TEST_CASE( mindelay_test ) { try {
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    // send transfer with delay_sec set to 10
-   const auto& acnt = chain.control->chaindb().get<account_object,by_name>(config::token_account_name);
+   const auto& acnt = chain.control->chaindb().get<account_object>(config::token_account_name);
    const auto abi = acnt.get_abi();
    chain::abi_serializer abis(abi, chain.abi_serializer_max_time);
-   const auto a = chain.control->chaindb().get<account_object,by_name>(config::token_account_name).get_abi();
+   const auto a = chain.control->chaindb().get<account_object>(config::token_account_name).get_abi();
 
    string action_type_name = abis.get_action_type(name("transfer"));
 

--- a/unittests/eosio_system_tester.hpp
+++ b/unittests/eosio_system_tester.hpp
@@ -57,7 +57,7 @@ public:
       set_abi(config::token_account_name, eosio_token_abi);
 
       {
-         const auto& accnt = control->chaindb().get<account_object,by_name>(config::token_account_name);
+         const auto& accnt = control->chaindb().get<account_object>(config::token_account_name);
          abi_def abi;
          BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
          token_abi_ser.set_abi(abi, abi_serializer_max_time);
@@ -71,7 +71,7 @@ public:
       set_abi( config::system_account_name, eosio_system_abi );
 
       {
-         const auto& accnt = control->chaindb().get<account_object,by_name>( config::system_account_name );
+         const auto& accnt = control->chaindb().get<account_object>( config::system_account_name );
          abi_def abi;
          BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
          abi_ser.set_abi(abi, abi_serializer_max_time);
@@ -420,7 +420,7 @@ public:
          set_abi(config::msig_account_name, eosio_msig_abi);
 
          produce_blocks();
-         const auto& accnt = control->chaindb().get<account_object,by_name>(config::msig_account_name);
+         const auto& accnt = control->chaindb().get<account_object>(config::msig_account_name);
          abi_def msig_abi;
          BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, msig_abi), true);
          msig_abi_ser.set_abi(msig_abi, abi_serializer_max_time);

--- a/unittests/identity_tests.cpp
+++ b/unittests/identity_tests.cpp
@@ -43,12 +43,12 @@ public:
       set_abi(N(identitytest), identity_test_abi);
       produce_blocks(1);
 
-      const auto& accnt = control->chaindb().get<account_object,by_name>( N(identity) );
+      const auto& accnt = control->chaindb().get<account_object>( N(identity) );
       abi_def abi;
       BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
       abi_ser.set_abi(abi, abi_serializer_max_time);
 
-      const auto& acnt_test = control->chaindb().get<account_object,by_name>( N(identitytest) );
+      const auto& acnt_test = control->chaindb().get<account_object>( N(identitytest) );
       abi_def abi_test;
       BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(acnt_test.abi, abi_test), true);
       abi_ser_test.set_abi(abi_test, abi_serializer_max_time);

--- a/unittests/providebw_tests.cpp
+++ b/unittests/providebw_tests.cpp
@@ -93,7 +93,7 @@ public:
         set_code(account, wast, signer);
         set_abi(account, abi, signer);
         if (account == config::system_account_name) {
-           const auto& accnt = control->chaindb().get<account_object,by_name>( account );
+           const auto& accnt = control->chaindb().get<account_object>( account );
            abi_def abi_definition;
            BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi_definition), true);
            abi_ser.set_abi(abi_definition, abi_serializer_max_time);
@@ -124,9 +124,9 @@ BOOST_FIXTURE_TEST_CASE( providebw_test, system_contract_tester ) {
       //   set_privileged(token_account_name);
 
         // Verify eosio.msig and eosio.token is privileged
-        const auto& eosio_msig_acc = get<account_object, by_name>(msig_account_name);
+        const auto& eosio_msig_acc = get<account_object>(msig_account_name);
         BOOST_TEST(eosio_msig_acc.privileged == true);
-        const auto& eosio_token_acc = get<account_object, by_name>(token_account_name);
+        const auto& eosio_token_acc = get<account_object>(token_account_name);
       //   BOOST_TEST(eosio_token_acc.privileged == true);
 
 

--- a/unittests/special_accounts_tests.cpp
+++ b/unittests/special_accounts_tests.cpp
@@ -34,7 +34,7 @@ BOOST_FIXTURE_TEST_CASE(accounts_exists, tester)
       chain::controller *control = this->control.get();
       auto& chain1_db = control->chaindb();
 
-      auto nobody = chain1_db.find<account_object, by_name>(config::null_account_name);
+      auto nobody = chain1_db.find<account_object>(config::null_account_name);
       BOOST_CHECK(nobody != nullptr);
       const auto& nobody_active_authority = chain1_db.get<permission_object, by_owner>(boost::make_tuple(config::null_account_name, config::active_name));
       BOOST_CHECK_EQUAL(nobody_active_authority.auth.threshold, 1);
@@ -46,7 +46,7 @@ BOOST_FIXTURE_TEST_CASE(accounts_exists, tester)
       BOOST_CHECK_EQUAL(nobody_owner_authority.auth.accounts.size(), 0);
       BOOST_CHECK_EQUAL(nobody_owner_authority.auth.keys.size(), 0);
 
-      auto producers = chain1_db.find<account_object, by_name>(config::producers_account_name);
+      auto producers = chain1_db.find<account_object>(config::producers_account_name);
       BOOST_CHECK(producers != nullptr);
 
       const auto& active_producers = control->head_block_state()->active_schedule;

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -176,7 +176,7 @@ BOOST_FIXTURE_TEST_CASE( abi_from_variant, TESTER ) try {
 
    auto resolver = [&,this]( const account_name& name ) -> optional<abi_serializer> {
       try {
-         const auto& accnt  = this->control->chaindb().get<account_object,by_name>( name );
+         const auto& accnt  = this->control->chaindb().get<account_object>( name );
          abi_def abi;
          if (abi_serializer::to_abi(accnt.abi, abi)) {
             return abi_serializer(abi, abi_serializer_max_time);
@@ -638,7 +638,7 @@ BOOST_FIXTURE_TEST_CASE( stl_test, TESTER ) try {
     set_abi(N(stltest), stltest_abi);
     produce_blocks(1);
 
-    const auto& accnt  = control->chaindb().get<account_object,by_name>( N(stltest) );
+    const auto& accnt  = control->chaindb().get<account_object>( N(stltest) );
     abi_def abi;
     BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
     abi_serializer abi_ser(abi, abi_serializer_max_time);
@@ -954,7 +954,7 @@ BOOST_FIXTURE_TEST_CASE(noop, TESTER) try {
    set_code(N(noop), noop_wast);
 
    set_abi(N(noop), noop_abi);
-   const auto& accnt  = control->chaindb().get<account_object,by_name>(N(noop));
+   const auto& accnt  = control->chaindb().get<account_object>(N(noop));
    abi_def abi;
    BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
    abi_serializer abi_ser(abi, abi_serializer_max_time);
@@ -1017,7 +1017,7 @@ BOOST_FIXTURE_TEST_CASE(noop, TESTER) try {
 BOOST_FIXTURE_TEST_CASE(eosio_abi, TESTER) try {
    produce_blocks(2);
 
-   const auto& accnt  = control->chaindb().get<account_object,by_name>(config::system_account_name);
+   const auto& accnt  = control->chaindb().get<account_object>(config::system_account_name);
    abi_def abi;
    BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
    abi_serializer abi_ser(abi, abi_serializer_max_time);


### PR DESCRIPTION
Resolve #642:
- Use cache map with it LRU to load ABI
- Use cached ABI in chain-controller
- Use cached ABI in event-engine
- Update import genesis to use cache ABI

Resolve #363 
- Use account as primary key in account_object, account_sequence_object and resource_usage_object

Resolve #416:
- Implement undo for ABI structures.