### PR TITLE
Syncing nodes. #883

### DIFF
--- a/contracts/eosiolib/privileged.hpp
+++ b/contracts/eosiolib/privileged.hpp
@@ -34,7 +34,10 @@ namespace eosio {
    uint32_t   max_inline_action_size;              ///< maximum allowed size (in bytes) of an inline action
    uint16_t   max_inline_action_depth;             ///< recursion depth limit on sending inline actions
    uint16_t   max_authority_depth;                 ///< recursion depth limit for checking if an authority is satisfied
-   
+
+   uint64_t   ram_size;
+   uint64_t   reserved_ram_size;
+
    std::vector<uint64_t> max_block_usage;
    std::vector<uint64_t> max_transaction_usage;
    
@@ -58,6 +61,8 @@ namespace eosio {
 
            (max_transaction_lifetime)(deferred_trx_expiration_window)(max_transaction_delay)
            (max_inline_action_size)(max_inline_action_depth)(max_authority_depth)
+
+           (ram_size)(reserved_ram_size)
            
            (max_block_usage)(max_transaction_usage)
            

--- a/libraries/chain/chain_config.cpp
+++ b/libraries/chain/chain_config.cpp
@@ -15,6 +15,11 @@ namespace eosio { namespace chain {
          EOS_ASSERT( max_transaction_usage[i] < max_block_usage[i], action_validate_exception, "max transaction usage must be less than max block usage" );
       }
 
+      EOS_ASSERT( ram_size >= config::_GB, action_validate_exception,
+                  "RAM size can't be less than 1 GB");
+      EOS_ASSERT( reserved_ram_size * 2 <= ram_size, action_validate_exception,
+                  "Reserved RAM size can't be less than half of RAM size");
+
       EOS_ASSERT( context_free_discount_net_usage_den > 0, action_validate_exception,
                   "net usage discount ratio for context free data cannot have a 0 denominator" );
       EOS_ASSERT( context_free_discount_net_usage_num <= context_free_discount_net_usage_den, action_validate_exception,

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -5,8 +5,8 @@
 #include <cyberway/chaindb/table_info.hpp>
 #include <cyberway/chaindb/typed_name.hpp>
 
-#include <eosio/chain/resource_limits.hpp>
-#include <eosio/chain/resource_limits_private.hpp>
+#include <eosio/chain/int_arithmetic.hpp>
+#include <eosio/chain/global_property_object.hpp>
 
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/member.hpp>
@@ -892,10 +892,10 @@ namespace cyberway { namespace chaindb {
             add_ram_usage(cache_obj.cell(), delta);
 
             if (is_system_code(cache_obj.service().code)) {
-                using state_object = eosio::chain::resource_limits::resource_limits_state_object;
-                if (cache_obj.has_data() && cache_obj.service().table == chaindb::tag<state_object>::get_code()) {
-                    auto& state = multi_index_item_data<state_object>::get_T(cache_obj);
-                    ram_limit_ = get_ram_limit(state.ram_size, state.reserved_ram_size);
+                using global_property_object = eosio::chain::global_property_object;
+                if (cache_obj.has_data() && cache_obj.service().table == chaindb::tag<global_property_object>::get_code()) {
+                    auto& gpo = multi_index_item_data<global_property_object>::get_T(cache_obj);
+                    ram_limit_ = get_ram_limit(gpo.configuration.ram_size, gpo.configuration.reserved_ram_size);
                 }
             }
 

--- a/libraries/chain/chaindb/mongo_driver_utils.cpp
+++ b/libraries/chain/chaindb/mongo_driver_utils.cpp
@@ -8,6 +8,7 @@
 #include <cyberway/chaindb/mongo_asset_converter.hpp>
 #include <cyberway/chaindb/exception.hpp>
 #include <cyberway/chaindb/names.hpp>
+#include <cyberway/chaindb/noscope_tables.hpp>
 
 #include <fc/time.hpp>
 #include <fc/variant_object.hpp>
@@ -754,7 +755,9 @@ namespace cyberway { namespace chaindb {
     }
 
     sub_document& build_find_pk_document(sub_document& doc, const table_info& table, const object_value& obj) {
-        append_scope_value(doc, table);
+        if (!is_noscope_table(table)) {
+            append_scope_value(doc, table);
+        }
         append_pk_value(doc, table, obj.service.pk);
         return doc;
     }

--- a/libraries/chain/chaindb/undo_state.cpp
+++ b/libraries/chain/chaindb/undo_state.cpp
@@ -424,7 +424,7 @@ namespace cyberway { namespace chaindb {
             index.account_abi = controller_.get_account_abi_info(config::system_account_name);
             index.table = index.abi().find_table(N(undo));
             index.pk_order = index.abi().find_pk_order(*index.table);
-            index.index = index.abi().find_pk_index(*index.table);
+            index.index = index.abi().find_index(*index.table, tag<by_rev>::get_code());
 
             auto  account_table = tag<account_object>::get_code();
             auto& cursor = driver_.lower_bound(index, {});
@@ -480,7 +480,7 @@ namespace cyberway { namespace chaindb {
             index.account_abi = controller_.get_account_abi_info(config::system_account_name);
             index.table = index.abi().find_table(N(undo));
             index.pk_order = index.abi().find_pk_order(*index.table);
-            index.index = index.abi().find_pk_index(*index.table);
+            index.index = index.abi().find_index(*index.table, tag<by_rev>::get_code());
 
             auto& cursor = driver_.lower_bound(index, {});
             for (; cursor.pk != primary_key::End; driver_.next(cursor)) {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -9,7 +9,6 @@
 #include <eosio/chain/block_summary_object.hpp>
 #include <eosio/chain/eosio_contract.hpp>
 #include <eosio/chain/global_property_object.hpp>
-#include <eosio/chain/contract_table_objects.hpp>
 #include <eosio/chain/generated_transaction_object.hpp>
 #include <eosio/chain/transaction_object.hpp>
 #include <eosio/chain/reversible_block_object.hpp>
@@ -17,7 +16,6 @@
 #include <eosio/chain/authorization_manager.hpp>
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/stake.hpp>
-#include <eosio/chain/chain_snapshot.hpp>
 #include <eosio/chain/thread_utils.hpp>
 
 #include <chainbase/chainbase.hpp>

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -639,25 +639,6 @@ struct controller_impl {
       blocksum_table.modify( tapos_block_summary, [&]( auto& bs ) {
         bs.block_id = head->id;
       });
-      
-      conf.genesis.initial_configuration.max_block_usage = 
-        std::vector<uint64_t>(config::default_max_block_usage.begin(), config::default_max_block_usage.end());
-      conf.genesis.initial_configuration.max_transaction_usage = 
-        std::vector<uint64_t>(config::default_max_transaction_usage.begin(), config::default_max_transaction_usage.end());
-      conf.genesis.initial_configuration.target_virtual_limits = 
-        std::vector<uint64_t>(config::default_target_virtual_limits.begin(), config::default_target_virtual_limits.end());
-      conf.genesis.initial_configuration.min_virtual_limits = 
-        std::vector<uint64_t>(config::default_min_virtual_limits.begin(), config::default_min_virtual_limits.end());
-      conf.genesis.initial_configuration.max_virtual_limits = 
-        std::vector<uint64_t>(config::default_max_virtual_limits.begin(), config::default_max_virtual_limits.end());
-      conf.genesis.initial_configuration.usage_windows = 
-        std::vector<uint32_t>(config::default_usage_windows.begin(), config::default_usage_windows.end());
-      conf.genesis.initial_configuration.virtual_limit_decrease_pct = 
-        std::vector<uint16_t>(config::default_virtual_limit_decrease_pct.begin(), config::default_virtual_limit_decrease_pct.end());
-      conf.genesis.initial_configuration.virtual_limit_increase_pct = 
-        std::vector<uint16_t>(config::default_virtual_limit_increase_pct.begin(), config::default_virtual_limit_increase_pct.end());
-      conf.genesis.initial_configuration.account_usage_windows = 
-        std::vector<uint32_t>(config::default_account_usage_windows.begin(), config::default_account_usage_windows.end());
 
       conf.genesis.initial_configuration.validate();
       chaindb.emplace<global_property_object>([&](auto& gpo ){

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -206,6 +206,8 @@ abi_def eosio_contract_abi(abi_def eos_abi)
          {"max_inline_action_size", "uint32"},
          {"max_inline_action_depth", "uint16"},
          {"max_authority_depth", "uint16"},
+         {"ram_size", "uint64"},
+         {"reserved_ram_size", "uint64"},
          {"max_block_usage", "uint64[]"},
          {"max_transaction_usage", "uint64[]"},
          {"target_virtual_limits", "uint64[]"},
@@ -461,9 +463,7 @@ abi_def eosio_contract_abi(abi_def eos_abi)
          {"id", "uint64"},
          {"block_usage_accumulators", "usage_accumulator[]"},
          {"pending_usage", "int64[]"},
-         {"virtual_limits", "uint64[]"},
-         {"ram_size", "uint64"},
-         {"reserved_ram_size", "uint64"}}
+         {"virtual_limits", "uint64[]"}}
    });
 
    eos_abi.tables.emplace_back( eosio::chain::table_def {

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -566,8 +566,7 @@ abi_def eosio_contract_abi(abi_def eos_abi)
    eos_abi.structs.emplace_back(struct_def{
       "_SERVICE_", "", {
          {"upk", "uint64"},
-         {"code", "uint64"},
-         {"table", "uint64"}}
+         {"rev", "int64"}}
    });
 
    eos_abi.structs.emplace_back(struct_def{
@@ -578,6 +577,7 @@ abi_def eosio_contract_abi(abi_def eos_abi)
    eos_abi.tables.emplace_back(table_def{
        "undo", "undo", "uint64", {
            {cyberway::chaindb::tag<by_id>::get_code(), true, {{"_SERVICE_.upk", "asc"}}},
+           {cyberway::chaindb::tag<by_rev>::get_code(), true, {{"_SERVICE_.rev", "asc"},{"_SERVICE_.upk", "asc"}}},
        },
    });
 

--- a/libraries/chain/genesis_state.cpp
+++ b/libraries/chain/genesis_state.cpp
@@ -13,6 +13,25 @@ namespace eosio { namespace chain {
 genesis_state::genesis_state() {
    initial_timestamp = fc::time_point::from_iso_string( "2018-06-01T12:00:00" );
    initial_key = fc::variant(eosio_root_key).as<public_key_type>();
+
+   initial_configuration.max_block_usage =
+      std::vector<uint64_t>(config::default_max_block_usage.begin(), config::default_max_block_usage.end());
+   initial_configuration.max_transaction_usage =
+      std::vector<uint64_t>(config::default_max_transaction_usage.begin(), config::default_max_transaction_usage.end());
+   initial_configuration.target_virtual_limits =
+      std::vector<uint64_t>(config::default_target_virtual_limits.begin(), config::default_target_virtual_limits.end());
+   initial_configuration.min_virtual_limits =
+      std::vector<uint64_t>(config::default_min_virtual_limits.begin(), config::default_min_virtual_limits.end());
+   initial_configuration.max_virtual_limits =
+      std::vector<uint64_t>(config::default_max_virtual_limits.begin(), config::default_max_virtual_limits.end());
+   initial_configuration.usage_windows =
+      std::vector<uint32_t>(config::default_usage_windows.begin(), config::default_usage_windows.end());
+   initial_configuration.virtual_limit_decrease_pct =
+      std::vector<uint16_t>(config::default_virtual_limit_decrease_pct.begin(), config::default_virtual_limit_decrease_pct.end());
+   initial_configuration.virtual_limit_increase_pct =
+      std::vector<uint16_t>(config::default_virtual_limit_increase_pct.begin(), config::default_virtual_limit_increase_pct.end());
+   initial_configuration.account_usage_windows =
+      std::vector<uint32_t>(config::default_account_usage_windows.begin(), config::default_account_usage_windows.end());
 }
 
 chain::chain_id_type genesis_state::compute_chain_id() const {

--- a/libraries/chain/include/cyberway/chaindb/noscope_tables.hpp
+++ b/libraries/chain/include/cyberway/chaindb/noscope_tables.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <eosio/chain/account_object.hpp>
+#include <eosio/chain/global_property_object.hpp>
+#include <eosio/chain/block_summary_object.hpp>
+#include <eosio/chain/transaction_object.hpp>
+#include <eosio/chain/generated_transaction_object.hpp>
+#include <eosio/chain/permission_object.hpp>
+#include <eosio/chain/permission_link_object.hpp>
+#include <eosio/chain/resource_limits.hpp>
+#include <eosio/chain/resource_limits_private.hpp>
+
+#include <cyberway/chain/domain_object.hpp>
+
+namespace cyberway { namespace chaindb {
+
+    inline bool is_noscope_table(const table_info& info) {
+        if (!is_system_code(info.code)) {
+            return false;
+        }
+
+        switch (info.table_name()) {
+            case tag<eosio::chain::account_object>::get_code():
+            case tag<eosio::chain::account_sequence_object>::get_code():
+            case tag<eosio::chain::global_property_object>::get_code():
+            case tag<eosio::chain::dynamic_global_property_object>::get_code():
+            case tag<eosio::chain::block_summary_object>::get_code():
+            case tag<eosio::chain::transaction_object>::get_code():
+            case tag<eosio::chain::generated_transaction_object>::get_code():
+            case tag<eosio::chain::permission_object>::get_code():
+            case tag<eosio::chain::permission_usage_object>::get_code():
+            case tag<eosio::chain::permission_link_object>::get_code():
+            case tag<eosio::chain::resource_limits::resource_usage_object>::get_code():
+            case tag<eosio::chain::resource_limits::resource_limits_config_object>::get_code():
+            case tag<eosio::chain::resource_limits::resource_limits_state_object>::get_code():
+            case tag<cyberway::chain::domain_object>::get_code():
+            case tag<cyberway::chain::username_object>::get_code():
+            case N(undo):
+                return true;
+        }
+        return false;
+    }
+
+}  } // namespace cyberway::chaindb

--- a/libraries/chain/include/eosio/chain/chain_config.hpp
+++ b/libraries/chain/include/eosio/chain/chain_config.hpp
@@ -31,6 +31,9 @@ struct chain_config {
    uint32_t   max_inline_action_size;              ///< maximum allowed size (in bytes) of an inline action
    uint16_t   max_inline_action_depth;             ///< recursion depth limit on sending inline actions
    uint16_t   max_authority_depth;                 ///< recursion depth limit for checking if an authority is satisfied
+
+   uint64_t   ram_size;
+   uint64_t   reserved_ram_size;
    
    std::vector<uint64_t> max_block_usage;
    std::vector<uint64_t> max_transaction_usage;
@@ -62,8 +65,10 @@ struct chain_config {
          << "Max Transaction Delay: " << c.max_transaction_delay << ", "
          << "Max Inline Action Size: " << c.max_inline_action_size << ", "
          << "Max Inline Action Depth: " << c.max_inline_action_depth << ", "
-         << "Max Authority Depth: " << c.max_authority_depth << "\n";
-                 
+         << "Max Authority Depth: " << c.max_authority_depth << ", "
+         << "RAM size: " << c.ram_size << ", "
+         << "Reserved RAM size: " << c.reserved_ram_size << "\n";
+
       out << "Max Block Usage: ";            for (auto r : c.max_block_usage)            { out << r << " "; } out << "\n";
       out << "Max Transaction Usage: ";      for (auto r : c.max_transaction_usage)      { out << r << " "; } out << "\n";
       out << "Target Virtual Limits: ";      for (auto r : c.target_virtual_limits)      { out << r << " "; } out << "\n";
@@ -89,6 +94,8 @@ struct chain_config {
                            lhs.max_inline_action_size,
                            lhs.max_inline_action_depth,
                            lhs.max_authority_depth,
+                           lhs.ram_size,
+                           lhs.reserved_ram_size,
                            lhs.max_block_usage,
                            lhs.max_transaction_usage,
                            lhs.target_virtual_limits,
@@ -111,6 +118,8 @@ struct chain_config {
                            rhs.max_inline_action_size,
                            rhs.max_inline_action_depth,
                            rhs.max_authority_depth,
+                           rhs.ram_size,
+                           rhs.reserved_ram_size,
                            rhs.max_block_usage,
                            rhs.max_transaction_usage,
                            rhs.target_virtual_limits,
@@ -138,7 +147,8 @@ FC_REFLECT(eosio::chain::chain_config,
 
            (max_transaction_lifetime)(deferred_trx_expiration_window)(max_transaction_delay)
            (max_inline_action_size)(max_inline_action_depth)(max_authority_depth)
-           
+
+           (ram_size)(reserved_ram_size)
            (max_block_usage)(max_transaction_usage)
            
            (target_virtual_limits)(min_virtual_limits)(max_virtual_limits)(usage_windows)

--- a/libraries/chain/include/eosio/chain/genesis_state.hpp
+++ b/libraries/chain/include/eosio/chain/genesis_state.hpp
@@ -34,6 +34,9 @@ struct genesis_state {
       .max_inline_action_size               = config::default_max_inline_action_size,
       .max_inline_action_depth              = config::default_max_inline_action_depth,
       .max_authority_depth                  = config::default_max_auth_depth,
+
+      .ram_size                             = config::default_ram_size,
+      .reserved_ram_size                    = config::default_reserved_ram_size,
    };
 
    time_point                               initial_timestamp;

--- a/libraries/chain/include/eosio/chain/multi_index_includes.hpp
+++ b/libraries/chain/include/eosio/chain/multi_index_includes.hpp
@@ -41,6 +41,7 @@ using bmi::tag;
 using bmi::composite_key_compare;
 
 struct by_id;
+struct by_rev;
 
 namespace eosio { namespace chain {
 
@@ -64,6 +65,7 @@ namespace eosio { namespace chain { namespace resource_limits {
 } } } // namespace eosio::chain::resource_limits
 
 CHAINDB_TAG(by_id, primary) // "primary" for compatibility with contracts
+CHAINDB_TAG(by_rev, revision)
 CHAINDB_TAG(eosio::chain::by_parent, parent)
 CHAINDB_TAG(eosio::chain::by_owner, owner)
 CHAINDB_TAG(eosio::chain::by_name, name)

--- a/libraries/chain/include/eosio/chain/resource_limits_private.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits_private.hpp
@@ -134,8 +134,6 @@ using namespace int_arithmetic;
       std::vector<usage_accumulator> block_usage_accumulators;
       std::vector<int64_t> pending_usage;
       std::vector<uint64_t> virtual_limits;
-      uint64_t ram_size = config::default_ram_size;
-      uint64_t reserved_ram_size = config::default_reserved_ram_size;
       void update_virtual_limit(const resource_limits_config_object& cfg, resource_id res);
       void add_pending_delta(int64_t delta, const chain_config& chain_cfg, resource_id res);
    };
@@ -163,4 +161,4 @@ FC_REFLECT(eosio::chain::resource_limits::resource_usage_object, (owner)(accumul
 
 FC_REFLECT(eosio::chain::resource_limits::resource_limits_config_object, (id)(limit_parameters)(account_usage_average_windows))
 
-FC_REFLECT(eosio::chain::resource_limits::resource_limits_state_object, (id)(block_usage_accumulators)(pending_usage)(virtual_limits)(ram_size)(reserved_ram_size))
+FC_REFLECT(eosio::chain::resource_limits::resource_limits_state_object, (id)(block_usage_accumulators)(pending_usage)(virtual_limits))

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -415,7 +415,7 @@ namespace bacc = boost::accumulators;
          net_usage,
          billed_ram_bytes,
          control.pending_block_time()); // can fail due to billed_ram_bytes
-      if( !control.skip_db_sessions() ) {
+      if( control.is_producing_block() ) {
          control.chaindb().apply_all_changes();
       }
    }

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1450,6 +1450,12 @@ namespace eosio {
          c->syncing = true;
          return;
       }
+      // TODO: added by CyberWay
+      if (lib_num < peer_lib && head > msg.head_num) {
+         fc_dlog(logger, "sync check state 5");
+         verify_catchup(c, msg.head_num, msg.head_id);
+         return;
+      }
 
       if (head < msg.head_num ) {
          fc_dlog(logger, "sync check state 3");

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -3035,7 +3035,7 @@ namespace eosio {
       }
       chain::controller&cc = my->chain_plug->chain();
       {
-         cc.accepted_block.connect(  boost::bind(&net_plugin_impl::accepted_block, my.get(), _1));
+         cc.accepted_block_header.connect(  boost::bind(&net_plugin_impl::accepted_block, my.get(), _1));
       }
 
       my->incoming_transaction_ack_subscription = app().get_channel<channels::transaction_ack>().subscribe(boost::bind(&net_plugin_impl::transaction_ack, my.get(), _1));


### PR DESCRIPTION
Resolve #874:
- Don't add to primary index the `scope`-field for inter-chain tables
- Add index by revision to undo-table
- As result - fix loading of undo-table on nodes with deep undo history

Resolve #883:
- Add switching to fork with bigger LIB but smaller HEAD block

Resolve #882:
- Add waiting of block from previous BP to decrease time of sync
- Broadcast of block after checking linking to previous block and signature of BP

Resolve #884:
- Sync changes to DB on each transaction only on block-producing. 
- Sync changes to DB on block committing on block incoming 

Resolve #885:
- Add RAM size to genesis info and blockchain configuration 
- Requires PRs in golos.contracts and cyberway.cdt