### PR TITLE
Restore objects on throwing exception in modifier before undo. #859

### DIFF
--- a/Docker/builder/Dockerfile
+++ b/Docker/builder/Dockerfile
@@ -8,20 +8,20 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y sudo wget curl net-tools ca-certificates unzip gnupg
 
-RUN echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" >> /etc/apt/sources.list.d/llvm.list \
+RUN echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" >> /etc/apt/sources.list.d/llvm.list \
   && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add - \
   && apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y git-core sudo ruby curl \
      llvm-4.0 llvm-4.0-dev clang-4.0 libclang-4.0-dev  \
-     llvm-5.0 llvm-5.0-dev clang-5.0 libclang-5.0-dev \
+     llvm-7 llvm-7-dev clang-7 libclang-7-dev libclang-common-7-dev libllvm7 \
      make automake autoconf libtool doxygen graphviz autotools-dev build-essential \
      python2.7 python2.7-dev python3 python3-dev \
      libbz2-dev libssl-dev libusb-1.0-0-dev libcurl4-gnutls-dev libgmp-dev libgmp3-dev libicu-dev zlib1g-dev \
      pkg-config ninja-build mpi-default-dev\
   && rm -rf /var/lib/apt/lists/*
 
-RUN update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-5.0/bin/clang 400 \
-  && update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-5.0/bin/clang++ 400
+RUN update-alternatives --install /usr/bin/clang clang /usr/lib/llvm-7/bin/clang 400 \
+  && update-alternatives --install /usr/bin/clang++ clang++ /usr/lib/llvm-7/bin/clang++ 400
 
 RUN wget https://cmake.org/files/v3.9/cmake-3.9.6-Linux-x86_64.sh \
     && bash cmake-3.9.6-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir --skip-license \
@@ -33,7 +33,7 @@ ENV CXX clang++
 RUN wget https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2 -O - | tar -xj \
     && cd boost_1_67_0 \
     && ./bootstrap.sh --prefix=/usr/local \
-    && echo 'using clang : 5.0 : clang++-5.0 ;' >> project-config.jam \
+    && echo 'using clang : 7.1 : clang++-7 ;' >> project-config.jam \
     && ./b2 -d0 -j$(nproc) --with-thread --with-date_time --with-system --with-filesystem --with-program_options \
        --with-signals --with-serialization --with-chrono --with-test --with-context --with-locale --with-coroutine --with-iostreams toolset=clang link=static install \
     && cd .. && rm -rf boost_1_67_0

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -446,10 +446,15 @@ namespace cyberway { namespace chaindb {
             auto obj   = object_value{table.to_service(cache_obj.pk()), std::move(value)};
 
             storage.in_ram = cache_obj.service().in_ram;
-            auto delta = update(table, std::move(storage), obj, cache_obj.object());
-            cache_.set_object(table, cache_obj, std::move(obj));
-
-            return delta;
+            try {
+                auto delta = update(table, std::move(storage), obj, cache_obj.object());
+                cache_.set_object(table, cache_obj, std::move(obj));
+                return delta;
+            } catch (...) {
+                // case of throwing in storage_payer_info::add_usage
+                cache_.set_object(table, cache_obj, cache_obj.object());
+                throw;
+            }
         }
 
         void change_ram_state(cache_object& cache_obj, storage_payer_info storage) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,12 +5,6 @@ if( GPERFTOOLS_FOUND )
     list( APPEND PLATFORM_SPECIFIC_LIBS tcmalloc )
 endif()
 
-find_package(LLVM 5.0 REQUIRED CONFIG)
-
-link_directories(${LLVM_LIBRARY_DIR})
-
-set( CMAKE_CXX_STANDARD 17 )
-
 include_directories("${CMAKE_SOURCE_DIR}/plugins/wallet_plugin/include")
 
 file(GLOB UNIT_TESTS "*.cpp")

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -6,12 +6,6 @@ if( GPERFTOOLS_FOUND )
     list( APPEND PLATFORM_SPECIFIC_LIBS tcmalloc )
 endif()
 
-find_package(LLVM 5.0 REQUIRED CONFIG)
-
-link_directories(${LLVM_LIBRARY_DIR})
-
-set( CMAKE_CXX_STANDARD 17 )
-
 add_subdirectory(contracts)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/config.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/include/config.hpp ESCAPE_QUOTES)


### PR DESCRIPTION
Resolve #859:
- if error happens in modifier there is no information to restore object in undo-state. for such exceptions the original value is manually restored from cache_object.

Additional changes:
- switch compiler in docker to clang-7