### PR TITLE
Set object owner to actual payer. #991

### DIFF
--- a/libraries/chain/chaindb/controller.cpp
+++ b/libraries/chain/chaindb/controller.cpp
@@ -132,7 +132,7 @@ namespace cyberway { namespace chaindb {
     }
 
     void storage_payer_info::set_payer_in(object_value& obj) const {
-        obj.service.payer  = owner;
+        obj.service.payer  = payer;
         obj.service.size   = size;
         obj.service.in_ram = in_ram;
     }


### PR DESCRIPTION
Resolve #991:
- Removing object created with provider should have information about payer on update/remove.