### PR TITLE
Store genesis balance conversions: GBG to GOLOS & GOLOS from obj #775

### DIFF
--- a/programs/create-genesis/ee_genesis/event_engine_genesis.hpp
+++ b/programs/create-genesis/ee_genesis/event_engine_genesis.hpp
@@ -14,12 +14,15 @@ public:
 
     void start(const bfs::path& ee_directory, const fc::sha256& hash);
     void finalize();
-public:
-    ee_genesis_serializer messages;
-    ee_genesis_serializer transfers;
-    ee_genesis_serializer pinblocks;
-    ee_genesis_serializer accounts;
-    ee_genesis_serializer funds;
+
+    enum ee_ser_type {messages, transfers, pinblocks, accounts, funds, balance_conversions};
+    ee_genesis_serializer& get_serializer(ee_ser_type type) {
+        return serializers.at(type);
+    }
+
+private:
+    std::map<ee_ser_type, ee_genesis_serializer> serializers;
+
 };
 
 struct vote_info {
@@ -42,7 +45,7 @@ struct reblog_info {
 
 struct comment_info {
     OBJECT_CTOR(comment_info);
-    
+
     name parent_author;
     string parent_permlink;
     name author;
@@ -71,6 +74,14 @@ struct transfer_info {
     fc::time_point_sec time;
 };
 
+struct balance_convert_info {
+    OBJECT_CTOR(balance_convert_info);
+
+    name owner;
+    asset amount;
+    string memo;
+};
+
 struct pin_info {
     OBJECT_CTOR(pin_info);
 
@@ -89,8 +100,9 @@ struct block_info {
 
 FC_REFLECT(cyberway::genesis::ee::vote_info, (voter)(weight)(time)(rshares))
 FC_REFLECT(cyberway::genesis::ee::reblog_info, (account)(title)(body)(time))
-FC_REFLECT(cyberway::genesis::ee::comment_info, (parent_author)(parent_permlink)(author)(permlink)(created)(last_update)(title)(body)
-        (tags)(language)(net_rshares)(author_reward)(benefactor_reward)(curator_reward)(votes)(reblogs))
+FC_REFLECT(cyberway::genesis::ee::comment_info, (parent_author)(parent_permlink)(author)(permlink)(created)(last_update)
+    (title)(body)(tags)(language)(net_rshares)(author_reward)(benefactor_reward)(curator_reward)(votes)(reblogs))
 FC_REFLECT(cyberway::genesis::ee::transfer_info, (from)(to)(quantity)(memo)(time))
+FC_REFLECT(cyberway::genesis::ee::balance_convert_info, (owner)(amount)(memo))
 FC_REFLECT(cyberway::genesis::ee::pin_info, (pinner)(pinning))
 FC_REFLECT(cyberway::genesis::ee::block_info, (blocker)(blocking))

--- a/programs/create-genesis/ee_genesis/genesis_ee_builder.cpp
+++ b/programs/create-genesis/ee_genesis/genesis_ee_builder.cpp
@@ -409,7 +409,7 @@ void genesis_ee_builder::build_reblogs(std::vector<reblog_info>& reblogs, uint64
     }
 }
 
-void genesis_ee_builder::build_messages() {
+void genesis_ee_builder::write_messages() {
     if (!dump_comments.is_open()) {
         return;
     }
@@ -454,7 +454,7 @@ void genesis_ee_builder::build_messages() {
     build_children(0);
 }
 
-void genesis_ee_builder::build_transfers() {
+void genesis_ee_builder::write_transfers() {
     if (!dump_transfers.is_open()) {
         return;
     }
@@ -474,7 +474,7 @@ void genesis_ee_builder::build_transfers() {
     }
 }
 
-void genesis_ee_builder::build_pinblocks() {
+void genesis_ee_builder::write_pinblocks() {
     if (!dump_follows.is_open()) {
         return;
     }
@@ -507,7 +507,7 @@ void genesis_ee_builder::build_pinblocks() {
     }
 }
 
-void genesis_ee_builder::build_accounts() {
+void genesis_ee_builder::write_accounts() {
     std::cout << "-> Writing accounts..." << std::endl;
     auto& out = out_.get_serializer(event_engine_genesis::accounts);
     out.start_section(config::system_account_name, N(domain), "domain_info");
@@ -542,7 +542,7 @@ void genesis_ee_builder::build_accounts() {
     }
 }
 
-void genesis_ee_builder::build_funds() {
+void genesis_ee_builder::write_funds() {
     std::cout << "-> Writing funds..." << std::endl;
 
     auto& out = out_.get_serializer(event_engine_genesis::funds);
@@ -559,7 +559,7 @@ void genesis_ee_builder::build_funds() {
     }
 }
 
-void genesis_ee_builder::write_genesis_converts() {
+void genesis_ee_builder::write_balance_converts() {
     std::cout << "-> Writing genesis balance conversions..." << std::endl;
     auto& out = out_.get_serializer(event_engine_genesis::balance_conversions);
     out.start_section(config::token_account_name, N(genesis.conv), "balance_convert");
@@ -584,12 +584,12 @@ void genesis_ee_builder::build(const bfs::path& out_dir) {
 
     out_.start(out_dir, fc::sha256());
 
-    build_messages();
-    build_transfers();
-    build_pinblocks();
-    build_accounts();
-    build_funds();
-    write_genesis_converts();
+    write_messages();
+    write_transfers();
+    write_pinblocks();
+    write_accounts();
+    write_funds();
+    write_balance_converts();
 
     out_.finalize();
 }

--- a/programs/create-genesis/ee_genesis/genesis_ee_builder.cpp
+++ b/programs/create-genesis/ee_genesis/genesis_ee_builder.cpp
@@ -19,8 +19,10 @@ namespace cyberway { namespace genesis { namespace ee {
 
 constexpr auto GLS = SY(3, GOLOS);
 
-genesis_ee_builder::genesis_ee_builder(const genesis_info& info, const export_info& exp_info, const std::string& shared_file, uint32_t last_block)
-        : info_(info), exp_info_(exp_info), last_block_(last_block), maps_(shared_file, chainbase::database::read_write, MAP_FILE_SIZE) {
+genesis_ee_builder::genesis_ee_builder(
+    const genesis_create& genesis, const std::string& shared_file, uint32_t last_block)
+    :   genesis_(genesis), info_(genesis.get_info()), exp_info_(genesis.get_exp_info()),
+        last_block_(last_block), maps_(shared_file, chainbase::database::read_write, MAP_FILE_SIZE) {
     maps_.add_index<comment_header_index>();
     maps_.add_index<vote_header_index>();
     maps_.add_index<reblog_header_index>();
@@ -411,10 +413,9 @@ void genesis_ee_builder::build_messages() {
     if (!dump_comments.is_open()) {
         return;
     }
-
     std::cout << "-> Writing messages..." << std::endl;
-
-    out_.messages.start_section(info_.golos.names.posting, N(message), "message_info");
+    auto& out = out_.get_serializer(event_engine_genesis::messages);
+    out.start_section(info_.golos.names.posting, N(message), "message_info");
 
     const auto& comment_idx = maps_.get_index<comment_header_index, by_parent_hash>();
 
@@ -427,7 +428,7 @@ void genesis_ee_builder::build_messages() {
             comment_operation op;
             read_operation(dump_comments, op);
 
-            out_.messages.emplace<comment_info>([&](auto& c) {
+            out.emplace<comment_info>([&](auto& c) {
                 c.parent_author = generate_name(op.parent_author);
                 c.parent_permlink = op.parent_permlink;
                 c.author = generate_name(op.author);
@@ -457,14 +458,13 @@ void genesis_ee_builder::build_transfers() {
     if (!dump_transfers.is_open()) {
         return;
     }
-
     std::cout << "-> Writing transfers..." << std::endl;
-
-    out_.transfers.start_section(config::token_account_name, N(transfer), "transfer");
+    auto& out = out_.get_serializer(event_engine_genesis::transfers);
+    out.start_section(config::token_account_name, N(transfer), "transfer");
 
     transfer_operation op;
     while (read_operation(dump_transfers, op)) {
-        out_.transfers.emplace<transfer_info>([&](auto& t) {
+        out.emplace<transfer_info>([&](auto& t) {
             t.from = generate_name(op.from);
             t.to = generate_name(op.to);
             t.quantity = op.amount;
@@ -478,30 +478,29 @@ void genesis_ee_builder::build_pinblocks() {
     if (!dump_follows.is_open()) {
         return;
     }
-
     std::cout << "-> Writing pinblocks..." << std::endl;
-
     const auto& follow_index = maps_.get_index<follow_header_index, by_id>();
 
-    out_.pinblocks.start_section(info_.golos.names.social, N(pin), "pin");
+    auto& out = out_.get_serializer(event_engine_genesis::pinblocks);
+    out.start_section(info_.golos.names.social, N(pin), "pin");
 
     for (const auto& follow : follow_index) {
         if (follow.ignores) {
             continue;
         }
-        out_.pinblocks.emplace<pin_info>([&](auto& p) {
+        out.emplace<pin_info>([&](auto& p) {
             p.pinner = generate_name(follow.follower);
             p.pinning = generate_name(follow.following);
         });
     }
 
-    out_.pinblocks.start_section(info_.golos.names.social, N(block), "block");
+    out.start_section(info_.golos.names.social, N(block), "block");
 
     for (const auto& follow : follow_index) {
         if (!follow.ignores) {
             continue;
         }
-        out_.pinblocks.emplace<block_info>([&](auto& b) {
+        out.emplace<block_info>([&](auto& b) {
             b.blocker = generate_name(follow.follower);
             b.blocking = generate_name(follow.following);
         });
@@ -510,11 +509,11 @@ void genesis_ee_builder::build_pinblocks() {
 
 void genesis_ee_builder::build_accounts() {
     std::cout << "-> Writing accounts..." << std::endl;
-
-    out_.accounts.start_section(config::system_account_name, N(domain), "domain_info");
+    auto& out = out_.get_serializer(event_engine_genesis::accounts);
+    out.start_section(config::system_account_name, N(domain), "domain_info");
 
     const auto app = info_.golos.names.issuer;
-    out_.accounts.insert(mvo
+    out.insert(mvo
         ("owner", app)
         ("linked_to", app)
         ("name", info_.golos.domain)
@@ -522,7 +521,7 @@ void genesis_ee_builder::build_accounts() {
 
     const auto& meta_index = maps_.get_index<account_metadata_index, by_account>();
 
-    out_.accounts.start_section(config::system_account_name, N(account), "account_info");
+    out.start_section(config::system_account_name, N(account), "account_info");
 
     for (auto& a : exp_info_.account_infos) {
         auto acc = a.second;
@@ -539,24 +538,45 @@ void genesis_ee_builder::build_accounts() {
                 acc["json_metadata"] = "{created_at: 'GENESIS'}";
             }
         }
-        out_.accounts.insert(acc);
+        out.insert(acc);
     }
 }
 
 void genesis_ee_builder::build_funds() {
     std::cout << "-> Writing funds..." << std::endl;
 
-    out_.funds.start_section(config::token_account_name, N(currency), "currency_stats");
+    auto& out = out_.get_serializer(event_engine_genesis::funds);
+    out.start_section(config::token_account_name, N(currency), "currency_stats");
 
     for (auto& cs : exp_info_.currency_stats) {
-        out_.funds.insert(cs);
+        out.insert(cs);
     }
 
-    out_.funds.start_section(config::token_account_name, N(balance), "balance_event");
+    out.start_section(config::token_account_name, N(balance), "balance_event");
 
     for (auto& be : exp_info_.balance_events) {
-        out_.funds.insert(be);
+        out.insert(be);
     }
+}
+
+void genesis_ee_builder::write_genesis_converts() {
+    std::cout << "-> Writing genesis balance conversions..." << std::endl;
+    auto& out = out_.get_serializer(event_engine_genesis::balance_conversions);
+    out.start_section(config::token_account_name, N(genesis.conv), "balance_convert");
+    auto store_convs = [&](auto* conv) {
+        for (const auto& cg: *conv) {
+            auto& c = cg.second;
+            if (c.value.get_amount() > 0) {
+                out.emplace<balance_convert_info>([&](auto& t) {
+                    t.owner = genesis_.name_by_idx(cg.first);
+                    t.amount = c.value;
+                    t.memo = c.memo;
+                });
+            }
+        }
+    };
+    store_convs(exp_info_.conv_gls);
+    store_convs(exp_info_.conv_gbg);
 }
 
 void genesis_ee_builder::build(const bfs::path& out_dir) {
@@ -569,6 +589,7 @@ void genesis_ee_builder::build(const bfs::path& out_dir) {
     build_pinblocks();
     build_accounts();
     build_funds();
+    write_genesis_converts();
 
     out_.finalize();
 }

--- a/programs/create-genesis/ee_genesis/genesis_ee_builder.hpp
+++ b/programs/create-genesis/ee_genesis/genesis_ee_builder.hpp
@@ -40,11 +40,11 @@ private:
 
     void build_votes(std::vector<vote_info>& votes, uint64_t msg_hash, operation_number msg_created);
     void build_reblogs(std::vector<reblog_info>& reblogs, uint64_t msg_hash, operation_number msg_created, bfs::ifstream& dump_reblogs);
-    void build_messages();
-    void build_transfers();
-    void build_pinblocks();
-    void build_accounts();
-    void build_funds();
+    void write_messages();
+    void write_transfers();
+    void write_pinblocks();
+    void write_accounts();
+    void write_funds();
     void write_genesis_converts();
 
     bfs::ifstream dump_delete_comments;

--- a/programs/create-genesis/ee_genesis/genesis_ee_builder.hpp
+++ b/programs/create-genesis/ee_genesis/genesis_ee_builder.hpp
@@ -1,14 +1,12 @@
 #pragma once
-
 #include "golos_dump_container.hpp"
 #include "event_engine_genesis.hpp"
 #include "map_objects.hpp"
-#include "../genesis_info.hpp"
-#include "../export_info.hpp"
+#include "../genesis_create.hpp"
 
-#include <boost/filesystem.hpp>
-#include <fc/exception/exception.hpp>
 #include <chainbase/chainbase.hpp>
+#include <fc/exception/exception.hpp>
+#include <boost/filesystem.hpp>
 
 namespace cyberway { namespace genesis { namespace ee {
 
@@ -20,7 +18,7 @@ using namespace cyberway::golos::ee;
 class genesis_ee_builder final {
 public:
     genesis_ee_builder(const genesis_ee_builder&) = delete;
-    genesis_ee_builder(const genesis_info& info, const export_info& exp_info, const std::string& shared_file, uint32_t last_block);
+    genesis_ee_builder(const genesis_create&, const std::string& shared_file, uint32_t last_block);
     ~genesis_ee_builder();
 
     void read_operation_dump(const bfs::path& in_dump_dir);
@@ -47,6 +45,7 @@ private:
     void build_pinblocks();
     void build_accounts();
     void build_funds();
+    void write_genesis_converts();
 
     bfs::ifstream dump_delete_comments;
     bfs::ifstream dump_comments;
@@ -59,8 +58,11 @@ private:
     bfs::ifstream dump_metas;
 
     bfs::path in_dump_dir_;
+
+    const genesis_create& genesis_;
     const genesis_info& info_;
     const export_info& exp_info_;
+
     event_engine_genesis out_;
     uint32_t last_block_;
     chainbase::database maps_;

--- a/programs/create-genesis/ee_genesis/genesis_ee_builder.hpp
+++ b/programs/create-genesis/ee_genesis/genesis_ee_builder.hpp
@@ -45,7 +45,7 @@ private:
     void write_pinblocks();
     void write_accounts();
     void write_funds();
-    void write_genesis_converts();
+    void write_balance_converts();
 
     bfs::ifstream dump_delete_comments;
     bfs::ifstream dump_comments;

--- a/programs/create-genesis/export_info.hpp
+++ b/programs/create-genesis/export_info.hpp
@@ -11,10 +11,65 @@ using mvo = fc::mutable_variant_object;
 using namespace eosio::chain;
 using acc_idx = uint32_t;
 
+struct converted_info {
+    asset value;
+    string memo;
+
+private:
+    string _cur_type;   // to group values by type
+    asset _cur_sum;
+
+    void update_memo(const asset& x, string type) {
+        if (_cur_type == type) {
+            _cur_sum += x;
+        } else {
+            if (_cur_type.size() > 0) {
+                if (memo.size() > 0)
+                    memo += " + ";
+                memo += _cur_sum.to_string() + " (" + _cur_type + ")";
+            }
+            _cur_type = type;
+            _cur_sum = x;
+        }
+    }
+
+public:
+    void add(const asset& x, string type) {
+        if (x.get_amount() == 0)
+            return;
+        if (empty()) {
+            value = x;                  // sets symbol
+        } else {
+            value += x;
+        }
+        update_memo(x, type);
+    }
+
+    void finish() {
+        update_memo(asset(), "non-existing");
+    }
+
+    void converted(const asset& x) {
+        if (x.get_amount() == 0 || value.get_amount() == 0)
+            return;
+        finish();
+        if (std::count(memo.begin(), memo.end(), '(') > 1)  // only add "=" if there are several records
+            memo = value.to_string() + " = " + memo;
+        value = x;
+    }
+
+    bool empty() const {
+        return value.get_amount() == 0;
+    }
+};
+
 struct export_info {
     fc::flat_map<acc_idx, mvo> account_infos;
     std::vector<mvo> currency_stats;
     std::vector<mvo> balance_events;
+
+    fc::flat_map<acc_idx, converted_info>* conv_gbg = nullptr;
+    fc::flat_map<acc_idx, converted_info>* conv_gls = nullptr;
 };
 
 }} // cyberway::genesis

--- a/programs/create-genesis/genesis_create.hpp
+++ b/programs/create-genesis/genesis_create.hpp
@@ -30,7 +30,13 @@ public:
     ~genesis_create();
 
     void read_state(const bfs::path& state_file);
-    void write_genesis(const bfs::path& out_file, export_info&, const genesis_info&, const genesis_state&, const contracts_map&);
+    void write_genesis(const bfs::path& out_file, const genesis_info&, const genesis_state&, const contracts_map&);
+
+    // ee interface
+    const genesis_info& get_info() const;
+    const genesis_state& get_conf() const;
+    const export_info& get_exp_info() const;
+    name name_by_idx(acc_idx idx) const;
 
 private:
     struct genesis_create_impl;

--- a/programs/create-genesis/main.cpp
+++ b/programs/create-genesis/main.cpp
@@ -144,7 +144,7 @@ void config_reader::read_config(const variables_map& options) {
     if (create_ee_genesis) {
         make_dir_absolute(ee_directory, "Events", false);
         if (!op_dump_dir.empty()) {
-           make_dir_absolute(op_dump_dir, "Operation dump", true);
+            make_dir_absolute(op_dump_dir, "Operation dump", true);
         }
     }
 
@@ -194,22 +194,22 @@ int main(int argc, char** argv) {
         cr.read_config(vmap);
         cr.read_contracts();
 
-        export_info exp_info;
 
         genesis_create builder{};
         builder.read_state(cr.info.state_file);
-        builder.write_genesis(cr.out_file, exp_info, cr.info, cr.genesis, cr.contracts);
+        builder.write_genesis(cr.out_file, cr.info, cr.genesis, cr.contracts);
 
+        const auto ee_shared_name = "shared_memory";
         if (cr.create_ee_genesis) {
-            bfs::remove_all("shared_memory");
+            bfs::remove_all(ee_shared_name);
 
-            genesis_ee_builder ee_builder(cr.info, exp_info, "shared_memory", cr.last_block);
+            genesis_ee_builder ee_builder{builder, ee_shared_name, cr.last_block};
             if (!cr.op_dump_dir.empty()) {
                 ee_builder.read_operation_dump(cr.op_dump_dir);
             }
             ee_builder.build(cr.ee_directory);
 
-            bfs::remove_all("shared_memory");
+            bfs::remove_all(ee_shared_name);
         }
     } catch (const fc::exception& e) {
         elog("${e}", ("e", e.to_detail_string()));

--- a/programs/create-genesis/serializer.hpp
+++ b/programs/create-genesis/serializer.hpp
@@ -160,7 +160,7 @@ public:
     }
 
     void insert(primary_key_t pk, uint64_t scope, const variant& v) {   // common case where scope is owner account
-        insert (pk, scope, scope, v);
+        insert(pk, scope, scope, v);
     }
 
     void insert(primary_key_t pk, uint64_t scope, name ram_payer, const variant& v) {


### PR DESCRIPTION
+ Store conversions of GBG to GOLOS (including savings/orders/escrows, etc)
+ Store "transfers" to GOLOS from external objects: savings/orders/escrows, etc
+ generalize ee-genesis serializers
+ base interface to use genesis objects/functions inside ee-genesis

***
Zero amounts are not stored.

When store GBG conversions, all GBG values of an account accumulated and converted to GOLOS. `memo` field shows sum and sources of GBGs:
```
{
"owner": "bittrex",
"amount": "9262700.227 GOLOS"
"memo": "7066918.126 GBG = 7066915.866 GBG (balance) + 2.260 GBG (savings)"
}
```

When store GOLOS, `memo` shows sources (other than balance, coz it's already at it's place), and sum is in `amount`:
```
{
"owner": "bittrex",
"amount": "20.101 GOLOS"
"memo": "20.101 GOLOS (savings)"
}
```