### PR TITLE
Add contract ABIs to EE-genesis #987

### DIFF
--- a/plugins/event_engine_plugin/include/eosio/event_engine_plugin/messages.hpp
+++ b/plugins/event_engine_plugin/include/eosio/event_engine_plugin/messages.hpp
@@ -101,6 +101,7 @@ namespace eosio {
    };
 
    const auto core_genesis_code = N(core);
+   const auto abi_genesis_code = N(abi);
 
    struct AcceptTrxMessage : public BaseMessage, TrxMetadata {
        AcceptTrxMessage(MsgChannel msg_channel, BaseMessage::MsgType msg_type, const chain::transaction_metadata_ptr &trx_meta)

--- a/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
+++ b/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
@@ -271,6 +271,9 @@ static abi_def create_funds_abi() {
 }
 
 void event_engine_genesis::start(const bfs::path& ee_directory, const fc::sha256& hash) {
+    abi_dir = ee_directory / "abis";
+    fc::create_directories(abi_dir);
+
     using ser_info = std::tuple<string, abi_def>;
     const std::map<ee_ser_type, ser_info> infos = {
         {ee_ser_type::messages,    {"messages.dat",    create_messages_abi()}},
@@ -294,6 +297,10 @@ void event_engine_genesis::finalize() {
     for (auto& s: serializers) {
         s.second.finalize();
     }
+}
+
+void event_engine_genesis::add_abi(const account_name& abi_name, const bfs::path& abi_file) {
+    bfs::copy_file(abi_file, abi_dir / abi_name.to_string().append(".abi"), bfs::copy_option::overwrite_if_exists);
 }
 
 } } } // cyberway::genesis::ee

--- a/programs/create-genesis/ee_genesis/event_engine_genesis.hpp
+++ b/programs/create-genesis/ee_genesis/event_engine_genesis.hpp
@@ -16,14 +16,15 @@ public:
     void start(const bfs::path& ee_directory, const fc::sha256& hash);
     void finalize();
 
+    void add_abi(const account_name& abi_name, const bfs::path& abi_file);
+
     enum ee_ser_type {messages, transfers, withdraws, delegations, rewards, pinblocks, accounts, witnesses, funds, balance_conversions};
     ee_genesis_serializer& get_serializer(ee_ser_type type) {
         return serializers.at(type);
     }
-
 private:
+    bfs::path abi_dir;
     std::map<ee_ser_type, ee_genesis_serializer> serializers;
-
 };
 
 struct vote_info {

--- a/programs/create-genesis/ee_genesis/genesis_ee_builder.cpp
+++ b/programs/create-genesis/ee_genesis/genesis_ee_builder.cpp
@@ -422,6 +422,13 @@ void genesis_ee_builder::read_operation_dump(const bfs::path& in_dump_dir) {
     process_account_metas();
 }
 
+void genesis_ee_builder::write_contract_abis() {
+    std::cout << "-> Writing ABIs..." << std::endl;
+    for (const auto& acc: info_.accounts) if (!!acc.abi) {
+        out_.add_abi(acc.name, acc.abi->path);
+    }
+}
+
 void genesis_ee_builder::build_votes(std::vector<vote_info>& votes, uint64_t msg_hash, operation_number msg_created) {
     const auto& vote_idx = maps_.get_index<vote_header_index, by_hash_voter>();
 
@@ -863,6 +870,7 @@ void genesis_ee_builder::build(const bfs::path& out_dir) {
 
     out_.start(out_dir, fc::sha256());
 
+    write_contract_abis();
     write_messages();
     write_transfers();
     write_withdraws();

--- a/programs/create-genesis/ee_genesis/genesis_ee_builder.hpp
+++ b/programs/create-genesis/ee_genesis/genesis_ee_builder.hpp
@@ -41,6 +41,7 @@ private:
     void process_follows();
     void process_account_metas();
 
+    void write_contract_abis();
     void build_votes(std::vector<vote_info>& votes, uint64_t msg_hash, operation_number msg_created);
     void build_reblogs(std::vector<reblog_info>& reblogs, uint64_t msg_hash, operation_number msg_created, bfs::ifstream& dump_reblogs);
     comment_operation get_comment(const comment_header& comment);


### PR DESCRIPTION
Resolves #987:

- `create-genesis` writes ABI files in `event-genesis/abis` directory. Files are naming like `gls.publish.abi`, not `golos.publication.abi`. **These names are really account names, not original ABI-file names.**
- Added cmd line option to EE-plugin:
```
("event-engine-genesis-abi",  bpo::value<vector<string>>()->composing()->multitoken())
```
- Added `abi` genesis message which looks like:
```
{"msg_channel":"Genesis","msg_type":"GenesisData","id":1,"code":"abi","name":"cyber.token","data":{"version":"cyberway::abi/1.1",...}}
```
- `name` is contract account name (name of `event-genesis/abis/*.abi`-file).
- `data` is JSON object of ABI, not string (to make it more compact and avoid problems with compatibility with JS).
- Added `abistart` message which is sending before `abi`. All together looks like:
```
{"msg_channel":"Genesis","msg_type":"GenesisData","id":0,"code":"core","name":"abistart","data":{}}
{"msg_channel":"Genesis","msg_type":"GenesisData","id":1,"code":"abi","name":"cyber.token","data":{"version":"cyberway::abi/1.1",...}}
{"msg_channel":"Genesis","msg_type":"GenesisData","id":2,"code":"abi","name":"gls.publish","data":{"version":"cyberway::abi/1.1",...}}
{"msg_channel":"Genesis","msg_type":"GenesisData","id":3,"code":"core","name":"datastart","data":{}}
{"msg_channel":"Genesis","msg_type":"GenesisData","id":4,"code":...}
{"msg_channel":"Genesis","msg_type":"GenesisData","id":5,"code":...}
{"msg_channel":"Genesis","msg_type":"GenesisData","id":6,"code":"core","name":"dataend","data":{}}
{"msg_channel":"Blocks","msg_type":"AcceptTrx",...}
```