### PR TITLE
Fail on change abi #930, #928

### DIFF
--- a/libraries/chain/chaindb/account_abi_info.cpp
+++ b/libraries/chain/chaindb/account_abi_info.cpp
@@ -74,12 +74,16 @@ namespace cyberway { namespace  chaindb {
         void init_info() {
             init_info(eosio::chain::eosio_contract_abi());
 
-            auto obj = driver_.object_by_pk(index, config::system_account_name);
-            if (obj.value.is_object()) {
-                auto& abi = obj.value["abi"];
-                if (abi.is_blob() && !abi.get_blob().data.empty()) {
-                    init_info(abi.get_blob());
+            try {
+                auto obj = driver_.object_by_pk(index, config::system_account_name);
+                if (obj.value.is_object()) {
+                    auto& abi = obj.value["abi"];
+                    if (abi.is_blob() && !abi.get_blob().data.empty()) {
+                        init_info(abi.get_blob());
+                    }
                 }
+            } catch (...) {
+                // fail to read abi from db
             }
         }
 

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -191,13 +191,16 @@ namespace cyberway { namespace chaindb {
         : code(v.code), table(v.table_name()) {
         }
 
-        friend bool operator < (const cache_service_key& l, const cache_service_key& r) {
-            if (l.table < r.table) return true;
-            if (l.table > r.table) return false;
-
-            return l.code < r.code;
+        friend bool operator == (const cache_service_key& l, const cache_service_key& r) {
+            return l.code == r.code && l.table == r.table;
         }
     }; // cache_service_key
+
+    struct cache_service_hash final {
+        std::size_t operator()(const cache_service_key& key) const {
+            return (key.code ^ key.table);
+        }
+    }; // cache_service_hash
 
     //-----------------------------------------------------------------------------------------------
 
@@ -225,7 +228,7 @@ namespace cyberway { namespace chaindb {
         }
     }; // struct cache_service_info
 
-    using cache_service_tree = std::map<cache_service_key, cache_service_info>;
+    using cache_service_tree = std::unordered_map<cache_service_key, cache_service_info, cache_service_hash>;
 
     //-----------------------------------------------------------------------------------------------
 

--- a/libraries/chain/chaindb/journal.cpp
+++ b/libraries/chain/chaindb/journal.cpp
@@ -113,13 +113,15 @@ namespace cyberway { namespace chaindb {
         index_.clear();
     }
 
-    journal::write_ctx journal::create_ctx(const table_info& table) {
-        auto table_itr = table_object::find(index_, table);
+    journal::write_ctx journal::create_ctx(const table_info& info) {
+        auto table_itr = table_object::find(index_, info);
         if (index_.end() != table_itr) {
             return write_ctx(const_cast<table_t_&>(*table_itr));
         }
 
-        return write_ctx(table_object::emplace(index_, table));
+        auto& table = table_object::emplace(index_, info);
+        table.info_map.reserve(64);
+        return write_ctx(table);
     }
 
     journal::info_t_& journal::write_ctx::info(const primary_key_t pk) {
@@ -130,6 +132,7 @@ namespace cyberway { namespace chaindb {
         auto itr = table.info_map.find(pk);
         if (itr == table.info_map.end()) {
             itr = table.info_map.emplace(pk, info_t_()).first;
+            itr->second.undo_map.reserve(16);
         }
         info_ = &itr->second;
 

--- a/libraries/chain/chaindb/undo_state.cpp
+++ b/libraries/chain/chaindb/undo_state.cpp
@@ -30,7 +30,11 @@ namespace cyberway { namespace chaindb {
     class table_undo_stack;
 
     struct undo_state final {
-        undo_state(table_undo_stack& table, revision_t rev): table_(table), revision_(rev) { }
+        undo_state(table_undo_stack& table, revision_t rev): table_(table), revision_(rev) {
+            new_values_.reserve(32);
+            old_values_.reserve(32);
+            removed_values_.reserve(32);
+        }
 
         void set_next_pk(primary_key_t, primary_key_t);
         void move_next_pk(undo_state& src);
@@ -53,7 +57,7 @@ namespace cyberway { namespace chaindb {
             --revision_;
         }
 
-        using pk_value_map_t_ = std::map<primary_key_t, object_value>;
+        using pk_value_map_t_ = fc::flat_map<primary_key_t, object_value>;
 
         table_undo_stack& table_;
         pk_value_map_t_   new_values_;
@@ -443,11 +447,12 @@ namespace cyberway { namespace chaindb {
             account_abi_info info;
         }; // struct abi_history
 
-        using abi_history_map_t_ = std::map<account_name_t, std::deque<abi_history_t_>>;
+        using abi_history_map_t_ = fc::flat_map<account_name_t, std::deque<abi_history_t_>>;
 
         abi_history_map_t_ load_abi_history(const index_info& index) {
             abi_history_map_t_ map;
 
+            map.reserve(32);
             auto  account_table = tag<account_object>::get_code();
             auto& cursor = driver_.lower_bound(index, {});
             for (; cursor.pk != primary_key::End; driver_.next(cursor)) {

--- a/libraries/chain/chaindb/value_verifier.cpp
+++ b/libraries/chain/chaindb/value_verifier.cpp
@@ -8,7 +8,8 @@ namespace cyberway { namespace chaindb {
 
     struct value_verifier_impl final {
         value_verifier_impl(const chaindb_controller& controller)
-        : driver_(controller.get_driver()),
+        : controller_(controller),
+          driver_(controller.get_driver()),
           info_(controller.get_system_abi_info()) {
         }
 
@@ -39,12 +40,16 @@ namespace cyberway { namespace chaindb {
                 }
             }
 
+            if (start_revision != controller_.revision()) {
+                controller_.apply_code_changes(obj.pk());
+            }
             abi_info info(obj.pk(), def);
             info.verify_tables_structure(driver_);
         }
 
-        const driver_interface& driver_;
-        const system_abi_info&  info_;
+        const chaindb_controller& controller_;
+        const driver_interface&   driver_;
+        const system_abi_info&    info_;
     }; // struct value_verifier_impl
 
     value_verifier::value_verifier(const chaindb_controller& controller)

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -576,8 +576,7 @@ abi_def eosio_contract_abi(abi_def eos_abi)
 
    eos_abi.tables.emplace_back(table_def{
        "undo", "undo", "uint64", {
-           {cyberway::chaindb::tag<by_id>::get_code(), true, {{"_SERVICE_.upk", "asc"}}},
-           {cyberway::chaindb::tag<by_rev>::get_code(), true, {{"_SERVICE_.rev", "asc"},{"_SERVICE_.upk", "asc"}}},
+           {cyberway::chaindb::tag<by_id>::get_code(), true, {{"_SERVICE_.upk", "asc"}}}
        },
    });
 

--- a/libraries/chain/include/cyberway/chaindb/journal.hpp
+++ b/libraries/chain/include/cyberway/chaindb/journal.hpp
@@ -112,14 +112,14 @@ namespace cyberway { namespace chaindb {
         }
 
     private:
-        using undo_map_t_ = std::map<primary_key_t /* undo_pk */, write_operation>;
+        using undo_map_t_ = fc::flat_map<primary_key_t /* undo_pk */, write_operation>;
 
         struct info_t_ final {
             write_operation data;
             undo_map_t_     undo_map;
         }; // struct info_t_
 
-        using info_map_t_ = std::map<primary_key_t /* pk */, info_t_>;
+        using info_map_t_ = fc::flat_map<primary_key_t /* pk */, info_t_>;
 
         struct table_t_ final: public table_object::object {
             using table_object::object::object;

--- a/libraries/chain/include/eosio/chain/multi_index_includes.hpp
+++ b/libraries/chain/include/eosio/chain/multi_index_includes.hpp
@@ -41,7 +41,6 @@ using bmi::tag;
 using bmi::composite_key_compare;
 
 struct by_id;
-struct by_rev;
 
 namespace eosio { namespace chain {
 
@@ -65,7 +64,6 @@ namespace eosio { namespace chain { namespace resource_limits {
 } } } // namespace eosio::chain::resource_limits
 
 CHAINDB_TAG(by_id, primary) // "primary" for compatibility with contracts
-CHAINDB_TAG(by_rev, revision)
 CHAINDB_TAG(eosio::chain::by_parent, parent)
 CHAINDB_TAG(eosio::chain::by_owner, owner)
 CHAINDB_TAG(eosio::chain::by_name, name)


### PR DESCRIPTION
Resolve #930:
- Apply code changes before verifying of db structure.

Resolve #928:
- Performance. Create index by revision in undo-table only on loading data on chain-startup

Additional changes. Performace:
- Change std::map  to fc::flat_map  in undo-collections
- Change std::map to std::unordered_map in cache_map for tables.