### PR TITLE
Bandwith delegation supported in the get_account api funcion 

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -188,8 +188,8 @@ namespace {
           prices_(rm.get_pricelist()),
           stake_agent_(controller_.find<eosio::chain::stake_agent_object, eosio::chain::stake_agent_object::by_key>
                        (eosio::chain::stake::agent_key(chain::symbol(CORE_SYMBOL).to_symbol_code(), account_))),
-          total_stake_(stake_agent_->get_effective_stake()),
-          owned_stake_(stake_agent_->get_own_funds() - stake_agent_->provided),
+          total_stake_(stake_agent_ == nullptr ? 0 : stake_agent_->get_effective_stake()),
+          owned_stake_(stake_agent_ == nullptr ? 0 : (stake_agent_->get_own_funds() - stake_agent_->provided)),
           resources_usage_(rm.get_account_usage(name)),
           resources_info_(chain::resource_limits::resources_num),
           resource_limits_(chain::resource_limits::resources_num),

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -186,9 +186,10 @@ namespace {
           controller_(controller),
           account_(name),
           prices_(rm.get_pricelist()),
-          total_stake_(rm.get_account_stake_ratio(fc::time_point::now(), account_, false).numerator),
-          owned_stake_(controller_.find<eosio::chain::stake_agent_object, eosio::chain::stake_agent_object::by_key>
-                       (eosio::chain::stake::agent_key(chain::symbol(CORE_SYMBOL).to_symbol_code(), account_))->balance),
+          stake_agent_(controller_.find<eosio::chain::stake_agent_object, eosio::chain::stake_agent_object::by_key>
+                       (eosio::chain::stake::agent_key(chain::symbol(CORE_SYMBOL).to_symbol_code(), account_))),
+          total_stake_(stake_agent_->get_effective_stake()),
+          owned_stake_(stake_agent_->get_own_funds() - stake_agent_->provided),
           resources_usage_(rm.get_account_usage(name)),
           resources_info_(chain::resource_limits::resources_num),
           resource_limits_(chain::resource_limits::resources_num),
@@ -307,6 +308,7 @@ namespace {
         cyberway::chaindb::chaindb_controller& controller_;
         chain::account_name account_;
         std::vector<chain::resource_limits::ratio> prices_;
+        const eosio::chain::stake_agent_object* stake_agent_;
         uint64_t total_stake_;
         uint64_t owned_stake_;
         uint64_t account_balance_ = 0;

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2376,19 +2376,27 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
          return ss.str();
       };
 
-
+      asset owned_memory_stake = asset::from_string(res.self_delegated_bandwidth.get_object()["ram_weight"].as_string());
+      asset total_memory_stake = asset::from_string(res.total_resources.get_object()["ram_weight"].as_string());
 
       std::cout << "memory: " << std::endl << indent
           <<   "quota (eq storage.max):" << std::setw(15) << to_pretty_net(res.ram_quota)
           <<   "max:"                    << std::setw(15) << to_pretty_net(res.ram_limit.max)
           <<   "used:"                   << std::setw(15) << to_pretty_net(res.ram_limit.used)
-          <<   "avilable:"               << std::setw(15) << to_pretty_net(res.ram_limit.available) << std::endl << std::endl;
+          <<   "avilable:"               << std::setw(15) << to_pretty_net(res.ram_limit.available) << std::endl << indent
+          <<   "staked:"                 << std::setw(20) << owned_memory_stake << std::endl << indent
+          <<   "delegated:"              << std::setw(17) << total_memory_stake - owned_memory_stake << std::endl << endl;
+
+
+      asset owned_storage_stake = asset::from_string(res.self_delegated_bandwidth.get_object()["storage_weight"].as_string());
+      asset total_storage_stake = asset::from_string(res.total_resources.get_object()["storage_weight"].as_string());
 
       std::cout << "storage: " << std::endl << indent
           <<   "max: "                    << std::setw(15) << to_pretty_net(res.storage_limit.max)
           <<   "used: "                   << std::setw(15) << to_pretty_net(res.storage_limit.used)
-          <<   "avilable: "               << std::setw(15) << to_pretty_net(res.storage_limit.available) << std::endl << std::endl;
-
+          <<   "avilable: "               << std::setw(15) << to_pretty_net(res.storage_limit.available) << std::endl << indent
+          <<   "staked:"                 << std::setw(20) << owned_storage_stake << std::endl << indent
+          <<   "delegated:"              << std::setw(17) << total_storage_stake - owned_storage_stake << std::endl << std::endl;
 
       std::cout << "net bandwidth: " << std::endl;
       if ( res.total_resources.is_object() ) {
@@ -2466,7 +2474,10 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
 
          if( res.self_delegated_bandwidth.is_object() ) {
             asset cpu_own = asset::from_string( res.self_delegated_bandwidth.get_object()["cpu_weight"].as_string() );
-            staked += cpu_own;
+            asset ram_own = asset::from_string( res.self_delegated_bandwidth.get_object()["ram_weight"].as_string() );
+            asset store_own = asset::from_string( res.self_delegated_bandwidth.get_object()["storage_weight"].as_string() );
+
+            staked += cpu_own + ram_own + store_own;
 
             auto cpu_others = cpu_total - cpu_own;
 


### PR DESCRIPTION
Resolve #978.

Additionaly fixed wrong bandwith calculation in the total field and
added staking values to the memory and storage fields in the cleos.
