### PR TITLE
Add contracts ABI to EE-genesis #987

### DIFF
--- a/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
+++ b/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
@@ -4,6 +4,20 @@ namespace cyberway { namespace genesis { namespace ee {
 
 #define ABI_VERSION "cyberway::abi/1.0"
 
+static abi_def create_contracts_abi() {
+    abi_def abi;
+    abi.version = ABI_VERSION;
+
+    abi.structs.emplace_back( struct_def {
+        "setabi", "", {
+            {"account", "name"},
+            {"abi", "bytes"}
+        }
+    });
+
+    return abi;
+}
+
 static abi_def create_messages_abi() {
     abi_def abi;
     abi.version = ABI_VERSION;
@@ -273,6 +287,7 @@ static abi_def create_funds_abi() {
 void event_engine_genesis::start(const bfs::path& ee_directory, const fc::sha256& hash) {
     using ser_info = std::tuple<string, abi_def>;
     const std::map<ee_ser_type, ser_info> infos = {
+        {ee_ser_type::contracts,   {"contracts.dat",   create_contracts_abi()}},
         {ee_ser_type::messages,    {"messages.dat",    create_messages_abi()}},
         {ee_ser_type::transfers,   {"transfers.dat",   create_transfers_abi()}},
         {ee_ser_type::withdraws,   {"withdraws.dat",   create_withdraws_abi()}},

--- a/programs/create-genesis/ee_genesis/event_engine_genesis.hpp
+++ b/programs/create-genesis/ee_genesis/event_engine_genesis.hpp
@@ -16,7 +16,7 @@ public:
     void start(const bfs::path& ee_directory, const fc::sha256& hash);
     void finalize();
 
-    enum ee_ser_type {messages, transfers, withdraws, delegations, rewards, pinblocks, accounts, witnesses, funds, balance_conversions};
+    enum ee_ser_type {contracts, messages, transfers, withdraws, delegations, rewards, pinblocks, accounts, witnesses, funds, balance_conversions};
     ee_genesis_serializer& get_serializer(ee_ser_type type) {
         return serializers.at(type);
     }
@@ -24,6 +24,13 @@ public:
 private:
     std::map<ee_ser_type, ee_genesis_serializer> serializers;
 
+};
+
+struct setabi_info {
+    OBJECT_CTOR(setabi_info);
+
+    name account;
+    bytes abi;
 };
 
 struct vote_info {
@@ -160,6 +167,7 @@ struct block_info {
 
 } } } // cyberway::genesis::ee
 
+FC_REFLECT(cyberway::genesis::ee::setabi_info, (account)(abi))
 FC_REFLECT(cyberway::genesis::ee::vote_info, (voter)(weight)(time)(rshares))
 FC_REFLECT(cyberway::genesis::ee::reblog_info, (account)(title)(body)(time))
 FC_REFLECT(cyberway::genesis::ee::comment_info, (parent_author)(parent_permlink)(author)(permlink)(created)(last_update)

--- a/programs/create-genesis/ee_genesis/genesis_ee_builder.cpp
+++ b/programs/create-genesis/ee_genesis/genesis_ee_builder.cpp
@@ -422,6 +422,18 @@ void genesis_ee_builder::read_operation_dump(const bfs::path& in_dump_dir) {
     process_account_metas();
 }
 
+void genesis_ee_builder::write_contracts_abis() {
+    std::cout << "-> Writing ABIs..." << std::endl;
+    auto& out = out_.get_serializer(event_engine_genesis::contracts);
+    out.start_section(config::system_account_name, N(setabi), "setabi");
+    for (const auto& acc: genesis_.get_contracts()) if (acc.second.abi.size()) {
+        out.emplace<setabi_info>([&](auto& r) {
+            r.account = acc.first;
+            r.abi = acc.second.abi;
+        });
+    }
+}
+
 void genesis_ee_builder::build_votes(std::vector<vote_info>& votes, uint64_t msg_hash, operation_number msg_created) {
     const auto& vote_idx = maps_.get_index<vote_header_index, by_hash_voter>();
 
@@ -863,6 +875,7 @@ void genesis_ee_builder::build(const bfs::path& out_dir) {
 
     out_.start(out_dir, fc::sha256());
 
+    write_contracts_abis();
     write_messages();
     write_transfers();
     write_withdraws();

--- a/programs/create-genesis/ee_genesis/genesis_ee_builder.hpp
+++ b/programs/create-genesis/ee_genesis/genesis_ee_builder.hpp
@@ -41,6 +41,7 @@ private:
     void process_follows();
     void process_account_metas();
 
+    void write_contracts_abis();
     void build_votes(std::vector<vote_info>& votes, uint64_t msg_hash, operation_number msg_created);
     void build_reblogs(std::vector<reblog_info>& reblogs, uint64_t msg_hash, operation_number msg_created, bfs::ifstream& dump_reblogs);
     comment_operation get_comment(const comment_header& comment);

--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -1347,6 +1347,9 @@ const genesis_info& genesis_create::get_info() const {
 const genesis_state& genesis_create::get_conf() const {
     return _impl->_conf;
 }
+const contracts_map& genesis_create::get_contracts() const {
+    return _impl->_contracts;
+}
 const export_info& genesis_create::get_exp_info() const {
     return _impl->_exp_info;
 }

--- a/programs/create-genesis/genesis_create.hpp
+++ b/programs/create-genesis/genesis_create.hpp
@@ -36,6 +36,7 @@ public:
     // ee interface
     const genesis_info& get_info() const;
     const genesis_state& get_conf() const;
+    const contracts_map& get_contracts() const;
     const export_info& get_exp_info() const;
     name name_by_idx(acc_idx idx) const;
     supply_distributor get_gbg_to_golos_converter() const;


### PR DESCRIPTION
Resolves #987.

Currently it fully imitates `setabi` action of chain, and it is main advantage of this alternative PR version.

TODO: Also can be added all contracts to accounts.dat, but most of account fields do not seem to be need now for contracts.