### PR TITLE
Contracts storage usage #961, #931

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -514,8 +514,6 @@ storage_payer_info apply_context::get_storage_payer( account_name owner, account
 }
 
 void apply_context::add_storage_usage( const storage_payer_info& storage ) {
-   bool is_authorized = false;
-
    if( storage.delta > 0 ) {
       if( !(privileged || storage.payer == receiver) ) {
          EOS_ASSERT( control.is_ram_billing_in_notify_allowed() || (receiver == act.account), subjective_block_production_exception,
@@ -524,13 +522,9 @@ void apply_context::add_storage_usage( const storage_payer_info& storage ) {
             require_authorization( storage.payer );
          }
       }
-
-      is_authorized = true;
-   } else {
-      is_authorized = has_authorization( storage.payer );
    }
 
-   trx_context.add_storage_usage( storage, is_authorized );
+   trx_context.add_storage_usage( storage );
 }
 
 int apply_context::get_action( uint32_t type, uint32_t index, char* buffer, size_t buffer_size )const

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -113,9 +113,11 @@ namespace cyberway { namespace chaindb {
         } else if (BOOST_LIKELY(!!apply_ctx)) {
             apply_ctx->add_storage_usage(*this);
         } else if (!!transaction_ctx) {
-            transaction_ctx->add_storage_usage(*this, false);
+            transaction_ctx->add_storage_usage(*this);
         } else if (!!resource_mng) {
-            resource_mng->add_storage_usage(payer, delta, time_slot, false);
+            CYBERWAY_ASSERT(0 > delta /* updating and removing */ || 0 == time_slot /* genesis */,
+                eosio::chain::resource_limit_exception, "SYSTEM: attempt to use STORAGE without authorization");
+            resource_mng->add_storage_usage(payer, delta, time_slot);
         }
     }
 

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -987,7 +987,8 @@ struct controller_impl {
             ram_to_bill_bytes = std::min(ram_to_bill_bytes, trx_context.hard_limits[resource_limits::RAM].max);
          }
          
-         resource_limits.add_transaction_usage( trx_context.bill_to_accounts, cpu_time_to_bill_us, 0, ram_to_bill_bytes, self.pending_block_time(), false ); // Should never fail
+         resource_limits.add_transaction_usage( trx_context.bill_to_accounts, trx_context.pricelist,
+             cpu_time_to_bill_us, 0, ram_to_bill_bytes, self.pending_block_time(), false ); // Should never fail
          trace->receipt = push_receipt(gtrx.trx_id, transaction_receipt::hard_fail, cpu_time_to_bill_us, 0, ram_to_bill_bytes, 0);
 
          emit( self.accepted_transaction, trx );

--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -33,7 +33,7 @@ namespace resource_limits {
 
    using ratio = impl::ratio<uint64_t>;
    static constexpr ratio constant_rate = ratio{ uint64_t(config::percent_100), uint64_t(config::percent_100) };
-   
+   using ratios = std::vector<ratio>;
    
    struct elastic_limit_parameters {
       uint64_t target;           // the desired usage
@@ -65,9 +65,10 @@ namespace resource_limits {
 
          void update_account_usage( const flat_set<account_name>& accounts, uint32_t ordinal );
 
-         void add_transaction_usage( const flat_set<account_name>& accounts, uint64_t cpu_usage, uint64_t net_usage, uint64_t ram_usage, fc::time_point pending_block_time, bool validate = true );
+         void add_transaction_usage( const flat_set<account_name>& accounts, const ratios&, uint64_t cpu_usage, uint64_t net_usage, uint64_t ram_usage, fc::time_point pending_block_time, bool validate = true );
 
-         void add_storage_usage(const account_name& account, int64_t delta, uint32_t time_slot, bool);
+         void add_storage_usage( const account_name& account, int64_t delta, uint32_t time_slot );
+         void add_storage_usage( const flat_map<account_name, int64_t>&, const ratios& prices, fc::time_point, bool validate = true );
 
          void process_block_usage(uint32_t time_slot);
 
@@ -76,7 +77,7 @@ namespace resource_limits {
 
          uint64_t get_block_limit(resource_id res, const chain_config& chain_cfg) const;
          
-         std::vector<ratio> get_pricelist() const;
+         ratios get_pricelist() const;
 
          ratio get_resource_usage_by_account_cost_ratio(account_name account, resource_id res) const;
          ratio get_account_stake_ratio(fc::time_point pending_block_time, const account_name& account, bool update_state);
@@ -84,7 +85,7 @@ namespace resource_limits {
          uint64_t get_used_resources_cost(account_name account, const std::vector<ratio>& prices, uint64_t max_cost = UINT64_MAX) const;
          uint64_t get_used_resources_cost(account_name account) const { return get_used_resources_cost(account, get_pricelist()); };
 
-         uint64_t get_account_balance(fc::time_point pending_block_time, const account_name& account, const std::vector<ratio>& prices, bool update_state);
+         uint64_t get_account_balance(fc::time_point pending_block_time, const account_name& account, const ratios& prices, bool update_state);
 
          std::vector<uint64_t> get_account_usage(const account_name& account) const;
 

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -102,7 +102,7 @@ namespace eosio { namespace chain {
          uint32_t update_billed_cpu_time( fc::time_point now );
          uint64_t update_billed_ram_bytes();
 
-         void add_storage_usage( const storage_payer_info&, bool is_authorized );
+         void add_storage_usage( const storage_payer_info& );
 
 // TODO: request bw, why provided?
 //         uint64_t get_provided_net_limit(account_name account) const;
@@ -170,6 +170,9 @@ namespace eosio { namespace chain {
 
          vector<action_receipt>        executed;
          flat_set<account_name>        bill_to_accounts;
+         flat_map<account_name, int64_t> accounts_storage_deltas;
+
+         resource_limits::ratios       pricelist;
 
          fc::microseconds              delay;
          bool                          is_input           = false;
@@ -205,14 +208,15 @@ namespace eosio { namespace chain {
 //         std::map<account_name, provided_bandwith> provided_bandwith_;
 
         fc::flat_map<account_name, account_name> storage_providers;
-         
+
         class available_resources_t {
-            std::vector<resource_limits::ratio> pricelist;
-            std::map<account_name, uint64_t> cpu_limits;
+            transaction_context& trx_ctx;
+            fc::flat_map<account_name, uint64_t> cpu_limits;
             uint64_t min_cpu_limit = UINT64_MAX;
-            bool explicit_cpu_time = false;
         public:
-            void init(bool, resource_limits_manager& rl, const flat_set<account_name>& accounts, fc::time_point pending_block_time);
+            available_resources_t(transaction_context& ctx): trx_ctx(ctx) { }
+
+            void init();
             void update_storage_usage(const storage_payer_info&);
             void add_net_usage(int64_t delta);
             void check_cpu_usage(int64_t usage) const;

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -402,6 +402,8 @@ namespace bacc = boost::accumulators;
        auto& rl = control.get_mutable_resource_limits_manager();
 
        update_billed_ram_bytes();
+
+       storage_bytes = ((storage_bytes + 1023) >> 10) << 10; // Round up to nearest kbytes
        
        net_usage = ((net_usage + 7)/8)*8;
        


### PR DESCRIPTION
Resolve #961:
- Add storage usage for contracts.

Resolve #931:
- Ceil-round-up of storage usage in receipts.

Additional changes:
- Allow to curve storage usage without authorization (actual for contracts)
- Fix exception type in resource manager. 