### PR TITLE
Add additional funds to genesis (via genesis-info) #875

### DIFF
--- a/programs/create-genesis/genesis_info.hpp
+++ b/programs/create-genesis/genesis_info.hpp
@@ -173,11 +173,18 @@ struct genesis_info {
         uint32_t version;       // High byte is major version, next one is hardfork version, low 16bits are revision
         time_point_sec time;
     };
+    struct funds_share {
+        account_name name;
+        // value multiplied to base CYBER supply. use num/denom to avoid floating point
+        int64_t numerator;
+        int64_t denominator;
+    };
 
     struct parameters {
         stake_params stake;
         posting_rules posting_rules;
         fc::optional<hardfork_info> require_hardfork;
+        std::vector<funds_share> funds;
     } params;
 };
 
@@ -199,5 +206,6 @@ FC_REFLECT(cyberway::genesis::genesis_info::golos_config,
 FC_REFLECT(cyberway::genesis::genesis_info::stake_params,
     (enabled)(max_proxies)(payout_step_length)(payout_steps_num)(min_own_staked_for_election))
 FC_REFLECT(cyberway::genesis::genesis_info::hardfork_info, (version)(time))
-FC_REFLECT(cyberway::genesis::genesis_info::parameters, (stake)(posting_rules)(require_hardfork))
+FC_REFLECT(cyberway::genesis::genesis_info::funds_share, (name)(numerator)(denominator))
+FC_REFLECT(cyberway::genesis::genesis_info::parameters, (stake)(posting_rules)(require_hardfork)(funds))
 FC_REFLECT(cyberway::genesis::genesis_info, (state_file)(genesis_json)(accounts)(auth_links)(tables)(golos)(params))

--- a/programs/create-genesis/main.cpp
+++ b/programs/create-genesis/main.cpp
@@ -153,7 +153,7 @@ void config_reader::read_config(const variables_map& options) {
     make_absolute(info.state_file, "Golos state");
     make_absolute(info.genesis_json, "Genesis json");
     genesis = fc::json::from_file(info.genesis_json).as<genesis_state>();
-    
+
     std::cout << "Initial configuration = {" << std::endl << genesis.initial_configuration << "}" << std::endl;
 
     // base validation and init
@@ -166,6 +166,9 @@ void config_reader::read_config(const variables_map& options) {
     }
     EOS_ASSERT(info.golos.max_supply >= 0, genesis_exception, "max_supply can't be negative");
     EOS_ASSERT(info.golos.sys_max_supply >= 0, genesis_exception, "sys_max_supply can't be negative");
+    for (const auto& f: info.params.funds) {
+        EOS_ASSERT(f.numerator * f.denominator != 0, genesis_exception, "funds numerator & denominator must not be 0");
+    }
 }
 
 void config_reader::read_contracts() {


### PR DESCRIPTION
sample config:
```json
{
    "params": {
        "funds": [
            {"name": "cyber.appfund", "numerator":1, "denominator":1},
            {"name": "cyber.devs",    "numerator":2, "denominator":9}
        ]
    }
}
```