### PR TITLE
Allow to use empty structs in abi-serializer result.

### DIFF
--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -433,7 +433,8 @@ namespace eosio { namespace chain {
       fc::mutable_variant_object mvo;
       _binary_to_variant(rtype, stream, mvo, ctx);
       // QUESTION: Is this assert actually desired? It disallows unpacking empty structs from datastream.
-      EOS_ASSERT( mvo.size() > 0, unpack_exception, "Unable to unpack '${p}' from stream", ("p", ctx.get_path_string()) );
+      // TODO: removed by CyberWay
+      // EOS_ASSERT( mvo.size() > 0, unpack_exception, "Unable to unpack '${p}' from stream", ("p", ctx.get_path_string()) );
       return fc::variant( std::move(mvo) );
    }
 

--- a/plugins/event_engine_plugin/event_engine_plugin.cpp
+++ b/plugins/event_engine_plugin/event_engine_plugin.cpp
@@ -103,8 +103,8 @@ private:
             auto result = abi->to_object(action_type, act.data.data(), act.data.size());
             return result;
         } catch (const fc::exception &err) {
-            ilog("Can't unpack arguments for action ${account}:${event}: ${err}",
-                    ("account", act.account)("event", act.name)("err", err.to_string()));
+            ilog("Can't unpack arguments for action ${account}:${action}: ${err}",
+                    ("account", act.account)("action", act.name)("err", err.to_string()));
             return fc::variant();
         }
     }


### PR DESCRIPTION
Don't show error on empty arguments in contract method.
