### PR TITLE
Vesting supply to EE-genesis #937

### DIFF
--- a/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
+++ b/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
@@ -255,6 +255,12 @@ static abi_def create_funds_abi() {
         }
     });
 
+    abi.structs.emplace_back( struct_def {
+        "vesting_supply", "", {
+            {"supply", "asset"},
+        }
+    });
+
     return abi;
 }
 

--- a/programs/create-genesis/ee_genesis/genesis_ee_builder.cpp
+++ b/programs/create-genesis/ee_genesis/genesis_ee_builder.cpp
@@ -807,6 +807,10 @@ void genesis_ee_builder::write_funds() {
     for (auto& be : exp_info_.balance_events) {
         out.insert(be);
     }
+
+    out.start_section(info_.golos.names.vesting, N(stat), "vesting_supply");
+
+    out.insert(exp_info_.vesting_supply);
 }
 
 void genesis_ee_builder::write_balance_converts() {

--- a/programs/create-genesis/export_info.hpp
+++ b/programs/create-genesis/export_info.hpp
@@ -69,6 +69,7 @@ struct export_info {
     fc::flat_map<acc_idx, mvo> witnesses;
     fc::flat_map<acc_idx, fc::flat_set<name>> witness_votes;
     std::vector<mvo> currency_stats;
+    mvo vesting_supply;
     std::vector<mvo> balance_events;
     std::vector<mvo> delegations;
     fc::flat_map<uint64_t, cyberway::golos::active_comment_data> active_comments;

--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -717,10 +717,12 @@ struct genesis_create::genesis_create_impl final {
         // vesting info
         db.start_section(_info.golos.names.vesting, N(stat), "vesting_stats", 1);
         primary_key_t vests_pk = VESTS >> 8;
-        db.insert(vests_pk, _info.golos.names.vesting, mvo
-            ("supply", asset(data.total_gests.get_amount(), symbol(VESTS)))
+        auto vesting_stat = mvo
+            ("supply", asset(data.total_gests.get_amount(), symbol(VESTS)));
+        db.insert(vests_pk, _info.golos.names.vesting, vesting_stat
             ("notify_acc", _info.golos.names.control)
         );
+        _exp_info.vesting_supply = vesting_stat;
 
         // funds
         const auto n_acc_balances = std::count_if(_info.accounts.begin(), _info.accounts.end(), [](const auto& a) {return a.sys_balance;}); //


### PR DESCRIPTION
Resolves #937.

Fully corresponding to `"stat"_n` event from `golos.vesting`.