### PR TITLE
Add parent_author/permlink to EE-genesis rewards #982

### DIFF
--- a/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
+++ b/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
@@ -115,6 +115,8 @@ static abi_def create_rewards_abi() {
         "author_reward", "", {
             {"author", "name"},
             {"permlink", "string"},
+            {"parent_author", "name"},
+            {"parent_permlink", "string"},
             {"sbd_and_steem_payout", "asset"},
             {"vesting_payout", "asset"},
             {"time", "time_point_sec"},
@@ -126,6 +128,8 @@ static abi_def create_rewards_abi() {
             {"benefactor", "name"},
             {"author", "name"},
             {"permlink", "string"},
+            {"parent_author", "name"},
+            {"parent_permlink", "string"},
             {"reward", "asset"},
             {"time", "time_point_sec"},
         }
@@ -135,8 +139,10 @@ static abi_def create_rewards_abi() {
         "curation_reward", "", {
             {"curator", "name"},
             {"reward", "asset"},
-            {"comment_author", "name"},
-            {"comment_permlink", "string"},
+            {"author", "name"},
+            {"permlink", "string"},
+            {"parent_author", "name"},
+            {"parent_permlink", "string"},
             {"time", "time_point_sec"},
         }
     });

--- a/programs/create-genesis/ee_genesis/event_engine_genesis.hpp
+++ b/programs/create-genesis/ee_genesis/event_engine_genesis.hpp
@@ -96,6 +96,8 @@ struct author_reward {
 
     name author;
     string permlink;
+    name parent_author;
+    string parent_permlink;
     asset sbd_and_steem_payout;
     asset vesting_payout;
     fc::time_point_sec time;
@@ -107,6 +109,8 @@ struct benefactor_reward {
     name benefactor;
     name author;
     string permlink;
+    name parent_author;
+    string parent_permlink;
     asset reward;
     fc::time_point_sec time;
 };
@@ -116,8 +120,10 @@ struct curation_reward {
 
     name curator;
     asset reward;
-    name comment_author;
-    string comment_permlink;
+    name author;
+    string permlink;
+    name parent_author;
+    string parent_permlink;
     fc::time_point_sec time;
 };
 
@@ -161,9 +167,9 @@ FC_REFLECT(cyberway::genesis::ee::comment_info, (parent_author)(parent_permlink)
     (author_reward)(benefactor_reward)(curator_reward)(votes)(reblogs))
 FC_REFLECT(cyberway::genesis::ee::transfer_info, (from)(to)(quantity)(memo)(to_vesting)(time))
 FC_REFLECT(cyberway::genesis::ee::withdraw_info, (from)(to)(quantity)(time))
-FC_REFLECT(cyberway::genesis::ee::author_reward, (author)(permlink)(sbd_and_steem_payout)(vesting_payout)(time))
-FC_REFLECT(cyberway::genesis::ee::benefactor_reward, (benefactor)(author)(permlink)(reward)(time))
-FC_REFLECT(cyberway::genesis::ee::curation_reward, (curator)(reward)(comment_author)(comment_permlink)(time))
+FC_REFLECT(cyberway::genesis::ee::author_reward, (author)(permlink)(parent_author)(parent_permlink)(sbd_and_steem_payout)(vesting_payout)(time))
+FC_REFLECT(cyberway::genesis::ee::benefactor_reward, (benefactor)(author)(permlink)(parent_author)(parent_permlink)(reward)(time))
+FC_REFLECT(cyberway::genesis::ee::curation_reward, (curator)(reward)(author)(permlink)(parent_author)(parent_permlink)(time))
 FC_REFLECT(cyberway::genesis::ee::delegation_reward, (delegator)(delegatee)(reward)(time))
 FC_REFLECT(cyberway::genesis::ee::balance_convert_info, (owner)(amount)(memo))
 FC_REFLECT(cyberway::genesis::ee::pin_info, (pinner)(pinning))


### PR DESCRIPTION
Resolves #982.

Slightly slow and complicated, but don't requires any changes in operation dump, and don't increases its size. Just recreate EE-genesis and copy it to IO nodes.