### PR TITLE
817 unsuccessfull finds

### DIFF
--- a/.buildkite/steps/deploy-unit_test.sh
+++ b/.buildkite/steps/deploy-unit_test.sh
@@ -15,7 +15,7 @@ docker-compose up -d mongo
 
 # Run unit-tests
 sleep 10s
-docker run --rm --network docker_cyberway-net -ti cyberway/cyberway:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/cyberway/bin/unit_test -l message -r detailed -t "!api_tests/*" -t "!abi_tests/*" -t "!bootseq_tests/*" -t "!eosio_system_tests/*" -t "!multi_index_tests/*" -t "!ram_tests/*" -t "!providebw_tests/*"'
+docker run --rm --network docker_cyberway-net -ti cyberway/cyberway:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/cyberway/bin/unit_test -l test_suite -r detailed -t "!api_tests/*" -t "!abi_tests/*" -t "!bootseq_tests/*" -t "!eosio_system_tests/*" -t "!multi_index_tests/*" -t "!ram_tests/*" -t "!providebw_tests/*"'
 result=$?
 
 docker-compose down

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -71,9 +71,6 @@ void apply_context::exec_one( action_trace& trace )
 
                this->chaindb_cache = &cache;
                control.get_wasm_interface().apply( a.code_version, a.code, *this );
