### PR TITLE
Restore nodeos_run_test.py and launcher_test.py #899

### DIFF
--- a/testnet.template
+++ b/testnet.template
@@ -2,6 +2,11 @@
 
 # set up a wallet just for holding the key used during blockchain ignition
 
+coresym=$1
+if [ -z "$coresym" ]; then
+    coresym=SYS
+fi
+
 bioshost=$BIOS_HOSTNAME
 if [ -z "$bioshost" ]; then
    bioshost=localhost
@@ -96,14 +101,15 @@ ecmd create account cyber cyber.token $pubsyskey $pubsyskey
 ecmd create account cyber cyber.vpay $pubsyskey $pubsyskey
 
 ecmd set contract cyber.token contracts/cyber.token
+sleep 3 # prevent "Transaction exceeded the current CPU usage limit"
 ecmd set contract cyber.msig contracts/cyber.msig
 
 echo ===== Start: $step ============ >> $logfile
-echo executing: cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action cyber.token create '["cyber", "10000000000.0000 SYS"]' -p cyber.token | tee -a $logfile
-echo executing: cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action cyber.token issue '["cyber", "1000000000.0000 SYS", "memo"]' -p cyber | tee -a $logfile
+echo executing: cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action cyber.token create '["cyber", "10000000000.0000 '$coresym'"]' -p cyber.token | tee -a $logfile
+echo executing: cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action cyber.token issue '["cyber", "1000000000.0000 '$coresym'", "memo"]' -p cyber | tee -a $logfile
 echo ----------------------- >> $logfile
-programs/cleos/cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action cyber.token create '["cyber", "10000000000.0000 SYS"]' -p cyber.token >> $logfile 2>&1
-programs/cleos/cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action cyber.token issue '["cyber", "1000000000.0000 SYS", "memo"]' -p cyber >> $logfile 2>&1
+programs/cleos/cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action cyber.token create '["cyber", "10000000000.0000 '$coresym'"]' -p cyber.token >> $logfile 2>&1
+programs/cleos/cleos --wallet-url $wdurl --url http://$bioshost:$biosport push action cyber.token issue '["cyber", "1000000000.0000 '$coresym'", "memo"]' -p cyber >> $logfile 2>&1
 echo ==== End: $step ============== >> $logfile
 step=$(($step + 1))
 

--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -849,7 +849,7 @@ class Cluster(object):
             Utils.Print("ERROR: Bios node doesn't appear to be running...")
             return None
 
-        cmd="bash bios_boot.sh"
+        cmd="bash bios_boot.sh %s" % (CORE_SYMBOL)
         if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
         if 0 != subprocess.call(cmd.split(), stdout=Utils.FNull):
             if not silent: Utils.Print("Launcher failed to shut down eos cluster.")

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -55,7 +55,7 @@ class Node(object):
         self.missingTransaction=False
         self.popenProc=None           # initial process is started by launcher, this will only be set on relaunch
         if self.enableMongo:
-            self.mongoEndpointArgs += "--host %s --port %d %s" % (mongoHost, mongoPort, mongoDb)
+            self.mongoEndpointArgs += "--host %s --port %d --quiet %s" % (mongoHost, mongoPort, mongoDb)
 
     def eosClientArgs(self):
         walletArgs=" " + self.walletMgr.getWalletEndpointArgs() if self.walletMgr is not None else ""
@@ -67,7 +67,7 @@ class Node(object):
 
     @staticmethod
     def assetToValue(asset):
-        return "%.*f %s" % (asset["decs"], asset["amount"]/(10**asset["decs"]), asset["sym"])
+        return asset #"%.*f %s" % (asset["decs"], asset["amount"]/(10**asset["decs"]), asset["sym"])
 
     @staticmethod
     def validateTransaction(trans):

--- a/tests/launcher_test.py
+++ b/tests/launcher_test.py
@@ -200,10 +200,11 @@ try:
     amountVal=None
     key=""
     try:
-        key="[traces][0][act][name]"
+        key="[actions][0][name]"
         typeVal=  transaction["actions"][0]["name"]
-        key="[traces][0][act][data][quantity]"
-        amountVal=transaction["actions"][0]["data"]["quantity"]["amount"]
+        key="[actions][0][data][quantity]"
+        amountVal=transaction["actions"][0]["data"]["quantity"]
+        amountVal=int(decimal.Decimal(amountVal.split()[0])*10000)
     except (TypeError, KeyError) as e:
         Print("transaction%s not found. Transaction: %s" % (key, transaction))
         raise

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -301,7 +301,8 @@ try:
             key="[actions][0][name]"
             typeVal=  transaction["actions"][0]["name"]
             key="[actions][0][data][quantity]"
-            amountVal=transaction["actions"][0]["data"]["quantity"]["amount"]
+            amountVal=transaction["actions"][0]["data"]["quantity"]
+            amountVal=int(decimal.Decimal(amountVal.split()[0])*10000)
     except (TypeError, KeyError) as e:
         Print("transaction%s not found. Transaction: %s" % (key, transaction))
         raise
@@ -320,9 +321,9 @@ try:
     if hashNum != 0:
         errorExit("FAILURE - get code currency1111 failed", raw=True)
 
-    contractDir="unittests/contracts/eosio.token"
-    wasmFile="eosio.token.wasm"
-    abiFile="eosio.token.abi"
+    contractDir="contracts/cyber.token"
+    wasmFile="cyber.token.wasm"
+    abiFile="cyber.token.abi"
     Print("Publish contract")
     trans=node.publishContract(currencyAccount.name, contractDir, wasmFile, abiFile, waitForTransBlock=True)
     if trans is None:
@@ -384,7 +385,7 @@ try:
         raise
 
     Print("Verify currency1111 contract has proper initial balance (via get currency1111 balance)")
-    amountStr=node.getTableAccountBalance("currency1111", currencyAccount.name)
+    amountStr=node.getTableAccountBalance("currency1111", currencyAccount.name) #? cleos get currency balance
 
     expected="100000.0000 CUR"
     actual=amountStr


### PR DESCRIPTION
+ pass core symbol to bios_boot.sh
+ use quiet mode to run mongo queries to get clean json output
+ update asset handling to support string storage instead of object
+ use `cyber.token` instead of `eosio.token` + use same contract's dir as in `Cluster.py`

Note: requires #901
