### PR TITLE
ABI stabilization #873, #938, #940, #943, #945, #245

### DIFF
--- a/libraries/chain/chaindb/abi_info.cpp
+++ b/libraries/chain/chaindb/abi_info.cpp
@@ -380,7 +380,12 @@ namespace cyberway { namespace chaindb {
             for (auto& index: ttr->second->indexes) {
                 indexes.emplace(index.name, &index);
                 path.clear();
-                for (auto& order: index.orders) path.append(":").append(order.field);
+                for (auto& order: index.orders) {
+                    path.append(":").append(order.field);
+                }
+                if (!index.unique) {
+                    path.append(":").append(ttr->second->indexes.front().orders.front().field);
+                }
                 paths.insert(path);
             }
             CYBERWAY_ASSERT(ttr->second->indexes.size() == indexes.size() && indexes.size() == paths.size(),

--- a/libraries/chain/chaindb/abi_info.cpp
+++ b/libraries/chain/chaindb/abi_info.cpp
@@ -43,7 +43,7 @@ namespace cyberway { namespace chaindb {
             fields.reserve(index.orders.size());
             for (auto& order: index.orders) fields.emplace(order.field);
             CYBERWAY_ASSERT(fields.size() == index.orders.size(), unique_field_name_exception,
-                "The index '${index}' should has unique field names",
+                "Index '${index}' has duplicates of fields",
                 ("index", get_full_index_name(abi.code(), table, index)));
         }
 
@@ -131,9 +131,9 @@ namespace cyberway { namespace chaindb {
             auto struct_name = get_root_index_name(table, index);
 
             CYBERWAY_ASSERT(!index.orders.empty(), invalid_index_description_exception,
-                "The index ${index} should have fields", ("index", struct_name));
+                "Index ${index} doesn't have fields", ("index", struct_name));
             CYBERWAY_ASSERT(index.orders.size() <= abi_info::MaxFieldCnt, invalid_index_description_exception,
-                "The index ${index} has too many fields ${orders} > ${max}",
+                "Index ${index} has too many fields ${orders} (> maximum = ${max})",
                 ("index", struct_name)("orders", index.orders.size())("max", int(abi_info::MaxFieldCnt)));
 
             auto max_size = index.orders.size() * abi_info::MaxPathDepth;
@@ -149,14 +149,14 @@ namespace cyberway { namespace chaindb {
             for (auto& order: index.orders) {
                 CYBERWAY_ASSERT(order.order == names::asc_order || order.order == names::desc_order,
                     invalid_index_description_exception,
-                    "Invalid type '${type}' for the index order for the index ${index}",
+                    "Invalid type '${type}' for index order for the index ${index}",
                     ("type", order.order)("index", root_struct.name));
 
                 boost::split(order.path, order.field, [](char c){return c == '.';});
                 CYBERWAY_ASSERT(!order.path.empty(), invalid_index_description_exception,
-                    "Path for index doesn't have any part in the index ${index}", ("index", root_struct.name));
+                    "Path in the index ${index} doesn't have any part ", ("index", root_struct.name));
                 CYBERWAY_ASSERT(order.path.size() <= abi_info::MaxPathDepth, invalid_index_description_exception,
-                    "Path for index is too long in the index ${index}", ("index", root_struct.name));
+                    "Path in the index ${index} is too long", ("index", root_struct.name));
 
                 auto dst_struct = &root_struct;
                 auto src_struct = &table_struct;
@@ -166,7 +166,7 @@ namespace cyberway { namespace chaindb {
                     for (auto& src_field: src_struct->fields) {
                         if (src_field.name != key) continue;
                         CYBERWAY_ASSERT(!serializer_.is_array(src_field.type), array_field_exception,
-                            "The field ${path} can't be used for the index ${index}",
+                            "Field ${path} can't be used for the index ${index}",
                             ("path", order.field)("index", root_struct.name));
 
                         was_key = true;
@@ -211,7 +211,7 @@ namespace cyberway { namespace chaindb {
 
         void validate_pk_index(const table_def& table) const {
             CYBERWAY_ASSERT(!table.indexes.empty(), invalid_primary_key_exception,
-                "The table ${table} must contain at least one index", ("table", get_table_name(table)));
+                "Table ${table} must contain at least one index", ("table", get_table_name(table)));
 
             auto& p = table.indexes.front();
             CYBERWAY_ASSERT(p.unique && p.orders.size() == 1, invalid_primary_key_exception,
@@ -222,7 +222,7 @@ namespace cyberway { namespace chaindb {
             CYBERWAY_ASSERT(
                 primary_key::is_valid_kind(k.type),
                 invalid_primary_key_exception,
-                "The field ${field} of the table ${table} is declared as primary and it should has type: "
+                "Field ${field} of table ${table} is declared as primary and it should has type: "
                 "int64, uint64, name, symbol_code or symbol",
                 ("field", k.field)("table", get_table_name(table)));
 
@@ -257,14 +257,14 @@ namespace cyberway { namespace chaindb {
         serializer_.set_abi(def, max_abi_time_);
 
         CYBERWAY_ASSERT(def.tables.size() <= MaxTableCnt, max_table_count_exception,
-            "The account '${code}' can't create more than ${max} tables",
+            "Account '${code}' can't create more than ${max} tables",
             ("code", get_code_name(code_))("max", size_t(MaxTableCnt)));
 
 
         table_map_.reserve(def.tables.size());
         for (auto& table: def.tables) {
             CYBERWAY_ASSERT(table.indexes.size() <= MaxIndexCnt, max_index_count_exception,
-                "The table '${table}' can't has more than ${max} indexes",
+                "Table '${table}' can't has more than ${max} indicies",
                 ("table", get_full_table_name(code_, table))("max", size_t(MaxIndexCnt)));
             auto id = table.name;
             table_map_.emplace(id, std::move(table));
@@ -291,7 +291,7 @@ namespace cyberway { namespace chaindb {
 //                ("value_type", value_type)("type", db_type())("value", value));
 
         CYBERWAY_ASSERT(value.is_object(), invalid_abi_store_type_exception,
-            "ABI serializer returns bad type for the ${value_type} for ${type}: ${value}",
+            "ABI serializer returns bad type for ${value_type} for '${type}': ${value}",
             ("value_type", value_type)("type", db_type())("value", value));
 
         return value;
@@ -305,7 +305,7 @@ namespace cyberway { namespace chaindb {
 //                ("value", value_type)("type", db_type())("value", value));
 
         CYBERWAY_ASSERT(value.is_object(), invalid_abi_store_type_exception,
-            "ABI serializer receive wrong type for the ${value_type} for '${type}': ${value}",
+            "ABI serializer receive wrong type for ${value_type} for '${type}': ${value}",
             ("value_type", value_type)("type", db_type())("value", value));
 
         return serializer_.variant_to_binary(type, value, max_abi_time_);
@@ -368,7 +368,7 @@ namespace cyberway { namespace chaindb {
             auto table = _detail::generate_table_info(*this, db_table);
             if (tables.end() == ttr || !ttr->second) {
                 CYBERWAY_ASSERT(db_table.row_count == 0, table_has_rows_exception,
-                    "Can't drop the table '${table}', because it has ${row_cnt} rows",
+                    "Can't drop table '${table}', because it has ${row_cnt} rows",
                     ("table", get_full_table_name(table))("row_cnt", db_table.row_count));
 
                 drop_tables.emplace_back(std::move(table));
@@ -410,7 +410,7 @@ namespace cyberway { namespace chaindb {
 
             for (auto& index: indexes) if (index.second) {
                 CYBERWAY_ASSERT(db_table.row_count == 0, table_has_rows_exception,
-                    "Can't create the index '${index}', because the table '${table}' has ${row_cnt} rows",
+                    "Can't create index '${index}', because the table '${table}' has ${row_cnt} rows",
                     ("index", get_full_index_name(table, index.second))
                     ("table", get_full_table_name(table))("row_cnt", db_table.row_count));
                 _detail::validate_unique_field_names(*this, *ttr->second, *index.second);

--- a/libraries/chain/chaindb/cache_map.cpp
+++ b/libraries/chain/chaindb/cache_map.cpp
@@ -601,6 +601,13 @@ namespace cyberway { namespace chaindb {
             release_cache_object(*service_ptr, cache_obj, true);
         }
 
+        void set_value(const table_info& table, cache_object& cache_obj, const object_value& value) {
+            auto service_ptr = find_cache_service(table);
+            if (service_ptr) {
+                convert_value(*service_ptr, cache_obj, value);
+            }
+        }
+
         void set_object(const table_info& table, cache_object& cache_obj, object_value value) {
             set_object(table, find_cache_service(table), cache_obj, std::move(value));
         }
@@ -1039,6 +1046,7 @@ namespace cyberway { namespace chaindb {
             //   1. create object for interchain tables ->  value.is_null()
             //   2. loading object from chaindb         -> !value.is_null()
             //   3. restore from undo state             -> !value.is_null()
+            //   4. restore on fail to update           -> !value.is_null()
             if (service.converter && !value.is_null()) {
                 service.converter->convert_variant(cache_obj, value);
             }
@@ -1328,6 +1336,10 @@ namespace cyberway { namespace chaindb {
         assert(value);
         assert(size);
         return impl_->find_unsuccess(key, index, value, size);
+    }
+
+    void cache_map::set_value(const table_info& table, cache_object& cache_obj, const object_value& value) const {
+        impl_->set_value(table, cache_obj, value);
     }
 
     void cache_map::set_object(const table_info& table, cache_object& cache_obj, object_value value) const {

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -11,7 +11,6 @@
 #include <cyberway/chaindb/storage_payer_info.hpp>
 
 #include <eosio/chain/name.hpp>
-#include <eosio/chain/symbol.hpp>
 #include <eosio/chain/apply_context.hpp>
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/transaction_context.hpp>
@@ -451,8 +450,8 @@ namespace cyberway { namespace chaindb {
                 cache_.set_object(table, cache_obj, std::move(obj));
                 return delta;
             } catch (...) {
-                // case of throwing in storage_payer_info::add_usage
-                cache_.set_object(table, cache_obj, cache_obj.object());
+                // case of throwing in storage_payer_info::add_usage(), value_verifier::verify()
+                cache_.set_value(table, cache_obj, cache_obj.object());
                 throw;
             }
         }

--- a/libraries/chain/include/cyberway/chaindb/abi_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/abi_info.hpp
@@ -8,12 +8,17 @@
 #include <cyberway/chaindb/exception.hpp>
 #include <cyberway/chaindb/names.hpp>
 
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
+
 namespace cyberway { namespace chaindb {
 
     using eosio::chain::abi_def;
     using eosio::chain::abi_serializer;
 
-    struct abi_info final {
+    struct abi_info;
+    using  abi_info_ptr = boost::intrusive_ptr<abi_info>;
+
+    struct abi_info final: public boost::intrusive_ref_counter<abi_info, boost::thread_unsafe_counter> {
         abi_info() = default;
         abi_info(const account_name& code, abi_def);
         abi_info(const account_name& code, blob);
@@ -58,10 +63,11 @@ namespace cyberway { namespace chaindb {
         }
 
         const order_def* find_pk_order(const table_def& table) const {
-            if (!table.indexes.empty()) {
-                return &table.indexes.front().orders.front();
-            }
-            return nullptr;
+            assert(!table.indexes.empty());
+            assert(!table.indexes.front().orders.empty());
+            assert(table.indexes.front().unique);
+
+            return &table.indexes.front().orders.front();
         }
 
         const account_name& code() const {
@@ -77,7 +83,7 @@ namespace cyberway { namespace chaindb {
             MaxIndexCnt   = 16,
             MaxPathDepth  = 4,
             MaxFieldCnt   = 16,
-            MaxIndexSize  = 1024,
+            MaxIndexSize  = 1024 - 64,
             MaxObjectSize = 1024 * 1024
         }; // constants
 

--- a/libraries/chain/include/cyberway/chaindb/abi_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/abi_info.hpp
@@ -73,9 +73,12 @@ namespace cyberway { namespace chaindb {
         }
 
         enum : size_t {
-            MaxTableCnt  = 64,
-            MaxIndexCnt  = 16,
-            MaxPathDepth = 4,
+            MaxTableCnt   = 64,
+            MaxIndexCnt   = 16,
+            MaxPathDepth  = 4,
+            MaxFieldCnt   = 16,
+            MaxIndexSize  = 1024,
+            MaxObjectSize = 1024 * 1024
         }; // constants
 
     private:

--- a/libraries/chain/include/cyberway/chaindb/account_abi_info.hpp
+++ b/libraries/chain/include/cyberway/chaindb/account_abi_info.hpp
@@ -17,30 +17,25 @@ namespace cyberway { namespace chaindb {
 
         account_name code() const {
             if (has_abi_info()) {
-                return account().name;
+                return abi_info_ptr_->code();
             }
             return account_name();
         }
 
         bool has_abi_info() const {
-            return !!account_ptr_;
+            return !!abi_info_ptr_;
         }
 
         const abi_info& abi() const {
-            return account().get_abi_info();
+            return *abi_info_ptr_;
         }
 
     private:
-        cache_object_ptr account_ptr_;
+        abi_info_ptr abi_info_ptr_;
 
-        template<typename Abi> void init(account_name_t, Abi&&);
+        template<typename Abi> void init(account_name_t, Abi);
 
         void init(cache_object_ptr);
-
-        const account_object& account() const {
-            assert(has_abi_info());
-            return multi_index_item_data<account_object>::get_T(account_ptr_);
-        }
     }; // struct account_abi_info
 
     struct system_abi_info final {

--- a/libraries/chain/include/cyberway/chaindb/cache_item.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_item.hpp
@@ -69,7 +69,7 @@ namespace cyberway { namespace chaindb {
         cache_cell::cache_cell_kind kind() const;
     }; // struct cache_object_state
 
-    struct cache_object final: public boost::intrusive_ref_counter<cache_object> {
+    struct cache_object final: public boost::intrusive_ref_counter<cache_object, boost::thread_unsafe_counter> {
         enum stage_kind {
             Released,
             Active,

--- a/libraries/chain/include/cyberway/chaindb/cache_map.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cache_map.hpp
@@ -33,6 +33,7 @@ namespace cyberway { namespace chaindb {
 
         void clear_unsuccess(const table_info&) const;
 
+        void set_value(const table_info&, cache_object&, const object_value&) const;
         void set_object(const table_info&, cache_object&, object_value) const;
         void set_service(const table_info&, cache_object&, service_state) const;
         void set_revision(const object_value&, revision_t) const;

--- a/libraries/chain/include/cyberway/chaindb/exception.hpp
+++ b/libraries/chain/include/cyberway/chaindb/exception.hpp
@@ -88,8 +88,7 @@ namespace cyberway { namespace chaindb {
         FC_DECLARE_DERIVED_EXCEPTION(driver_duplicate_exception, chaindb_internal_exception,
                                      3710014, "ChainDB driver duplicate unique records")
 
-        FC_DECLARE_DERIVED_EXCEPTION(driver_open_exception, chaindb_internal_exception,
-                                     3710015, "ChainDB driver fail to open database")
+        using driver_open_exception = eosio::chain::database_guard_exception;
 
         FC_DECLARE_DERIVED_EXCEPTION(driver_opened_cursors_exception, chaindb_internal_exception,
                                      3710016, "ChainDB driver has opened cursors")

--- a/libraries/chain/include/cyberway/chaindb/exception.hpp
+++ b/libraries/chain/include/cyberway/chaindb/exception.hpp
@@ -174,4 +174,10 @@ namespace cyberway { namespace chaindb {
         FC_DECLARE_DERIVED_EXCEPTION(object_exception, chaindb_object_exception,
                                      3740003, "Object has reserved field name")
 
+        FC_DECLARE_DERIVED_EXCEPTION(index_size_exception, chaindb_object_exception,
+                                     3740004, "Object index size overflow")
+
+        FC_DECLARE_DERIVED_EXCEPTION(object_size_exception, chaindb_object_exception,
+                                     3740005, "Object size overflow")
+
 } } // namespace cyberway::chaindb

--- a/libraries/chain/include/eosio/chain/abi_def.hpp
+++ b/libraries/chain/include/eosio/chain/abi_def.hpp
@@ -95,6 +95,9 @@ struct index_def {
    vector<order_def>  orders;
 };
 
+using index_names = std::vector<index_name>;
+using field_index_map = fc::flat_map<field_name, index_names>;
+
 struct table_def {
    table_def() = default;
    table_def(const table_name& name, const type_name& type, const vector<index_def>& indexes)
@@ -110,8 +113,8 @@ struct table_def {
    vector<index_def>  indexes;     //
 
    // The following fields are service and set by chain code
-   int64_t                    row_count = 0;
-   flat_map<field_name, uint> field_index_map;
+   int64_t         row_count = 0;
+   field_index_map field_indexes;
 };
 
 struct error_message {

--- a/libraries/chain/include/eosio/chain/account_object.hpp
+++ b/libraries/chain/include/eosio/chain/account_object.hpp
@@ -31,14 +31,14 @@ namespace eosio { namespace chain {
 
       void set_abi( bytes a ) {
          abi = std::move(a);
-         abi_info_.reset();
+         abi_info_ptr_.reset();
       }
 
       void set_abi( const eosio::chain::abi_def& a ) {
          abi.resize( fc::raw::pack_size( a ) );
          fc::datastream<char*> ds( const_cast<char*>(abi.data()), abi.size() );
          fc::raw::pack( ds, a );
-         abi_info_.reset();
+         abi_info_ptr_.reset();
       }
 
       eosio::chain::abi_def get_abi()const {
@@ -50,11 +50,10 @@ namespace eosio { namespace chain {
          return a;
       }
 
-      void generate_abi_info();
-      const cyberway::chaindb::abi_info& get_abi_info() const;
+      cyberway::chaindb::abi_info_ptr generate_abi_info();
 
    private:
-      std::unique_ptr<cyberway::chaindb::abi_info> abi_info_;
+      cyberway::chaindb::abi_info_ptr abi_info_ptr_;
    };
 
    struct by_name;

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -251,7 +251,7 @@ namespace eosio { namespace chain {
                                  3060100, "Guard Exception" )
 
       FC_DECLARE_DERIVED_EXCEPTION( database_guard_exception, guard_exception,
-                                    3060101, "Database usage is at unsafe levels" )
+                                    3060101, "Database is unavailable" )
       FC_DECLARE_DERIVED_EXCEPTION( reversible_guard_exception, guard_exception,
                                     3060102, "Reversible block log usage is at unsafe levels" )
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1192,8 +1192,8 @@ fc::microseconds chain_plugin::get_abi_serializer_max_time() const {
 
 void chain_plugin::log_guard_exception(const chain::guard_exception&e ) const {
    if (e.code() == chain::database_guard_exception::code_value) {
-      elog("Database has reached an unsafe level of usage, shutting down to avoid corrupting the database.  "
-           "Please increase the value set for \"chain-state-db-size-mb\" and restart the process!");
+      elog("Shutting down to avoid corrupting the database. Fix problem and restart the process! Details: ${details}",
+           ("details", e.to_detail_string()));
    } else if (e.code() == chain::reversible_guard_exception::code_value) {
       elog("Reversible block database has reached an unsafe level of usage, shutting down to avoid corrupting the database.  "
            "Please increase the value set for \"reversible-blocks-db-size-mb\" and restart the process!");


### PR DESCRIPTION
Resolve #873:
- Add nodeosd stopping on error on loading data from MongoDB

Resolve #938:
- Add skipping of service records on ABI history on nodeosd startup.

Resolve #940:
- Add checking on empty field list in index ABI description

Resolve #943:
- Add limits on size of index keys and objects

Resolve #945:
- undo-state use ABI revision, which was used on inserting/updating/deleting of object

Resolve #245:
- Add direction to list of fields on checking unique list of fields in index

Additional changes:
- Fix error messages on ABI validation
- Use std::optional instead of std::unique_ptr to store mongodb cursor
