### PR TITLE
Counting delegators in genesis #990

### DIFF
--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -799,6 +799,7 @@ struct genesis_create::genesis_create_impl final {
                 ("delegated", asset(vests.delegated, symbol(VESTS)))
                 ("received", asset(vests.received, symbol(VESTS)))
                 ("unlocked_limit", asset(0, symbol(VESTS)))
+                ("delegators", data.delegators[acc])
             );
         }
         ilog("Done.");

--- a/programs/create-genesis/state_reader.hpp
+++ b/programs/create-genesis/state_reader.hpp
@@ -80,6 +80,7 @@ struct state_object_visitor {
     std::vector<golos::vesting_delegation_expiration_object> delegation_expirations;
     fc::flat_map<acc_idx, share_type> delegated_vests;
     fc::flat_map<acc_idx, share_type> received_vests;
+    fc::flat_map<acc_idx, uint32_t> delegators;
 
     fc::flat_map<acc_idx,acc_idx> withdraw_routes;  // from:to
 
@@ -154,6 +155,7 @@ struct state_object_visitor {
         delegations.emplace_back(d);
         delegated_vests[d.delegator.id] += d.vesting_shares.get_amount();
         received_vests[d.delegatee.id] += d.vesting_shares.get_amount();
+        delegators[d.delegatee.id]++;
     }
 
     void operator()(const golos::vesting_delegation_expiration_object& d) {


### PR DESCRIPTION
Resolves #990.

If delegatee has more than `max_delegators`, they are *not* shrinking.