-               if (control.is_producing_block()) {
-                   chaindb.apply_code_changes(a.name);
-               }
             } catch( const wasm_exit& ) {}
          }
       } FC_RETHROW_EXCEPTIONS(warn, "pending console output: ${console}", ("console", _pending_console_output.str()))

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -328,17 +328,6 @@ namespace cyberway { namespace chaindb {
             pos = p;
         }
 
-        ~lru_cache_cell() {
-            clear();
-        }
-
-        void clear() {
-            for (auto& state: state_list) if (state.object_ptr) {
-                state.reset();
-            }
-            state_list.clear();
-        }
-
         void emplace(cache_object_ptr obj_ptr) {
             state_list.emplace_back(*this, std::move(obj_ptr));
 

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -1031,7 +1031,9 @@ namespace cyberway { namespace chaindb {
                 service.object_tree.emplace(cache_object_key(cache_obj), cache_obj_ptr);
             }
 
-            set_object(table, &service, cache_obj, std::move(value));
+            if (!value.is_null()) {
+                set_object(table, &service, cache_obj, std::move(value));
+            }
 
             return cache_obj_ptr;
         }

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -1034,9 +1034,14 @@ namespace cyberway { namespace chaindb {
     ) const {
         CYBERWAY_ASSERT(primary_key::is_good(pk), cache_primary_key_exception,
             "Value ${pk} can't be used as primary key", ("pk", pk));
+
         auto obj = object_value{info.to_service(pk), {}};
         obj.service.payer  = storage.owner;
         obj.service.in_ram = true;
+
+        CYBERWAY_ASSERT(!impl_->find(obj.service), driver_duplicate_exception,
+            "Duplicate unique records in the cache table ${table}", ("table", get_full_table_name(info)));
+
         return impl_->emplace(info, std::move(obj));
     }
 

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -202,16 +202,10 @@ namespace cyberway { namespace chaindb {
                 return;
             }
 
-            while (prev_state) {
+            if (prev_state) {
                 prev_state->object_ptr.reset();
-
-                auto pending_prev_state = cast(prev_state);
-                if (pending_prev_state) {
-                    prev_state = pending_prev_state->prev_state;
-                } else {
-                    prev_state = nullptr;
-                }
             }
+            prev_state = nullptr;
 
             if (is_deleted) {
                 object_ptr->state_ = nullptr;

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -242,7 +242,7 @@ namespace cyberway { namespace chaindb {
             } else {
                 state.prev_state = prev_state;
                 state.is_deleted = is_deleted;
-                add_ram_usage(state);
+                add_ram_bytes(state);
             }
         }
 
@@ -255,10 +255,11 @@ namespace cyberway { namespace chaindb {
             return revision_;
         }
 
+        uint64_t ram_bytes = 0;
         std::deque<pending_cache_object_state> state_list; // Expansion of a std::deque is cheaper than the expansion of a std::vector
 
     private:
-        void add_ram_usage(const pending_cache_object_state& state) {
+        void add_ram_bytes(const pending_cache_object_state& state) {
             auto object_size = state.object_ptr->service().size;
             if (!object_size) {
                 return;
@@ -268,8 +269,8 @@ namespace cyberway { namespace chaindb {
                 std::max(eosio::chain::int_arithmetic::safe_prop<uint64_t>(object_size, pos - state.prev_state->cell->pos, max_distance_), uint64_t(1)) : 
                 object_size * config::ram_load_multiplier;
                 
-            CYBERWAY_CACHE_ASSERT(UINT64_MAX - size >= delta, "Pending delta would overflow UINT64_MAX");
-            size += delta;
+            CYBERWAY_CACHE_ASSERT(UINT64_MAX - ram_bytes >= delta, "Pending delta would overflow UINT64_MAX");
+            ram_bytes += delta;
 
         }
 
@@ -573,7 +574,7 @@ namespace cyberway { namespace chaindb {
         }
 
         uint64_t calc_ram_bytes(const revision_t revision) {
-            return get_pending_cell(revision).size;
+            return get_pending_cell(revision).ram_bytes;
         }
 
         void set_revision(const revision_t revision) {

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -207,7 +207,7 @@ namespace cyberway { namespace chaindb {
 
                 case cursor_kind::InRAM:
                     if (!cache_ptr) {
-                        return {ram_cursor, primary_key::End};
+                        return {end_cursor, primary_key::End};
                     }
 
                 case cursor_kind::OneRecord:
@@ -220,7 +220,7 @@ namespace cyberway { namespace chaindb {
                     assert(false);
             }
 
-            auto object = index.abi().to_object(index, value, size);
+            auto  object = index.abi().to_object(index, value, size);
             auto& cursor = driver_.lower_bound(std::move(index), object);
             if (cache_ptr) {
                 cursor.pk     = cache_ptr->pk();
@@ -259,7 +259,7 @@ namespace cyberway { namespace chaindb {
 
                 case cursor_kind::InRAM:
                     if (!cache_ptr) {
-                        return {ram_cursor, primary_key::End};
+                        return {end_cursor, primary_key::End};
                     }
 
                 case cursor_kind::OneRecord:
@@ -740,7 +740,7 @@ namespace cyberway { namespace chaindb {
     }
 
     void chaindb_controller::clear_cache() const {
-        impl_->cache_.clear();
+        impl_->cache_.set_revision(revision());
     }
 
     void chaindb_controller::close(const cursor_request& request) const {

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -275,6 +275,10 @@ namespace cyberway { namespace chaindb {
             return cache_.create(table, pk, storage);
         }
 
+        void destroy_cache_object(cache_object& obj) {
+            cache_.destroy(obj);
+        }
+
         cache_object_ptr get_cache_object(const cursor_request& req, const bool with_blob) {
             auto& cursor = current(req);
 
@@ -742,6 +746,10 @@ namespace cyberway { namespace chaindb {
 
     account_abi_info chaindb_controller::get_account_abi_info(const account_name_t code) const {
         return impl_->get_account_abi_info(code);
+    }
+
+    void chaindb_controller::destroy_cache_object(cache_object& obj) const {
+        return impl_->destroy_cache_object(obj);
     }
 
     primary_key_t chaindb_controller::available_pk(const table_request& request) const {

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -186,9 +186,9 @@ namespace cyberway { namespace chaindb {
         find_info lower_bound(
             const index_request& request, const cursor_kind kind, const char* value, const size_t size
         ) {
-            auto  key    = request.to_service();
-            auto  index  = get_index(request);
-            auto  object = index.abi().to_object(index, value, size);
+            auto key    = request.to_service();
+            auto index  = get_index(request);
+            auto object = index.abi().to_object(index, value, size);
 
             cache_object_ptr cache_ptr;
 
@@ -223,7 +223,7 @@ namespace cyberway { namespace chaindb {
 
             auto& cursor = driver_.lower_bound(std::move(index), object);
             if (cache_ptr) {
-                cursor.pk =     cache_ptr->pk();
+                cursor.pk     = cache_ptr->pk();
                 cursor.object = cache_ptr->object();
                 return {cursor.id, cursor.pk};
             }
@@ -241,9 +241,9 @@ namespace cyberway { namespace chaindb {
         }
 
         find_info lower_bound(const table_request& request, const cursor_kind kind, const primary_key_t pk) {
-            auto  key    = request.to_service(pk);
-            auto  index  = get_pk_index(request);
-            auto  value  = primary_key::to_variant(index, pk);
+            auto key   = request.to_service(pk);
+            auto index = get_pk_index(request);
+            auto value = primary_key::to_variant(index, pk);
 
             auto cache_ptr = cache_.find(key);
             if (!cache_ptr) {

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -183,7 +183,9 @@ namespace cyberway { namespace chaindb {
             return get_table(request);
         }
 
-        const cursor_info& lower_bound(const index_request& request, const char* value, const size_t size) {
+        const cursor_info& lower_bound(
+            const index_request& request, const cursor_kind kind, const char* value, const size_t size
+        ) {
             auto  key    = request.to_service();
             auto  index  = get_index(request);
             auto  object = index.abi().to_object(index, value, size);
@@ -219,7 +221,7 @@ namespace cyberway { namespace chaindb {
             return cursor;
         }
 
-        const cursor_info& lower_bound(const table_request& request, const primary_key_t pk) {
+        const cursor_info& lower_bound(const table_request& request, const cursor_kind kind, const primary_key_t pk) {
             auto  key    = request.to_service(pk);
             auto  index  = get_pk_index(request);
             auto  value  = primary_key::to_variant(index, pk);
@@ -693,13 +695,17 @@ namespace cyberway { namespace chaindb {
         impl_->driver_.apply_code_changes(code);
     }
 
-    find_info chaindb_controller::lower_bound(const index_request& request, const char* key, size_t size) const {
-        const auto& info = impl_->lower_bound(request, key, size);
+    find_info chaindb_controller::lower_bound(
+        const index_request& request, const cursor_kind kind, const char* key, size_t size
+    ) const {
+        const auto& info = impl_->lower_bound(request, kind, key, size);
         return {info.id, info.pk};
     }
 
-    find_info chaindb_controller::lower_bound(const table_request& request, const primary_key_t pk) const {
-        const auto& info = impl_->lower_bound(request, pk);
+    find_info chaindb_controller::lower_bound(
+        const table_request& request, const cursor_kind kind, const primary_key_t pk
+    ) const {
+        const auto& info = impl_->lower_bound(request, kind, pk);
         return {info.id, info.pk};
     }
 

--- a/libraries/chain/chaindb/mongo_fail_driver.cpp
+++ b/libraries/chain/chaindb/mongo_fail_driver.cpp
@@ -53,6 +53,10 @@ namespace cyberway { namespace chaindb {
         NOT_SUPPORTED;
     }
 
+    void mongodb_driver::skip_pk(const table_info&, primary_key_t) const {
+        NOT_SUPPORTED;
+    }
+
     cursor_info& mongodb_driver::lower_bound(index_info, variant) const {
         NOT_SUPPORTED;
     }

--- a/libraries/chain/chaindb/undo_state.cpp
+++ b/libraries/chain/chaindb/undo_state.cpp
@@ -382,6 +382,7 @@ namespace cyberway { namespace chaindb {
 
         void insert(const table_info& table, object_value obj) {
             verifier_.verify(table, obj);
+            cache_.clear_unsuccess(table);
             if (enabled()) {
                 insert(get_table(table), std::move(obj));
             } else {
@@ -391,6 +392,7 @@ namespace cyberway { namespace chaindb {
 
         void update(const table_info& table, object_value orig_obj, object_value obj) {
             verifier_.verify(table, obj);
+            cache_.clear_unsuccess(table);
             if (enabled()) {
                 update(get_table(table), std::move(orig_obj), std::move(obj));
             } else {
@@ -399,6 +401,7 @@ namespace cyberway { namespace chaindb {
         }
 
         void remove(const table_info& table, object_value orig_obj) {
+            cache_.clear_unsuccess(table);
             if (enabled()) {
                 remove(get_table(table), std::move(orig_obj));
             } else {
@@ -553,6 +556,7 @@ namespace cyberway { namespace chaindb {
 
                 restore_undo_state(obj.second);
                 verifier_.verify(table.info(), obj.second);
+                cache_.clear_unsuccess(table.info());
                 cache_.emplace(table.info(), obj.second);
 
                 journal_.write(ctx,
@@ -561,6 +565,7 @@ namespace cyberway { namespace chaindb {
             }
 
             for (auto& obj: head.new_values_) {
+                cache_.clear_unsuccess(table.info());
                 cache_.remove(table.info(), obj.first);
                 journal_.write(ctx,
                     write_operation::remove(undo_rev, obj.second.clone_service()),
@@ -572,6 +577,7 @@ namespace cyberway { namespace chaindb {
 
                 restore_undo_state(obj.second);
                 verifier_.verify(table.info(), obj.second);
+                cache_.clear_unsuccess(table.info());
                 cache_.emplace(table.info(), obj.second);
 
                 journal_.write(ctx,

--- a/libraries/chain/chaindb/undo_state.cpp
+++ b/libraries/chain/chaindb/undo_state.cpp
@@ -402,6 +402,7 @@ namespace cyberway { namespace chaindb {
 
         void remove(const table_info& table, object_value orig_obj) {
             cache_.clear_unsuccess(table);
+            driver_.skip_pk(table, orig_obj.pk());
             if (enabled()) {
                 remove(get_table(table), std::move(orig_obj));
             } else {
@@ -567,6 +568,7 @@ namespace cyberway { namespace chaindb {
             for (auto& obj: head.new_values_) {
                 cache_.clear_unsuccess(table.info());
                 cache_.remove(table.info(), obj.first);
+                driver_.skip_pk(table.info(), obj.first);
                 journal_.write(ctx,
                     write_operation::remove(undo_rev, obj.second.clone_service()),
                     write_operation::remove(undo_rev, obj.second.clone_service()));

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -393,7 +393,6 @@ struct controller_impl {
       // revision ordinal to the appropriate expected value here.
       if( skip_session ) {
          chaindb.apply_all_changes();
-         set_revision( head->block_num );
       }
 
       int rev = 0;

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -419,6 +419,7 @@ struct controller_impl {
    void init(std::function<bool()> shutdown, const snapshot_reader_ptr& snapshot) {
 
       bool report_integrity_hash = !!snapshot;
+      bool initialized = false;
 
       EOS_ASSERT( !snapshot, fork_database_exception, "Snapshot not supported");
       if (snapshot) {
@@ -439,6 +440,7 @@ struct controller_impl {
       } else {
          if( !head ) {
             initialize_fork_db(); // set head to genesis state
+            initialized = true;
          }
 
          auto end = blog.read_head();
@@ -481,7 +483,9 @@ struct controller_impl {
          chaindb.undo_last_revision();
       }
 
-      initialize_caches();
+      if( !initialized ) {
+         initialize_caches();
+      }
 
       if( report_integrity_hash ) {
 // TODO: removed by CyberWay

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -481,9 +481,13 @@ struct controller_impl {
          chaindb.undo_last_revision();
       }
 
+      initialize_caches();
+
       if( report_integrity_hash ) {
-         const auto hash = calculate_integrity_hash();
-         ilog( "database initialized with hash: ${hash}", ("hash", hash) );
+// TODO: removed by CyberWay
+//         const auto hash = calculate_integrity_hash();
+//         ilog( "database initialized with hash: ${hash}", ("hash", hash) );
+          wlog( "integrity hash is disabled" );
       }
    }
 
@@ -577,6 +581,18 @@ struct controller_impl {
 
       initialize_database();
       read_genesis();
+   }
+
+   void initialize_caches() {
+       auto block_summary_table = chaindb.get_table<block_summary_object>();
+       for (auto& value: block_summary_table) {
+           // only load to RAM
+       }
+
+       auto transaction_table = chaindb.get_table<transaction_object>();
+       for (auto& value: transaction_table) {
+           // only load to RAM
+       }
    }
 
    void create_native_account( account_name name, const authority& owner, const authority& active, bool is_privileged = false ) {
@@ -2138,7 +2154,7 @@ void controller::validate_reversible_available_size() const {
 }
 
 bool controller::is_known_unexpired_transaction( const transaction_id_type& id) const {
-   return chaindb().find<transaction_object, by_trx_id>(id);
+   return chaindb().find<transaction_object, by_trx_id>(id, cyberway::chaindb::cursor_kind::InRAM);
 }
 
 void controller::set_subjective_cpu_leeway(fc::microseconds leeway) {

--- a/libraries/chain/genesis/genesis_import.cpp
+++ b/libraries/chain/genesis/genesis_import.cpp
@@ -46,7 +46,7 @@ struct genesis_import::impl final {
         // we need primary key for update, but it depends on table. add this hacky shortcut for accounts
         primary_key_t pk = ((primary_key_t*)r.data.data())[0];
         const name n(pk);
-        const auto* old = db.find<account_object>(n);  // vm_type/vm_version/privileged not set in genesis, copy
+        const auto* old = db.find<account_object>(n, cyberway::chaindb::cursor_kind::InRAM);  // vm_type/vm_version/privileged not set in genesis, copy
         if (!old) {
             return false;
         }

--- a/libraries/chain/include/cyberway/chaindb/cache_item.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_item.hpp
@@ -69,19 +69,7 @@ namespace cyberway { namespace chaindb {
         cache_cell::cache_cell_kind kind() const;
     }; // struct cache_object_state
 
-    struct cache_index_value;
-    struct cache_index_key;
-
-    struct cache_index_compare final {
-        using is_transparent = void;
-        template<typename LeftKey, typename RightKey> bool operator()(const LeftKey&, const RightKey&) const;
-    }; // struct cache_index_compare
-
-    using cache_index_tree = std::set<cache_index_value, cache_index_compare>;
-    using cache_indicies   = std::deque<cache_index_tree::const_iterator>;
-
-    struct cache_object final: public boost::intrusive_ref_counter<cache_object>
-    {
+    struct cache_object final: public boost::intrusive_ref_counter<cache_object> {
         enum stage_kind {
             Released,
             Active,
@@ -157,7 +145,6 @@ namespace cyberway { namespace chaindb {
         object_value        object_;
         bytes               blob_;  // for contracts tables
         cache_data_ptr      data_;  // for interchain tables
-        cache_indicies      indicies_;
         stage_kind          stage_ = Released;
 
         friend class  cache_map_impl;

--- a/libraries/chain/include/cyberway/chaindb/cache_item.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_item.hpp
@@ -85,6 +85,7 @@ namespace cyberway { namespace chaindb {
     private:
         friend class  cache_map_impl;
         friend struct lru_cache_cell;
+        friend struct lru_cache_object_state;
         friend struct system_cache_cell;
         friend struct pending_cache_cell;
         friend struct pending_cache_object_state;
@@ -115,8 +116,6 @@ namespace cyberway { namespace chaindb {
                 object_.service.scope == request.scope &&
                 object_.service.table == request.table;
         }
-
-        void release();
 
         template <typename T, typename... Args> void set_data(Args&&... args) {
             data_ = std::make_unique<T>(*this, std::forward<Args>(args)...);

--- a/libraries/chain/include/cyberway/chaindb/cache_item.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_item.hpp
@@ -116,7 +116,6 @@ namespace cyberway { namespace chaindb {
                 object_.service.table == request.table;
         }
 
-        void mark_deleted();
         void release();
 
         template <typename T, typename... Args> void set_data(Args&&... args) {

--- a/libraries/chain/include/cyberway/chaindb/cache_item.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_item.hpp
@@ -51,14 +51,24 @@ namespace cyberway { namespace chaindb {
         }; // enum cell_kind
 
         cache_map_impl* const map  = nullptr;
-        const cache_cell_kind kind = Unknown;
 
-        uint64_t pos  = 0;
         uint64_t size = 0;
 
-        cache_cell(cache_map_impl& m, cache_cell_kind k)
-        : map(&m), kind(k) {
+        cache_cell(cache_map_impl& m, uint64_t p, cache_cell_kind k)
+        : map(&m), pos_(p), kind_(k) {
         }
+
+        cache_cell_kind kind() const {
+            return kind_;
+        }
+
+        uint64_t pos() const {
+            return pos_;
+        }
+
+    protected:
+        const uint64_t pos_ = 0;
+        cache_cell_kind kind_ = Unknown;
     }; // struct cache_cell
 
     struct cache_object_state {
@@ -70,6 +80,7 @@ namespace cyberway { namespace chaindb {
         }
 
         void reset();
+        cache_cell::cache_cell_kind kind() const;
     }; // struct cache_object_state
 
     class cache_object final:
@@ -87,12 +98,13 @@ namespace cyberway { namespace chaindb {
         friend struct lru_cache_cell;
         friend struct lru_cache_object_state;
         friend struct system_cache_cell;
-        friend struct pending_cache_cell;
-        friend struct pending_cache_object_state;
 
-        cache_cell&         cell();
-        cache_map_impl&     map();
-        cache_object_state& state();
+        using cache_cell_kind = cache_cell::cache_cell_kind;
+
+        cache_cell&         cell() const;
+        cache_cell_kind     kind() const;
+        cache_map_impl&     map() const;
+        cache_object_state& state() const;
         cache_object_state* swap_state(cache_object_state& state);
 
     public:

--- a/libraries/chain/include/cyberway/chaindb/cache_map.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_map.hpp
@@ -25,6 +25,12 @@ namespace cyberway { namespace chaindb {
         cache_object_ptr emplace(const table_info&, object_value) const;
         void remove(const table_info&, primary_key_t) const;
 
+        void emplace_unsuccess(const table_info&, primary_key_t, primary_key_t) const;
+
+        cache_object_ptr find_unsuccess(const table_info&, primary_key_t) const;
+
+        void clear_unsuccess(const table_info&) const;
+
         void set_object(const table_info&, cache_object&, object_value) const;
         void set_service(const table_info&, cache_object&, service_state) const;
         void set_revision(const object_value&, revision_t) const;

--- a/libraries/chain/include/cyberway/chaindb/cache_map.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_map.hpp
@@ -16,6 +16,9 @@ namespace cyberway { namespace chaindb {
 
         cache_object_ptr create(const table_info&, primary_key_t, const storage_payer_info&) const;
         cache_object_ptr create(const table_info&, const storage_payer_info&) const;
+
+        void destroy(cache_object& obj) const;
+
         cache_object_ptr find(const service_state&) const;
         cache_object_ptr find(const service_state&, index_name_t, const char*, size_t) const;
 

--- a/libraries/chain/include/cyberway/chaindb/cache_map.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_map.hpp
@@ -26,8 +26,10 @@ namespace cyberway { namespace chaindb {
         void remove(const table_info&, primary_key_t) const;
 
         void emplace_unsuccess(const table_info&, primary_key_t, primary_key_t) const;
+        void emplace_unsuccess(const index_info&, const char*, size_t, primary_key_t) const;
 
-        cache_object_ptr find_unsuccess(const table_info&, primary_key_t) const;
+        cache_object_ptr find_unsuccess(const service_state&) const;
+        cache_object_ptr find_unsuccess(const service_state&, index_name_t, const char*, size_t) const;
 
         void clear_unsuccess(const table_info&) const;
 

--- a/libraries/chain/include/cyberway/chaindb/common.hpp
+++ b/libraries/chain/include/cyberway/chaindb/common.hpp
@@ -78,12 +78,12 @@ namespace cyberway { namespace chaindb {
     };
 
     class  chaindb_controller;
-    class  cache_object;
     class  cache_map;
     class  driver_interface;
     class  journal;
     class  value_verifier;
     class  undo_stack;
+    struct cache_object;
     struct table_info;
     struct index_info;
     struct undo_stack_impl;

--- a/libraries/chain/include/cyberway/chaindb/common.hpp
+++ b/libraries/chain/include/cyberway/chaindb/common.hpp
@@ -21,7 +21,9 @@ namespace cyberway { namespace chaindb {
 
     using cursor_t = int32_t;
     static constexpr cursor_t invalid_cursor = (0);
-    static constexpr cursor_t ram_cursor = std::numeric_limits<cursor_t>::max();
+    static constexpr cursor_t end_cursor     = (-1);
+    static constexpr cursor_t begin_cursor   = (-2);
+    static constexpr cursor_t ram_cursor     = (-3);
 
     using std::string;
 

--- a/libraries/chain/include/cyberway/chaindb/common.hpp
+++ b/libraries/chain/include/cyberway/chaindb/common.hpp
@@ -21,6 +21,7 @@ namespace cyberway { namespace chaindb {
 
     using cursor_t = int32_t;
     static constexpr cursor_t invalid_cursor = (0);
+    static constexpr cursor_t ram_cursor = std::numeric_limits<cursor_t>::max();
 
     using std::string;
 

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -159,8 +159,9 @@ namespace cyberway { namespace chaindb {
 
         void set_cache_converter(const table_request&, const cache_converter_interface&) const;
         cache_object_ptr create_cache_object(const table_request&, const storage_payer_info&) const;
-        cache_object_ptr create_cache_object(const table_request&, const primary_key_t, const storage_payer_info&) const;
+        cache_object_ptr create_cache_object(const table_request&, primary_key_t, const storage_payer_info&) const;
         cache_object_ptr get_cache_object(const cursor_request&, bool with_blob) const;
+        cache_object_ptr get_cache_object(const table_request&, primary_key_t, bool with_blob) const;
         account_abi_info get_account_abi_info(account_name_t) const;
 
         void destroy_cache_object(cache_object&) const;

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -178,11 +178,10 @@ namespace cyberway { namespace chaindb {
 
         void change_ram_state(cache_object&, const storage_payer_info&) const;
 
-        variant value_by_pk(const table_request& request, primary_key_t pk) const;
-        variant value_at_cursor(const cursor_request&) const;
         table_info   table_by_request(const table_request&) const;
         index_info   index_at_cursor(const cursor_request&) const;
         object_value object_at_cursor(const cursor_request&) const;
+        object_value object_by_pk(const table_request& request, primary_key_t) const;
 
     private:
         friend class chaindb_session;

--- a/libraries/chain/include/cyberway/chaindb/controller.hpp
+++ b/libraries/chain/include/cyberway/chaindb/controller.hpp
@@ -157,6 +157,8 @@ namespace cyberway { namespace chaindb {
         cache_object_ptr get_cache_object(const cursor_request&, bool with_blob) const;
         account_abi_info get_account_abi_info(account_name_t) const;
 
+        void destroy_cache_object(cache_object&) const;
+
         primary_key_t available_pk(const table_request&) const;
 
         int insert(const table_request&, const storage_payer_info&, primary_key_t, const char*, size_t) const;

--- a/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
+++ b/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
@@ -33,6 +33,8 @@ namespace cyberway { namespace chaindb {
         virtual void apply_all_changes() const = 0;
         virtual void apply_code_changes(const account_name& code) const = 0;
 
+        virtual void skip_pk(const table_info&, primary_key_t) const = 0;
+
         virtual cursor_info& lower_bound(index_info, variant key) const = 0;
         virtual cursor_info& upper_bound(index_info, variant key) const = 0;
         virtual cursor_info& locate_to(index_info, variant key, primary_key_t) const = 0;

--- a/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
+++ b/libraries/chain/include/cyberway/chaindb/driver_interface.hpp
@@ -11,6 +11,7 @@ namespace cyberway { namespace chaindb {
         cursor_t      id = invalid_cursor;
         index_info    index;
         primary_key_t pk = primary_key::End;
+        object_value  object;
     }; // struct cursor_info
 
     class driver_interface {

--- a/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
+++ b/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
@@ -9,6 +9,8 @@ namespace cyberway { namespace chaindb {
 
     class journal;
 
+    struct mongodb_driver_impl;
+
     class mongodb_driver final: public driver_interface {
     public:
         mongodb_driver(journal&, string, string);
@@ -47,8 +49,7 @@ namespace cyberway { namespace chaindb {
         primary_key_t available_pk(const table_info&) const override;
 
     private:
-        struct mongodb_impl_;
-        std::unique_ptr<mongodb_impl_> impl_;
+        std::unique_ptr<mongodb_driver_impl> impl_;
     }; // class mongodb_driver
 
 } } // namespace cyberway::chaindb

--- a/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
+++ b/libraries/chain/include/cyberway/chaindb/mongo_driver.hpp
@@ -31,6 +31,8 @@ namespace cyberway { namespace chaindb {
         void apply_code_changes(const account_name& code) const override;
         void apply_all_changes() const override;
 
+        void skip_pk(const table_info&, primary_key_t) const override;
+
         cursor_info& lower_bound(index_info, variant key) const override;
         cursor_info& upper_bound(index_info, variant key) const override;
         cursor_info& locate_to(index_info, variant key, primary_key_t) const override;

--- a/libraries/chain/include/cyberway/chaindb/multi_index.hpp
+++ b/libraries/chain/include/cyberway/chaindb/multi_index.hpp
@@ -718,7 +718,7 @@ public:
 
             return {obj, delta};
         } catch (...) {
-            cache_ptr->mark_deleted();
+            controller_.destroy_cache_object(*cache_ptr.get());
             throw;
         }
 

--- a/libraries/chain/include/cyberway/chaindb/multi_index.hpp
+++ b/libraries/chain/include/cyberway/chaindb/multi_index.hpp
@@ -54,10 +54,10 @@ namespace cyberway { namespace chaindb {
 
 namespace cyberway { namespace chaindb {
     namespace uninitilized_cursor {
-        static constexpr cursor_t state = 0;
-        static constexpr cursor_t end = -1;
-        static constexpr cursor_t begin = -2;
-        static constexpr cursor_t ram = ram_cursor;
+        static constexpr cursor_t state = invalid_cursor;
+        static constexpr cursor_t end   = end_cursor;
+        static constexpr cursor_t begin = begin_cursor;
+        static constexpr cursor_t ram   = ram_cursor;
     }
 
 template<typename O>
@@ -443,7 +443,7 @@ private:
 
     private:
         bool is_cursor_initialized() const {
-            return (cursor_ != uninitilized_cursor::ram && cursor_ > uninitilized_cursor::state);
+            return (cursor_ > uninitilized_cursor::state);
         }
 
         template<typename, typename> friend class index;

--- a/libraries/chain/stake.cpp
+++ b/libraries/chain/stake.cpp
@@ -16,9 +16,9 @@ void set_votes(cyberway::chaindb::chaindb_controller& db, const stake_stat_objec
     
     auto stat_itr = db.begin({config::token_account_name, token_code, N(stat), cyberway::chaindb::names::primary_index});
     EOS_ASSERT(stat_itr.pk != cyberway::chaindb::primary_key::End, transaction_exception, "SYSTEM: token doesn't exist");
-    const auto stat_obj = db.value_at_cursor({config::token_account_name, stat_itr.cursor});
+    const auto stat_obj = db.object_at_cursor({config::token_account_name, stat_itr.cursor});
     asset supply;
-    fc::from_variant(stat_obj["supply"], supply);
+    fc::from_variant(stat_obj.value["supply"], supply);
     
     auto candidates_table = db.get_table<stake_candidate_object>();
     auto candidates_idx = candidates_table.get_index<stake_candidate_object::by_key>();

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -687,7 +687,7 @@ namespace bacc = boost::accumulators;
 
    void transaction_context::record_transaction( const transaction_id_type& id, fc::time_point_sec expire ) {
       auto trx_idx = control.chaindb().get_index<transaction_object, by_trx_id>();
-      auto itr = trx_idx.find(id);
+      auto itr = trx_idx.find(id, cyberway::chaindb::cursor_kind::InRAM);
       EOS_ASSERT(trx_idx.end() == itr, tx_duplicate, "duplicate transaction ${id}", ("id", id ));
 
       trx_idx.emplace([&](transaction_object& transaction) {

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -449,7 +449,10 @@ namespace bacc = boost::accumulators;
    void transaction_context::squash() {
       // TODO: removed by CyberWay
       // if (undo_session) undo_session->squash();
-      if (chaindb_undo_session) chaindb_undo_session->squash();
+      if (chaindb_undo_session) {
+          control.chaindb().apply_all_changes();
+          chaindb_undo_session->squash();
+      }
    }
 
    void transaction_context::undo() {

--- a/libraries/chain/wasm_chaindb_interface.ipp
+++ b/libraries/chain/wasm_chaindb_interface.ipp
@@ -11,13 +11,15 @@
 
 namespace eosio { namespace chain {
 
-    using cyberway::chaindb::cursor_t;
-    using cyberway::chaindb::account_name_t;
-    using cyberway::chaindb::scope_name_t;
-    using cyberway::chaindb::table_name_t;
-    using cyberway::chaindb::index_name_t;
-    using cyberway::chaindb::primary_key_t;
-    using cyberway::chaindb::cursor_kind;
+    namespace chaindb = cyberway::chaindb;
+
+    using chaindb::cursor_t;
+    using chaindb::account_name_t;
+    using chaindb::scope_name_t;
+    using chaindb::table_name_t;
+    using chaindb::index_name_t;
+    using chaindb::primary_key_t;
+    using chaindb::cursor_kind;
 
     class chaindb_api : public context_aware_api {
     public:
@@ -100,10 +102,12 @@ namespace eosio { namespace chain {
             assert(context.chaindb_cache);
             auto& chaindb_cache = *context.chaindb_cache;
 
+            chaindb::cursor_request request{code, cursor};
+
             chaindb_cache.cache_code   = code;
             chaindb_cache.cache_cursor = cursor;
 
-            chaindb_cache.cache = context.chaindb.get_cache_object({code, cursor}, true);
+            chaindb_cache.cache = context.chaindb.get_cache_object(request, true);
 
             if (chaindb_cache.cache) {
                 auto& blob = chaindb_cache.cache->blob();
@@ -211,17 +215,11 @@ namespace eosio { namespace chain {
         void chaindb_ram_state(
             account_name_t code, scope_name_t scope, table_name_t table, primary_key_t pk, bool in_ram
         ) {
-            namespace chaindb = cyberway::chaindb;
-
             validate_db_access_violation(code);
 
-            chaindb::cache_object_ptr cache_ptr;
-            chaindb::table_request    request{code, scope, table};
+            chaindb::table_request request{code, scope, table};
 
-            auto find = context.chaindb.lower_bound(request, cursor_kind::ManyRecords, pk);
-            if (find.pk == pk) {
-                cache_ptr = context.chaindb.get_cache_object({code, find.cursor}, false);
-            }
+            auto cache_ptr = context.chaindb.get_cache_object(request, pk, false);
 
             EOS_ASSERT(cache_ptr, eosio::chain::object_query_exception,
                 "Object with the primary key ${pk} doesn't exist in the table ${table}:${scope}",

--- a/libraries/chain/wasm_chaindb_interface.ipp
+++ b/libraries/chain/wasm_chaindb_interface.ipp
@@ -17,6 +17,7 @@ namespace eosio { namespace chain {
     using cyberway::chaindb::table_name_t;
     using cyberway::chaindb::index_name_t;
     using cyberway::chaindb::primary_key_t;
+    using cyberway::chaindb::cursor_kind;
 
     class chaindb_api : public context_aware_api {
     public:
@@ -36,13 +37,13 @@ namespace eosio { namespace chain {
             account_name_t code, scope_name_t scope, table_name_t table, index_name_t index,
             array_ptr<const char> key, size_t size
         ) {
-            return context.chaindb.lower_bound({code, scope, table, index}, key, size).cursor;
+            return context.chaindb.lower_bound({code, scope, table, index}, cursor_kind::ManyRecords, key, size).cursor;
         }
 
         cursor_t chaindb_lower_bound_pk(
             account_name_t code, scope_name_t scope, table_name_t table, primary_key_t pk
         ) {
-            return context.chaindb.lower_bound({code, scope, table}, pk).cursor;
+            return context.chaindb.lower_bound({code, scope, table}, cursor_kind::ManyRecords, pk).cursor;
         }
 
         cursor_t chaindb_upper_bound(
@@ -217,7 +218,7 @@ namespace eosio { namespace chain {
             chaindb::cache_object_ptr cache_ptr;
             chaindb::table_request    request{code, scope, table};
 
-            auto find = context.chaindb.lower_bound(request, pk);
+            auto find = context.chaindb.lower_bound(request, cursor_kind::ManyRecords, pk);
             if (find.pk == pk) {
                 cache_ptr = context.chaindb.get_cache_object({code, find.cursor}, false);
             }

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -750,9 +750,9 @@ namespace eosio { namespace testing {
       share_type result = 0;
 
       auto& db = control->chaindb();
-      auto find = db.lower_bound({code, account, N(accounts)}, asset_symbol.to_symbol_code());
+      auto find = db.lower_bound({code, account, N(accounts)}, cyberway::chaindb::cursor_kind::OneRecord, asset_symbol.to_symbol_code());
       if (find.pk == asset_symbol.to_symbol_code()) {
-         auto cache = db.get_cache_object({code, find.cursor}, true);
+         auto cache = db.get_cache_object({code, account, N(accounts)}, find.pk, true);
          fc::datastream<const char *> ds(cache->blob().data(), cache->blob().size());
          fc::raw::unpack(ds, result);
       }
@@ -763,7 +763,7 @@ namespace eosio { namespace testing {
       vector<char> data;
 
       auto& db = control->chaindb();
-      auto find = db.lower_bound({code, scope, table}, act.value);
+      auto find = db.lower_bound({code, scope, table}, cyberway::chaindb::cursor_kind::ManyRecords, act.value);
       if (find.pk != act.value) return data;
 
       auto cache = db.get_cache_object({code, find.cursor}, true);

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -408,7 +408,7 @@ fc::variant chain_api_plugin_impl::get_payout(chain::account_name account) const
                                                                                  ("account", account));
 
     if (payouts_it.pk != cyberway::chaindb::primary_key::End) {
-        return chain_db.value_at_cursor({N(cyber.stake), payouts_it.cursor});
+        return chain_db.object_at_cursor({N(cyber.stake), payouts_it.cursor}).value;
     }
     return fc::variant();
 }
@@ -427,7 +427,7 @@ fc::optional<eosio::chain::asset> chain_api_plugin_impl::get_account_core_liquid
     const auto end_it = db_controller.end(request);
 
     for (; accounts_it.pk != end_it.pk; accounts_it.pk = db_controller.next({token_code, accounts_it.cursor})) {
-        const auto value = db_controller.value_at_cursor({token_code, accounts_it.cursor});
+        const auto value = db_controller.object_at_cursor({token_code, accounts_it.cursor}).value;
         const auto balance_object = value["balance"];
         eosio::chain::asset asset_value;
 
@@ -599,7 +599,7 @@ get_table_rows_result chain_api_plugin_impl::walk_table_row_range(const get_tabl
                 ("in_ram",  object.service.in_ram);
             result.rows.push_back(std::move(value));
         } else {
-            result.rows.push_back(chaindb.value_at_cursor(cursor));
+            result.rows.push_back(chaindb.object_at_cursor(cursor).value);
         }
     }
 
@@ -669,7 +669,7 @@ std::vector<chain::asset> chain_api_plugin_impl::get_currency_balance( const get
 
     for (; accounts_it.pk != cyberway::chaindb::primary_key::End; accounts_it.pk = chaindb.next(next_request)) {
 
-        const auto value = chaindb.value_at_cursor({p.code, accounts_it.cursor});
+        const auto value = chaindb.object_at_cursor({p.code, accounts_it.cursor}).value;
 
         const auto balance_object = value["balance"];
         eosio::chain::asset asset_value;
@@ -698,7 +698,7 @@ fc::variant chain_api_plugin_impl::get_currency_stats( const get_currency_stats_
         return {};
     }
 
-    const auto currency_stat_object = chaindb.value_at_cursor({p.code, itr.cursor});
+    const auto currency_stat_object = chaindb.object_at_cursor({p.code, itr.cursor}).value;
 
     chain::asset supply;
     fc::from_variant(currency_stat_object["supply"], supply);
@@ -765,7 +765,7 @@ std::string chain_api_plugin_impl::get_agent_public_key(chain::account_name acco
     const auto it = chaindb.lower_bound(request, fc::mutable_variant_object()("token_code", symbol.to_symbol_code())("account", account));
 
     if (it.pk != cyberway::chaindb::primary_key::End) {
-        return chaindb.value_at_cursor({N(), it.cursor})["signing_key"].as_string();
+        return chaindb.object_at_cursor({N(), it.cursor}).value["signing_key"].as_string();
     }
     return "";
 }

--- a/unittests/auth_tests.cpp
+++ b/unittests/auth_tests.cpp
@@ -386,7 +386,6 @@ try {
    auto& chaindb = chain.control->chaindb();
 
    using resource_usage_object = eosio::chain::resource_limits::resource_usage_object;
-   using by_owner = eosio::chain::resource_limits::by_owner;
 
    auto create_acc = [&](account_name a) {
 

--- a/unittests/identity_tests.cpp
+++ b/unittests/identity_tests.cpp
@@ -60,7 +60,7 @@ public:
 
    uint64_t get_result_uint64() {
       auto& chaindb = control->chaindb();
-      auto value = chaindb.value_by_pk({N(identitytest), 0, N(result)}, N(result));
+      auto value = chaindb.object_by_pk({N(identitytest), 0, N(result)}, N(result)).value;
       return value["identity"].as_uint64();
    }
 
@@ -104,7 +104,7 @@ public:
 
    fc::variant get_identity(uint64_t idnt) {
       auto& chaindb = control->chaindb();
-      auto value = chaindb.value_by_pk({N(identity), N(identity), N(idents)}, idnt);
+      auto value = chaindb.object_by_pk({N(identity), N(identity), N(idents)}, idnt).value;
       return value;
    }
 
@@ -142,7 +142,7 @@ public:
    fc::variant get_accountrow(const string& account) {
       auto& chaindb = control->chaindb();
       auto acnt = string_to_name(account.c_str());
-      return chaindb.value_by_pk({N(identity), acnt, N(account)}, N(account));
+      return chaindb.object_by_pk({N(identity), acnt, N(account)}, N(account)).value;
    }
 
    action_result settrust(const string& trustor, const string& trusting, uint64_t trust, bool auth = true)
@@ -164,7 +164,7 @@ public:
    bool get_trust(const string& trustor, const string& trusting) {
       auto& chaindb = control->chaindb();
       uint64_t tng = string_to_name(trusting.c_str());
-      return !chaindb.value_by_pk({N(identity), string_to_name(trustor.c_str()), N(trust)}, tng).is_null();
+      return !chaindb.object_by_pk({N(identity), string_to_name(trustor.c_str()), N(trust)}, tng).value.is_null();
    }
 
 public:

--- a/unittests/identity_tests.cpp
+++ b/unittests/identity_tests.cpp
@@ -127,11 +127,12 @@ public:
       auto find = cyberway::chaindb::lower_bound<false>()(
          chaindb,
          {N(identity), identity, N( certs ), N(bytuple)},
+         cyberway::chaindb::cursor_kind::OneRecord,
          boost::make_tuple(string_to_name(property.c_str()), trusted, string_to_name(certifier.c_str())));
       if (find.pk != cyberway::chaindb::primary_key::End) {
-         auto val = chaindb.value_at_cursor({N(identity), find.cursor});
-         auto& obj = val.get_object();
-         if (obj["property"].as_string() == property && obj["trusted"].as_uint64() == trusted && obj["certifier"].as_string() == certifier) {
+         auto cache = chaindb.get_cache_object({N(identity), identity, N(certs)}, find.pk, true);
+         auto val = cache->object().value;
+         if (val["property"].as_string() == property && val["trusted"].as_uint64() == trusted && val["certifier"].as_string() == certifier) {
              return val;
          }
       }

--- a/unittests/tic_tac_toe_tests.cpp
+++ b/unittests/tic_tac_toe_tests.cpp
@@ -52,7 +52,7 @@ namespace fc {
 
 struct ttt_tester : TESTER {
    void get_game(game& game, account_name scope, account_name key) {
-      auto value = control->chaindb().value_by_pk({N(tic.tac.toe), scope, N(games)}, key.value);
+      auto value = control->chaindb().object_by_pk({N(tic.tac.toe), scope, N(games)}, key.value).value;
       fc::from_variant(value, game);
    }
 };


### PR DESCRIPTION
Resolve #817:
- Implement cache for unsuccess finds. It works only for lower_bound
- Refactor cache_map

Resolve #818:
- Add skipping of removed objects in already opened cursors, because mongodb-client get objects from server by bulks, which can contain opened cursors

Resolve #640:
- Add strategy for interchain cursors.  In same cases we can return result without create cursor to mongodb

Additional changes:
- Change lifecycle of non-in-ram objects. 
- Apply changes to DB on transaction squash, not on each exec.