### PR TITLE
Extend authorities for golos transit accounts #985

### DIFF
--- a/programs/create-genesis/genesis_create.hpp
+++ b/programs/create-genesis/genesis_create.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "genesis_exception.hpp"
 #include "genesis_info.hpp"
 #include "export_info.hpp"
 #include "supply_distributor.hpp"
@@ -8,8 +9,6 @@
 
 
 namespace cyberway { namespace genesis {
-
-FC_DECLARE_EXCEPTION(genesis_exception, 9000000, "genesis create exception");
 
 using namespace eosio::chain;
 namespace bfs = boost::filesystem;

--- a/programs/create-genesis/genesis_exception.hpp
+++ b/programs/create-genesis/genesis_exception.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <fc/exception/exception.hpp>
+
+namespace cyberway { namespace genesis {
+
+FC_DECLARE_EXCEPTION(genesis_exception, 9000000, "genesis create exception");
+
+} } // namespace cyberway::genesis

--- a/programs/create-genesis/main.cpp
+++ b/programs/create-genesis/main.cpp
@@ -157,13 +157,7 @@ void config_reader::read_config(const variables_map& options) {
     std::cout << "Initial configuration = {" << std::endl << genesis.initial_configuration << "}" << std::endl;
 
     // base validation and init
-    for (auto& a: info.accounts) {
-        for (auto& p: a.permissions) {
-            EOS_ASSERT(p.key.length() == 0 || p.keys.size() == 0, genesis_exception,
-                "Account ${a} permission can't contain both `key` and `keys` fields at the same time", ("a",a.name));
-            p.init();
-        }
-    }
+    info.init();
     EOS_ASSERT(info.golos.max_supply >= 0, genesis_exception, "max_supply can't be negative");
     EOS_ASSERT(info.golos.sys_max_supply >= 0, genesis_exception, "sys_max_supply can't be negative");
     for (const auto& f: info.params.funds) {


### PR DESCRIPTION
Resolves #985
Add section `transit_account_authorities` in genesis-info.json with description of authorities added to exist accounts.