### PR TITLE
Add wallet data to EE-genesis  #855 #889 #890 #891 #892

### DIFF
--- a/programs/create-genesis/config.hpp
+++ b/programs/create-genesis/config.hpp
@@ -1,8 +1,6 @@
 #pragma once
 #include <eosio/chain/name.hpp>
 
-#define EE_TRANSFER_HISTORY_DAYS 30
-
 namespace cyberway { namespace genesis {
 
 constexpr auto GBG = SY(3,GBG);

--- a/programs/create-genesis/config.hpp
+++ b/programs/create-genesis/config.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <eosio/chain/name.hpp>
 
+#define EE_TRANSFER_HISTORY_DAYS 30
 
 namespace cyberway { namespace genesis {
 

--- a/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
+++ b/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
@@ -91,6 +91,43 @@ static abi_def create_delegations_abi() {
     return abi;
 }
 
+static abi_def create_rewards_abi() {
+    abi_def abi;
+    abi.version = ABI_VERSION;
+
+    abi.structs.emplace_back( struct_def {
+        "author_reward", "", {
+            {"author", "name"},
+            {"permlink", "string"},
+            {"sbd_and_steem_payout", "asset"},
+            {"vesting_payout", "asset"},
+            {"time", "time_point_sec"},
+        }
+    });
+
+    abi.structs.emplace_back( struct_def {
+        "curation_reward", "", {
+            {"curator", "name"},
+            {"reward", "asset"},
+            {"comment_author", "name"},
+            {"comment_permlink", "string"},
+            {"time", "time_point_sec"},
+        }
+    });
+
+    abi.structs.emplace_back( struct_def {
+        "delegation_reward", "", {
+            {"delegator", "name"},
+            {"delegatee", "name"},
+            {"payout_strategy", "uint8"},
+            {"reward", "asset"},
+            {"time", "time_point_sec"},
+        }
+    });
+
+    return abi;
+}
+
 static abi_def create_balance_convert_abi() {
     abi_def abi;
     abi.version = ABI_VERSION;
@@ -200,6 +237,7 @@ void event_engine_genesis::start(const bfs::path& ee_directory, const fc::sha256
         {ee_ser_type::messages,    {"messages.dat",    create_messages_abi()}},
         {ee_ser_type::transfers,   {"transfers.dat",   create_transfers_abi()}},
         {ee_ser_type::delegations, {"delegations.dat", create_delegations_abi()}},
+        {ee_ser_type::rewards,     {"rewards.dat",     create_rewards_abi()}},
         {ee_ser_type::pinblocks,   {"pinblocks.dat",   create_pinblocks_abi()}},
         {ee_ser_type::accounts,    {"accounts.dat",    create_accounts_abi()}},
         {ee_ser_type::witnesses,   {"witnesses.dat",   create_witnesses_abi()}},

--- a/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
+++ b/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
@@ -73,6 +73,22 @@ static abi_def create_transfers_abi() {
     return abi;
 }
 
+static abi_def create_withdraws_abi() {
+    abi_def abi;
+    abi.version = ABI_VERSION;
+
+    abi.structs.emplace_back( struct_def {
+        "withdraw", "", {
+            {"from", "name"},
+            {"to", "name"},
+            {"quantity", "asset"},
+            {"time", "time_point_sec"},
+        }
+    });
+
+    return abi;
+}
+
 static abi_def create_delegations_abi() {
     abi_def abi;
     abi.version = ABI_VERSION;
@@ -236,6 +252,7 @@ void event_engine_genesis::start(const bfs::path& ee_directory, const fc::sha256
     const std::map<ee_ser_type, ser_info> infos = {
         {ee_ser_type::messages,    {"messages.dat",    create_messages_abi()}},
         {ee_ser_type::transfers,   {"transfers.dat",   create_transfers_abi()}},
+        {ee_ser_type::withdraws,   {"withdraws.dat",   create_withdraws_abi()}},
         {ee_ser_type::delegations, {"delegations.dat", create_delegations_abi()}},
         {ee_ser_type::rewards,     {"rewards.dat",     create_rewards_abi()}},
         {ee_ser_type::pinblocks,   {"pinblocks.dat",   create_pinblocks_abi()}},

--- a/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
+++ b/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
@@ -73,6 +73,24 @@ static abi_def create_transfers_abi() {
     return abi;
 }
 
+static abi_def create_delegations_abi() {
+    abi_def abi;
+    abi.version = ABI_VERSION;
+
+    abi.structs.emplace_back( struct_def {
+        "delegate", "", {
+            {"from", "name"},
+            {"to", "name"},
+            {"quantity", "asset"},
+            {"interest_rate", "uint16"},
+            {"payout_strategy", "uint8"},
+            {"time", "time_point_sec"},
+        }
+    });
+
+    return abi;
+}
+
 static abi_def create_balance_convert_abi() {
     abi_def abi;
     abi.version = ABI_VERSION;
@@ -130,6 +148,7 @@ static abi_def create_accounts_abi() {
             {"balance", "asset"},
             {"balance_in_sys", "asset"},
             {"vesting_shares", "asset"},
+            {"received_vesting_shares", "asset"},
             {"json_metadata", "string"},
         }
     });
@@ -178,12 +197,13 @@ static abi_def create_funds_abi() {
 void event_engine_genesis::start(const bfs::path& ee_directory, const fc::sha256& hash) {
     using ser_info = std::tuple<string, abi_def>;
     const std::map<ee_ser_type, ser_info> infos = {
-        {ee_ser_type::messages,  {"messages.dat",   create_messages_abi()}},
-        {ee_ser_type::transfers, {"transfers.dat",  create_transfers_abi()}},
-        {ee_ser_type::pinblocks, {"pinblocks.dat",  create_pinblocks_abi()}},
-        {ee_ser_type::accounts,  {"accounts.dat",   create_accounts_abi()}},
-        {ee_ser_type::witnesses,  {"witnesses.dat",   create_witnesses_abi()}},
-        {ee_ser_type::funds,     {"funds.dat",      create_funds_abi()}},
+        {ee_ser_type::messages,    {"messages.dat",    create_messages_abi()}},
+        {ee_ser_type::transfers,   {"transfers.dat",   create_transfers_abi()}},
+        {ee_ser_type::delegations, {"delegations.dat", create_delegations_abi()}},
+        {ee_ser_type::pinblocks,   {"pinblocks.dat",   create_pinblocks_abi()}},
+        {ee_ser_type::accounts,    {"accounts.dat",    create_accounts_abi()}},
+        {ee_ser_type::witnesses,   {"witnesses.dat",   create_witnesses_abi()}},
+        {ee_ser_type::funds,       {"funds.dat",       create_funds_abi()}},
         {ee_ser_type::balance_conversions, {"balance_conversions.dat", create_balance_convert_abi()}}
     };
     for (const auto& i: infos) {

--- a/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
+++ b/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
@@ -65,6 +65,7 @@ static abi_def create_transfers_abi() {
             {"to", "name"},
             {"quantity", "asset"},
             {"memo", "string"},
+            {"to_vesting", "bool"},
             {"time", "time_point_sec"},
         }
     });

--- a/programs/create-genesis/ee_genesis/event_engine_genesis.hpp
+++ b/programs/create-genesis/ee_genesis/event_engine_genesis.hpp
@@ -15,7 +15,7 @@ public:
     void start(const bfs::path& ee_directory, const fc::sha256& hash);
     void finalize();
 
-    enum ee_ser_type {messages, transfers, pinblocks, accounts, witnesses, funds, balance_conversions};
+    enum ee_ser_type {messages, transfers, delegations, pinblocks, accounts, witnesses, funds, balance_conversions};
     ee_genesis_serializer& get_serializer(ee_ser_type type) {
         return serializers.at(type);
     }

--- a/programs/create-genesis/ee_genesis/event_engine_genesis.hpp
+++ b/programs/create-genesis/ee_genesis/event_engine_genesis.hpp
@@ -16,7 +16,7 @@ public:
     void start(const bfs::path& ee_directory, const fc::sha256& hash);
     void finalize();
 
-    enum ee_ser_type {messages, transfers, delegations, rewards, pinblocks, accounts, witnesses, funds, balance_conversions};
+    enum ee_ser_type {messages, transfers, withdraws, delegations, rewards, pinblocks, accounts, witnesses, funds, balance_conversions};
     ee_genesis_serializer& get_serializer(ee_ser_type type) {
         return serializers.at(type);
     }
@@ -82,6 +82,15 @@ struct transfer_info {
     fc::time_point_sec time;
 };
 
+struct withdraw_info {
+    OBJECT_CTOR(withdraw_info);
+
+    name from;
+    name to;
+    asset quantity;
+    fc::time_point_sec time;
+};
+
 struct author_reward {
     OBJECT_CTOR(author_reward);
 
@@ -142,6 +151,7 @@ FC_REFLECT(cyberway::genesis::ee::comment_info, (parent_author)(parent_permlink)
     (title)(body)(tags)(language)(net_rshares)(rewardweight)(max_payout)(benefics_prcnt)(curators_prcnt)(tokenprop)(archived)
     (author_reward)(benefactor_reward)(curator_reward)(votes)(reblogs))
 FC_REFLECT(cyberway::genesis::ee::transfer_info, (from)(to)(quantity)(memo)(to_vesting)(time))
+FC_REFLECT(cyberway::genesis::ee::withdraw_info, (from)(to)(quantity)(time))
 FC_REFLECT(cyberway::genesis::ee::author_reward, (author)(permlink)(sbd_and_steem_payout)(vesting_payout)(time))
 FC_REFLECT(cyberway::genesis::ee::curation_reward, (curator)(reward)(comment_author)(comment_permlink)(time))
 FC_REFLECT(cyberway::genesis::ee::delegation_reward, (delegator)(delegatee)(payout_strategy)(reward)(time))

--- a/programs/create-genesis/ee_genesis/event_engine_genesis.hpp
+++ b/programs/create-genesis/ee_genesis/event_engine_genesis.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ee_genesis_serializer.hpp"
+#include "golos_operations.hpp"
 #include <fc/crypto/sha256.hpp>
 
 namespace cyberway { namespace genesis { namespace ee {
@@ -15,7 +16,7 @@ public:
     void start(const bfs::path& ee_directory, const fc::sha256& hash);
     void finalize();
 
-    enum ee_ser_type {messages, transfers, delegations, pinblocks, accounts, witnesses, funds, balance_conversions};
+    enum ee_ser_type {messages, transfers, delegations, rewards, pinblocks, accounts, witnesses, funds, balance_conversions};
     ee_genesis_serializer& get_serializer(ee_ser_type type) {
         return serializers.at(type);
     }
@@ -81,6 +82,36 @@ struct transfer_info {
     fc::time_point_sec time;
 };
 
+struct author_reward {
+    OBJECT_CTOR(author_reward);
+
+    name author;
+    string permlink;
+    asset sbd_and_steem_payout;
+    asset vesting_payout;
+    fc::time_point_sec time;
+};
+
+struct curation_reward {
+    OBJECT_CTOR(curation_reward);
+
+    name curator;
+    asset reward;
+    name comment_author;
+    string comment_permlink;
+    fc::time_point_sec time;
+};
+
+struct delegation_reward {
+    OBJECT_CTOR(delegation_reward);
+
+    name delegator;
+    name delegatee;
+    cyberway::golos::ee::delegator_payout_strategy payout_strategy;
+    asset reward;
+    fc::time_point_sec time;
+};
+
 struct balance_convert_info {
     OBJECT_CTOR(balance_convert_info);
 
@@ -111,6 +142,9 @@ FC_REFLECT(cyberway::genesis::ee::comment_info, (parent_author)(parent_permlink)
     (title)(body)(tags)(language)(net_rshares)(rewardweight)(max_payout)(benefics_prcnt)(curators_prcnt)(tokenprop)(archived)
     (author_reward)(benefactor_reward)(curator_reward)(votes)(reblogs))
 FC_REFLECT(cyberway::genesis::ee::transfer_info, (from)(to)(quantity)(memo)(to_vesting)(time))
+FC_REFLECT(cyberway::genesis::ee::author_reward, (author)(permlink)(sbd_and_steem_payout)(vesting_payout)(time))
+FC_REFLECT(cyberway::genesis::ee::curation_reward, (curator)(reward)(comment_author)(comment_permlink)(time))
+FC_REFLECT(cyberway::genesis::ee::delegation_reward, (delegator)(delegatee)(payout_strategy)(reward)(time))
 FC_REFLECT(cyberway::genesis::ee::balance_convert_info, (owner)(amount)(memo))
 FC_REFLECT(cyberway::genesis::ee::pin_info, (pinner)(pinning))
 FC_REFLECT(cyberway::genesis::ee::block_info, (blocker)(blocking))

--- a/programs/create-genesis/ee_genesis/event_engine_genesis.hpp
+++ b/programs/create-genesis/ee_genesis/event_engine_genesis.hpp
@@ -77,6 +77,7 @@ struct transfer_info {
     name to;
     asset quantity;
     string memo;
+    bool to_vesting;
     fc::time_point_sec time;
 };
 
@@ -109,7 +110,7 @@ FC_REFLECT(cyberway::genesis::ee::reblog_info, (account)(title)(body)(time))
 FC_REFLECT(cyberway::genesis::ee::comment_info, (parent_author)(parent_permlink)(author)(permlink)(created)(last_update)
     (title)(body)(tags)(language)(net_rshares)(rewardweight)(max_payout)(benefics_prcnt)(curators_prcnt)(tokenprop)(archived)
     (author_reward)(benefactor_reward)(curator_reward)(votes)(reblogs))
-FC_REFLECT(cyberway::genesis::ee::transfer_info, (from)(to)(quantity)(memo)(time))
+FC_REFLECT(cyberway::genesis::ee::transfer_info, (from)(to)(quantity)(memo)(to_vesting)(time))
 FC_REFLECT(cyberway::genesis::ee::balance_convert_info, (owner)(amount)(memo))
 FC_REFLECT(cyberway::genesis::ee::pin_info, (pinner)(pinning))
 FC_REFLECT(cyberway::genesis::ee::block_info, (blocker)(blocking))

--- a/programs/create-genesis/ee_genesis/genesis_ee_builder.cpp
+++ b/programs/create-genesis/ee_genesis/genesis_ee_builder.cpp
@@ -498,6 +498,16 @@ void genesis_ee_builder::write_transfers() {
     }
 }
 
+void genesis_ee_builder::write_delegations() {
+    std::cout << "-> Writing delegations..." << std::endl;
+    auto& out = out_.get_serializer(event_engine_genesis::delegations);
+    out.start_section(info_.golos.names.vesting, N(delegate), "delegate");
+
+    for (auto& d : exp_info_.delegations) {
+        out.insert(d);
+    }
+}
+
 void genesis_ee_builder::write_pinblocks() {
     if (!dump_follows.is_open()) {
         return;
@@ -619,6 +629,7 @@ void genesis_ee_builder::build(const bfs::path& out_dir) {
 
     write_messages();
     write_transfers();
+    write_delegations();
     write_pinblocks();
     write_accounts();
     write_witnesses();

--- a/programs/create-genesis/ee_genesis/genesis_ee_builder.cpp
+++ b/programs/create-genesis/ee_genesis/genesis_ee_builder.cpp
@@ -15,10 +15,6 @@
 // 2300000 * 160 = 0.4 GB
 #define MAP_FILE_SIZE uint64_t(22*1024)*MEGABYTE
 
-#define TRANSFER_HISTORY_DAYS 30
-#define WITHDRAW_HISTORY_DAYS 30
-#define REWARD_HISTORY_DAYS   1
-
 namespace cyberway { namespace genesis { namespace ee {
 
 genesis_ee_builder::genesis_ee_builder(
@@ -514,7 +510,7 @@ void genesis_ee_builder::write_transfers() {
     out.start_section(config::token_account_name, N(transfer), "transfer");
 
     auto start_time = genesis_.get_conf().initial_timestamp;
-    start_time -= fc::days(TRANSFER_HISTORY_DAYS);
+    start_time -= fc::days(info_.ee_params.history_days.transfers);
 
     transfer_operation op;
     while (read_operation(dump_transfers, op)) {
@@ -542,7 +538,7 @@ void genesis_ee_builder::write_withdraws() {
     out.start_section(info_.golos.names.vesting, N(withdraw), "withdraw");
 
     auto start_time = genesis_.get_conf().initial_timestamp;
-    start_time -= fc::days(WITHDRAW_HISTORY_DAYS);
+    start_time -= fc::days(info_.ee_params.history_days.withdraws);
 
     fill_vesting_withdraw_operation op;
     while (read_operation(dump_vesting_withdraws, op)) {
@@ -573,7 +569,7 @@ void genesis_ee_builder::write_rewards_history() {
     auto& out = out_.get_serializer(event_engine_genesis::rewards);
 
     auto start_time = genesis_.get_conf().initial_timestamp;
-    start_time -= fc::days(REWARD_HISTORY_DAYS);
+    start_time -= fc::days(info_.ee_params.history_days.rewards);
 
     if (dump_author_rewards.is_open()) {
         std::cout << "-> Writing author rewards..." << std::endl;

--- a/programs/create-genesis/ee_genesis/genesis_ee_builder.hpp
+++ b/programs/create-genesis/ee_genesis/genesis_ee_builder.hpp
@@ -35,6 +35,7 @@ private:
     void process_reblogs();
     void process_delete_reblogs();
     void process_transfers();
+    void process_rewards_history();
     void process_follows();
     void process_account_metas();
 
@@ -43,6 +44,7 @@ private:
     void write_messages();
     void write_transfers();
     void write_delegations();
+    void write_rewards_history();
     void write_pinblocks();
     void write_accounts();
     void write_witnesses();
@@ -56,6 +58,9 @@ private:
     bfs::ifstream dump_reblogs;
     bfs::ifstream dump_delete_reblogs;
     bfs::ifstream dump_transfers;
+    bfs::ifstream dump_author_rewards;
+    bfs::ifstream dump_curation_rewards;
+    bfs::ifstream dump_delegation_rewards;
     bfs::ifstream dump_follows;
     bfs::ifstream dump_metas;
 

--- a/programs/create-genesis/ee_genesis/genesis_ee_builder.hpp
+++ b/programs/create-genesis/ee_genesis/genesis_ee_builder.hpp
@@ -42,6 +42,7 @@ private:
     void build_reblogs(std::vector<reblog_info>& reblogs, uint64_t msg_hash, operation_number msg_created, bfs::ifstream& dump_reblogs);
     void write_messages();
     void write_transfers();
+    void write_delegations();
     void write_pinblocks();
     void write_accounts();
     void write_witnesses();

--- a/programs/create-genesis/ee_genesis/genesis_ee_builder.hpp
+++ b/programs/create-genesis/ee_genesis/genesis_ee_builder.hpp
@@ -35,6 +35,7 @@ private:
     void process_reblogs();
     void process_delete_reblogs();
     void process_transfers();
+    void process_withdraws();
     void process_rewards_history();
     void process_follows();
     void process_account_metas();
@@ -43,6 +44,7 @@ private:
     void build_reblogs(std::vector<reblog_info>& reblogs, uint64_t msg_hash, operation_number msg_created, bfs::ifstream& dump_reblogs);
     void write_messages();
     void write_transfers();
+    void write_withdraws();
     void write_delegations();
     void write_rewards_history();
     void write_pinblocks();
@@ -58,6 +60,7 @@ private:
     bfs::ifstream dump_reblogs;
     bfs::ifstream dump_delete_reblogs;
     bfs::ifstream dump_transfers;
+    bfs::ifstream dump_vesting_withdraws;
     bfs::ifstream dump_author_rewards;
     bfs::ifstream dump_curation_rewards;
     bfs::ifstream dump_delegation_rewards;

--- a/programs/create-genesis/ee_genesis/golos_operations.hpp
+++ b/programs/create-genesis/ee_genesis/golos_operations.hpp
@@ -66,6 +66,13 @@ struct transfer_operation : operation {
     fc::time_point_sec timestamp;
 };
 
+struct fill_vesting_withdraw_operation : operation {
+    account_name_type from_account;
+    account_name_type to_account;
+    asset deposited;
+    fc::time_point_sec timestamp;
+};
+
 enum follow_type {
     undefined,
     blog,
@@ -134,6 +141,8 @@ REFLECT_OP_HASHED(cyberway::golos::ee::reblog_operation, (account)(author)(perml
 REFLECT_OP_HASHED(cyberway::golos::ee::delete_reblog_operation, (account))
 
 REFLECT_OP(cyberway::golos::ee::transfer_operation, (from)(to)(amount)(memo)(to_vesting)(timestamp))
+
+REFLECT_OP(cyberway::golos::ee::fill_vesting_withdraw_operation, (from_account)(to_account)(deposited)(timestamp))
 
 REFLECT_OP_HASHED(cyberway::golos::ee::follow_operation, (follower)(following)(what))
 

--- a/programs/create-genesis/ee_genesis/golos_operations.hpp
+++ b/programs/create-genesis/ee_genesis/golos_operations.hpp
@@ -61,6 +61,7 @@ struct transfer_operation : operation {
     /// The memo is plain-text, any encryption on the memo is up to
     /// a higher level protocol.
     string memo;
+    bool to_vesting;
     fc::time_point_sec timestamp;
 };
 
@@ -130,7 +131,7 @@ REFLECT_OP_HASHED(cyberway::golos::ee::reblog_operation, (account)(author)(perml
 
 REFLECT_OP_HASHED(cyberway::golos::ee::delete_reblog_operation, (account))
 
-REFLECT_OP(cyberway::golos::ee::transfer_operation, (from)(to)(amount)(memo)(timestamp))
+REFLECT_OP(cyberway::golos::ee::transfer_operation, (from)(to)(amount)(memo)(to_vesting)(timestamp))
 
 REFLECT_OP_HASHED(cyberway::golos::ee::follow_operation, (follower)(following)(what))
 

--- a/programs/create-genesis/ee_genesis/golos_operations.hpp
+++ b/programs/create-genesis/ee_genesis/golos_operations.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "golos_dump_container.hpp"
 #include <eosio/chain/asset.hpp>
 #include <fc/fixed_string.hpp>
 #include <fc/container/flat_fwd.hpp>
@@ -80,29 +81,30 @@ struct follow_operation : hashed_operation {
 struct author_reward_operation : hashed_operation {
     account_name_type author;
     string permlink;
-    asset sbd_payout;
-    asset steem_payout;
-    asset vesting_payout;
-};
-
-struct comment_benefactor_reward_operation : hashed_operation {
-    account_name_type benefactor;
-    account_name_type author;
-    string permlink;
-    asset reward;
+    asset sbd_and_steem_in_golos;
+    asset vesting_payout_in_golos;
+    fc::time_point_sec timestamp;
 };
 
 struct curation_reward_operation : hashed_operation {
     account_name_type curator;
-    asset reward;
+    asset reward_in_golos;
     account_name_type comment_author;
     string comment_permlink;
+    fc::time_point_sec timestamp;
 };
 
-struct auction_window_reward_operation : hashed_operation {
-    asset reward;
-    account_name_type comment_author;
-    string comment_permlink;
+enum delegator_payout_strategy {
+    to_delegator,
+    to_delegated_vesting
+};
+
+struct delegation_reward_operation : operation {
+    account_name_type delegator;
+    account_name_type delegatee;
+    delegator_payout_strategy payout_strategy;
+    asset vesting_shares_in_golos;
+    fc::time_point_sec timestamp;
 };
 
 struct total_comment_reward_operation : hashed_operation {
@@ -135,13 +137,12 @@ REFLECT_OP(cyberway::golos::ee::transfer_operation, (from)(to)(amount)(memo)(to_
 
 REFLECT_OP_HASHED(cyberway::golos::ee::follow_operation, (follower)(following)(what))
 
-REFLECT_OP_HASHED(cyberway::golos::ee::author_reward_operation, (author)(permlink)(sbd_payout)(steem_payout)(vesting_payout))
+REFLECT_OP_HASHED(cyberway::golos::ee::author_reward_operation, (author)(permlink)(sbd_and_steem_in_golos)(vesting_payout_in_golos)(timestamp))
 
-REFLECT_OP_HASHED(cyberway::golos::ee::curation_reward_operation, (curator)(reward)(comment_author)(comment_permlink))
+REFLECT_OP_HASHED(cyberway::golos::ee::curation_reward_operation, (curator)(reward_in_golos)(comment_author)(comment_permlink)(timestamp))
 
-REFLECT_OP_HASHED(cyberway::golos::ee::auction_window_reward_operation, (reward)(comment_author)(comment_permlink))
-
-REFLECT_OP_HASHED(cyberway::golos::ee::comment_benefactor_reward_operation, (benefactor)(author)(permlink)(reward))
+FC_REFLECT_ENUM(cyberway::golos::ee::delegator_payout_strategy, (to_delegator)(to_delegated_vesting))
+REFLECT_OP(cyberway::golos::ee::delegation_reward_operation, (delegator)(delegatee)(payout_strategy)(vesting_shares_in_golos)(timestamp))
 
 REFLECT_OP_HASHED(cyberway::golos::ee::total_comment_reward_operation, (author)(permlink)(author_reward)(benefactor_reward)(curator_reward)(net_rshares))
 

--- a/programs/create-genesis/export_info.hpp
+++ b/programs/create-genesis/export_info.hpp
@@ -69,6 +69,7 @@ struct export_info {
     std::vector<mvo> witness_events;
     std::vector<mvo> currency_stats;
     std::vector<mvo> balance_events;
+    std::vector<mvo> delegations;
     fc::flat_map<uint64_t, cyberway::golos::active_comment_data> active_comments;
 
     fc::flat_map<acc_idx, converted_info>* conv_gbg = nullptr;

--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -19,8 +19,6 @@
 // suppose name generation is slower than flat_map access by idx
 #define CACHE_GENERATED_NAMES
 
-#define EE_DELEGATION_HISTORY_DAYS 1
-
 namespace fc { namespace raw {
 
 template<typename T> void unpack(T& s, cyberway::golos::comment_object& c) {
@@ -806,7 +804,7 @@ struct genesis_create::genesis_create_impl final {
         db.start_section(_info.golos.names.vesting, N(delegation), "delegation", _visitor.delegations.size());
         primary_key_t pk = 0;
         auto ee_start_time = _conf.initial_timestamp;
-        ee_start_time -= fc::days(EE_DELEGATION_HISTORY_DAYS);
+        ee_start_time -= fc::days(_info.ee_params.history_days.delegations);
         for (const auto& d: _visitor.delegations) {
             auto delegator = name_by_acc(d.delegator);
             auto delegation = mvo

--- a/programs/create-genesis/genesis_info.hpp
+++ b/programs/create-genesis/genesis_info.hpp
@@ -186,6 +186,15 @@ struct genesis_info {
         fc::optional<hardfork_info> require_hardfork;
         std::vector<funds_share> funds;
     } params;
+
+    struct ee_parameters {
+        struct ee_history_days {
+            uint16_t transfers = 30;
+            uint16_t withdraws = 30;
+            uint16_t delegations = 30;
+            uint16_t rewards = 1;
+        } history_days;
+    } ee_params;
 };
 
 }} // cyberway::genesis
@@ -208,4 +217,6 @@ FC_REFLECT(cyberway::genesis::genesis_info::stake_params,
 FC_REFLECT(cyberway::genesis::genesis_info::hardfork_info, (version)(time))
 FC_REFLECT(cyberway::genesis::genesis_info::funds_share, (name)(numerator)(denominator))
 FC_REFLECT(cyberway::genesis::genesis_info::parameters, (stake)(posting_rules)(require_hardfork)(funds))
-FC_REFLECT(cyberway::genesis::genesis_info, (state_file)(genesis_json)(accounts)(auth_links)(tables)(golos)(params))
+FC_REFLECT(cyberway::genesis::genesis_info::ee_parameters::ee_history_days, (transfers)(withdraws)(delegations)(rewards))
+FC_REFLECT(cyberway::genesis::genesis_info::ee_parameters, (history_days))
+FC_REFLECT(cyberway::genesis::genesis_info, (state_file)(genesis_json)(accounts)(auth_links)(tables)(golos)(params)(ee_params))


### PR DESCRIPTION
Resolves #855 #889 #890 #891 #892

- Added transfers to vestings
- Added delegations history and field with  received ("Делегированные") vesting shares to accounts
- Added individual author, curator, delegation rewards
- Added vesting withdraws
- Added configurable limits on EE-genesis operations history length (rewards are 1 day, transfers, delegations and withdraws are 30 days)
- Rewards, transfers and withdraws have vesting amounts in GOLOS. Delegations and accounts have vesting amounts in VESTS. 

Note: there are changes in `genesis-info.json` but they are not breaking. `genesis-info.tmpl` can be updated  later.