### PR TITLE
Changes for bandwidth #979, #975, #977, #980

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -515,7 +515,7 @@ storage_payer_info apply_context::get_storage_payer( account_name owner, account
 
 void apply_context::add_storage_usage( const storage_payer_info& storage ) {
    if( storage.delta > 0 ) {
-      if( !(privileged || storage.payer == receiver) ) {
+      if( !(privileged || storage.owner == receiver) ) {
          EOS_ASSERT( control.is_ram_billing_in_notify_allowed() || (receiver == act.account), subjective_block_production_exception,
              "Cannot charge RAM to other accounts during notify." );
          if( storage.owner == storage.payer ) {

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -65,9 +65,10 @@ void apply_context::exec_one( action_trace& trace )
             try {
                auto reset_cache_on_exit = fc::make_scoped_exit([this]{
                   this->chaindb_cache = nullptr;
+                  this->cursors_guard = nullptr;
                });
 
-               chaindb_guard guard(*this);
+               chaindb_guard guard;
                chaindb_cursor_cache cache;
 
                this->chaindb_cache = &cache;

--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -679,9 +679,13 @@ namespace cyberway { namespace chaindb {
         int update(const table_info& table, storage_payer_info charge, object_value& obj, object_value orig_obj) {
             validate_object(table, obj, obj.pk());
 
-            charge.get_payer_from(orig_obj);
             charge.size   = calc_storage_usage(table, obj.value);
             charge.delta += charge.size - orig_obj.service.size;
+
+            if (charge.delta <= 0) {
+                charge.payer = charge.owner;
+            }
+            charge.get_payer_from(orig_obj);
 
             // don't charge on genesis
             if (undo_.revision() != start_revision) {

--- a/libraries/chain/include/cyberway/chaindb/cursor_cache.hpp
+++ b/libraries/chain/include/cyberway/chaindb/cursor_cache.hpp
@@ -9,19 +9,13 @@
 namespace cyberway { namespace chaindb {
 
     struct chaindb_guard final {
-        chaindb_guard() = delete;
+        chaindb_guard() = default;
         chaindb_guard(const chaindb_guard&) = delete;
         chaindb_guard(chaindb_guard&& other) = delete;
         chaindb_guard& operator = (const chaindb_guard& other) = delete;
         chaindb_guard& operator = (chaindb_guard&& other) = delete;
 
-        chaindb_guard(apply_context& context) :
-           context_(context) {
-        }
-
-        ~chaindb_guard() {
-            context_.cursors_guard = nullptr;
-        }
+        ~chaindb_guard() = default;
 
         cursor_t add(account_name_t code, find_info&& info) {
             external_code_cursors_[code].emplace_back(std::forward<find_info>(info));
@@ -51,7 +45,6 @@ namespace cyberway { namespace chaindb {
 
     private:
         std::map<account_name_t, std::vector<find_info>> external_code_cursors_;
-        apply_context& context_;
     }; // class chaindb_guard
 
     struct chaindb_cursor_cache final {

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -186,6 +186,8 @@ namespace eosio { namespace chain {
          uint64_t&                     billed_ram_bytes;
          bool                          explicit_billed_ram_bytes = false;
 
+         fc::flat_map<account_name, account_name> storage_providers;
+
       private:
          bool                          is_initialized = false;
 
@@ -206,8 +208,6 @@ namespace eosio { namespace chain {
 
 // TODO: request bw, why provided?
 //         std::map<account_name, provided_bandwith> provided_bandwith_;
-
-        fc::flat_map<account_name, account_name> storage_providers;
 
         class available_resources_t {
             transaction_context& trx_ctx;

--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -9,6 +9,7 @@
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/stake_object.hpp>
 #include <eosio/chain/int_arithmetic.hpp>
+#include <cyberway/chain/cyberway_contract_types.hpp>
 #include <fc/io/raw.hpp>
 #include <fc/variant.hpp>
 #include <boost/filesystem/path.hpp>
@@ -1139,9 +1140,13 @@ struct genesis_create::genesis_create_impl final {
         ilog("Scheduling Golos start...");
         db.start_section(config::system_account_name, N(gtransaction), "generated_transaction_object", 2);
         auto store_tx = [&](name code, name act_name, uint64_t sender_id_low, const bytes& data = {}) {
+            auto providebw = cyberway::chain::providebw(_info.golos.names.issuer, code);
             transaction tx{};
             tx.actions.emplace_back(action{{{code, config::active_name}}, code, act_name, data});
-            auto actor = _info.golos.names.issuer;
+            tx.actions.emplace_back(action{{{providebw.provider, N(providebw)}},
+                providebw.get_account(), providebw.get_name(),
+                fc::raw::pack(providebw)});
+            auto actor = code;
             db.emplace<generated_transaction_object>(actor, [&](auto& t){
                 t.set(tx);
                 t.trx_id = tx.id();


### PR DESCRIPTION
Resolve #979:
- check owner instead of payer in protection from writing data to notified account. can happens if contract has bw provider.

Resolve #975:
- add bw provider to transaction with onerror handler

Resolve #977:
- don't change payer if delta <= 0

Resolve #980:
- add gls as bw provider for golos scheduled transaction in genesis.