### PR TITLE
Send info about transaction scheduled from smart-contract #853

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -416,6 +416,7 @@ void apply_context::schedule_deferred_transaction( const uint128_t& sender_id, a
             gtx.expiration  = gtx.delay_until + fc::seconds(control.get_global_properties().configuration.deferred_trx_expiration_window);
 
             trx_size = gtx.set( trx );
+            push_event({name(), name("senddeferred"), fc::raw::pack(generated_transaction(gtx))});
          });
    } else {
       chaindb.emplace<generated_transaction_object>( get_storage_payer(owner), [&]( auto& gtx ) {
@@ -427,6 +428,7 @@ void apply_context::schedule_deferred_transaction( const uint128_t& sender_id, a
             gtx.expiration  = gtx.delay_until + fc::seconds(control.get_global_properties().configuration.deferred_trx_expiration_window);
 
             trx_size = gtx.set( trx );
+            push_event({name(), name("senddeferred"), fc::raw::pack(generated_transaction(gtx))});
          });
    }
 
@@ -443,6 +445,7 @@ bool apply_context::cancel_deferred_transaction( const uint128_t& sender_id, acc
 // TODO: Removed by CyberWay
 //      add_ram_usage( gto->payer, -(config::billable_size_v<generated_transaction_object> + gto->packed_trx.size()) );
       trx_table.erase(*gto, get_storage_payer());
+      push_event({name(), name("canceldefer"), fc::raw::pack(std::make_pair(sender, sender_id))});
    }
    return gto;
 }

--- a/libraries/chain/include/eosio/chain/event.hpp
+++ b/libraries/chain/include/eosio/chain/event.hpp
@@ -10,8 +10,6 @@ struct event {
     account_name   account;
     event_name     name;
     bytes          data;
-
-    event() {}
 };
 
 } } // namespace eosio::chain

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -222,6 +222,8 @@ namespace eosio { namespace chain {
                                     3050008, "Abort Called" )
       FC_DECLARE_DERIVED_EXCEPTION( inline_action_too_big, action_validate_exception,
                                     3050009, "Inline Action exceeds maximum size limit" )
+      FC_DECLARE_DERIVED_EXCEPTION( event_not_valid, action_validate_exception,
+                                    3050010, "Event not valid" )
 
    FC_DECLARE_DERIVED_EXCEPTION( database_exception, chain_exception,
                                  3060000, "Database exception" )

--- a/libraries/chain/include/eosio/chain/generated_transaction_object.hpp
+++ b/libraries/chain/include/eosio/chain/generated_transaction_object.hpp
@@ -89,6 +89,7 @@ namespace eosio { namespace chain {
 
          generated_transaction(const generated_transaction& gt) = default;
          generated_transaction(generated_transaction&& gt) = default;
+         generated_transaction() = default;
 
          transaction_id_type           trx_id;
          account_name                  sender;
@@ -112,3 +113,4 @@ namespace eosio { namespace chain {
 CHAINDB_SET_TABLE_TYPE(eosio::chain::generated_transaction_object, eosio::chain::generated_transaction_table)
 CHAINDB_TAG(eosio::chain::generated_transaction_object, gtransaction)
 FC_REFLECT(eosio::chain::generated_transaction_object, (id)(trx_id)(sender)(sender_id)(delay_until)(expiration)(published)(packed_trx))
+FC_REFLECT(eosio::chain::generated_transaction, (trx_id)(sender)(sender_id)(delay_until)(expiration)(published)(packed_trx))

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -1387,6 +1387,7 @@ class event_api : public context_aware_api {
         void send_event( array_ptr<char> data, size_t data_len ) {
             event evt;
             fc::raw::unpack<event>(data, data_len, evt);
+            EOS_ASSERT(evt.account != name(), event_not_valid, "Contract can't send event with empty account");
             context.push_event(std::move(evt));
         }
 };


### PR DESCRIPTION
1. `apply_context::schedule_deferred_transaction` send `:senddeferred` action with `generated_transaction_object`. This object has unpacked actions arguments.
```
            "events": [
                {
                    "args": {
                        "delay_until": "2019-07-02T02:38:26.000",
                        "expiration": "2019-07-02T02:48:26.000",
                        "packed_trx": "9dc31a5da63b91caa1fb00000000050001000000000090b1ca000000000088544301000000000090b1ca00000000a8ed323208010000000000000000",
                        "published": "2019-07-02T02:38:21.000",
                        "sender": "test",
                        "sender_id": 12341,
                        "trx": {
                            "actions": [
                                {
                                    "account": "test",
                                    "authorization": [
                                        {
                                            "actor": "test",
                                            "permission": "active"
                                        }
                                    ],
                                    "data": {
                                        "arg": 1
                                    },
                                    "hex_data": "0100000000000000",
                                    "name": "check"
                                }
                            ],
                            "context_free_actions": [],
                            "delay_sec": 5,
                            "expiration": "2019-07-02T02:38:21.000",
                            "max_cpu_usage_ms": 0,
                            "max_net_usage_words": 0,
                            "max_ram_kbytes": 0,
                            "max_storage_kbytes": 0,
                            "ref_block_num": 15270,
                            "ref_block_prefix": 4221684369,
                            "transaction_extensions": []
                        },
                        "trx_id": "dfb78561485748624a663ff01ab3cced5db807167ca12b93453ed711a80179e0"
                    },
                    "code": "",
                    "data": "",
                    "event": "senddeferred"
                }
            ],
```
2. `apply_context::cancel_deferred_transaction` send `:canceldefer` action with `sender` and `sender_id`
```
            "events": [
                {
                    "args": {
                        "sender": "test",
                        "sender_id": 123411
                    },
                    "code": "",
                    "data": "",
                    "event": "canceldefer"
                }
            ],
```
3. Disable send events from smart-contract with empty account.