### PR TITLE
Fake history account. #1004

### DIFF
--- a/libraries/chain/chaindb/mongo_driver.cpp
+++ b/libraries/chain/chaindb/mongo_driver.cpp
@@ -618,7 +618,6 @@ namespace cyberway { namespace chaindb {
 
         void create_index(const index_info& info) const {
             document idx_doc;
-            bool was_pk = false;
             auto& index = *info.index;
 
             if (!is_noscope_table(info)) {
@@ -631,10 +630,9 @@ namespace cyberway { namespace chaindb {
                 } else {
                     idx_doc.append(kvp(field, -1));
                 }
-                was_pk |= (order.field == info.pk_order->field);
             }
 
-            if (!was_pk && !index.unique) {
+            if (!index.unique) {
                 // when index is not unique, we add unique pk for deterministic order of records
                 idx_doc.append(kvp(info.pk_order->field, 1));
             }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -611,8 +611,6 @@ struct controller_impl {
             a.set_abi(eosio_contract_abi());
          } else if (name == config::domain_account_name) {
             a.set_abi(domain_contract_abi());
-         } else if (name == config::history_account_name) {
-            a.set_abi(history_contract_abi());
          }
       });
       chaindb.emplace<account_sequence_object>(name.value, [&](auto & a) { });
@@ -661,7 +659,6 @@ struct controller_impl {
           create_native_account( config::system_account_name, system_auth, system_auth, true );
           create_native_account(config::msig_account_name, system_auth, system_auth, true);
           create_native_account(config::domain_account_name, system_auth, system_auth);
-          create_native_account(config::history_account_name, system_auth, system_auth);
           create_native_account(config::govern_account_name, system_auth, system_auth, true);
           create_native_account(config::stake_account_name, system_auth, system_auth, true);
     

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -91,6 +91,7 @@ void apply_cyber_newaccount(apply_context& context) {
    auto name_str = name(create.name).to_string();
 
    EOS_ASSERT( !create.name.empty(), action_validate_exception, "account name cannot be empty" );
+   EOS_ASSERT( name_str.front() != '.', action_validate_exception, "account name cannot start from '.'" );
    EOS_ASSERT( name_str.size() <= 12, action_validate_exception, "account names can only be 12 chars long" );
 
    // Check if the creator is privileged
@@ -235,8 +236,6 @@ void apply_cyber_setabi(apply_context& context) {
         act.abi = cyberway::chaindb::merge_abi_def(eosio::chain::eosio_contract_abi(), act.abi);
     } else if (act.account == eosio::chain::config::domain_account_name) {
         act.abi = cyberway::chaindb::merge_abi_def(eosio::chain::domain_contract_abi(), act.abi);
-    } else if (act.account == eosio::chain::config::history_account_name) {
-        act.abi = cyberway::chaindb::merge_abi_def(eosio::chain::history_contract_abi(), act.abi);
     }
 
    int64_t abi_size = act.abi.size();

--- a/libraries/chain/eosio_contract.cpp
+++ b/libraries/chain/eosio_contract.cpp
@@ -139,8 +139,8 @@ void apply_cyber_newaccount(apply_context& context) {
 
 // system account and accounts with system prefix (cyber.*) are protected
 bool is_protected_account(name acc) {
-    // TODO: prefix can be checked without string using binary AND
-    return acc == config::system_account_name || name{acc}.to_string().find(system_prefix()) == 0;
+    auto mask = name_to_mask( config::system_account_name );
+    return (mask & acc.value) == config::system_account_name;
 }
 
 fc::sha256 bytes_hash(bytes data) {

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -803,14 +803,14 @@ abi_def history_contract_abi(abi_def abi) {
        name("pubkeyhist"), "pubkeyhist", {
           { name("primary"), true, {{"id", "asc"}} },
           { name("bypubkey"), false, {
-                {"public_key", "asc"}
-//                {"id", "asc"}
+                {"public_key", "asc"},
+                {"id", "asc"}
             }
           },
           { name("byaccperm"), false, {
                 {"name", "asc"},
-                {"permission", "asc"}
-//                {"id", "asc"}
+                {"permission", "asc"},
+                {"id", "asc"}
             }
           }
        }
@@ -831,7 +831,7 @@ abi_def history_contract_abi(abi_def abi) {
           },
           { name("bycontrol"), false, {
                 {"controlling_account", "asc"},
-//                {"id", "asc"}
+                {"id", "asc"}
             }
           },
           { name("controlauth"), false, {

--- a/libraries/chain/eosio_contract_abi.cpp
+++ b/libraries/chain/eosio_contract_abi.cpp
@@ -802,12 +802,12 @@ abi_def history_contract_abi(abi_def abi) {
     abi.tables.emplace_back( eosio::chain::table_def {
        name("pubkeyhist"), "pubkeyhist", {
           { name("primary"), true, {{"id", "asc"}} },
-          { name("bypubkey"), false, {
+          { name("bypubkey"), true, {
                 {"public_key", "asc"},
                 {"id", "asc"}
             }
           },
-          { name("byaccperm"), false, {
+          { name("byaccperm"), true, {
                 {"name", "asc"},
                 {"permission", "asc"},
                 {"id", "asc"}
@@ -829,7 +829,7 @@ abi_def history_contract_abi(abi_def abi) {
                 {"id", "asc"}
             }
           },
-          { name("bycontrol"), false, {
+          { name("bycontrol"), true, {
                 {"controlling_account", "asc"},
                 {"id", "asc"}
             }

--- a/libraries/chain/include/cyberway/chaindb/index_order_validator.hpp
+++ b/libraries/chain/include/cyberway/chaindb/index_order_validator.hpp
@@ -12,17 +12,13 @@ namespace eosio { namespace chain {
 
 namespace cyberway { namespace chaindb {
 
-    class index_info;
-    class index_order_validator
-    {
+    struct index_info;
+    class index_order_validator final {
     public:
-
         index_order_validator(const index_info& index);
-
         void verify(const fc::variant& key) const;
 
     private:
-
         const index_info& index_;
     };
 

--- a/libraries/chain/include/cyberway/chaindb/noscope_tables.hpp
+++ b/libraries/chain/include/cyberway/chaindb/noscope_tables.hpp
@@ -15,6 +15,10 @@
 namespace cyberway { namespace chaindb {
 
     inline bool is_noscope_table(const table_info& info) {
+        if (info.code == eosio::chain::config::history_account_name) {
+            return true;
+        }
+
         if (!is_system_code(info.code)) {
             return false;
         }

--- a/libraries/chain/include/eosio/chain/multi_index_includes.hpp
+++ b/libraries/chain/include/eosio/chain/multi_index_includes.hpp
@@ -13,7 +13,7 @@
 #include <cyberway/chaindb/multi_index.hpp>
 #include <cyberway/chaindb/index_object.hpp>
 
-#define CHAINDB_TABLE_TAG(_TYPE, _NAME, _ACCOUNT)       \
+#define CHAINDB_TABLE_TAG(_TYPE, _ACCOUNT, _NAME)       \
     namespace cyberway { namespace chaindb {            \
         template<> struct tag<_TYPE> {                  \
             using type = _TYPE;                         \

--- a/libraries/chain/include/eosio/chain/name.hpp
+++ b/libraries/chain/include/eosio/chain/name.hpp
@@ -37,6 +37,24 @@ namespace eosio { namespace chain {
       return name;
    }
 
+   static constexpr  uint64_t name_to_mask( uint64_t value ) {
+      uint64_t mask = (~0);
+
+      if( !(value & 0x0f) ) {
+         value >>= 4;
+         for( uint32_t i = 1; i <= 12 && !(value & 0x1f); ++i ){
+            if( i == 1 ){
+               mask <<= 4;
+            } else {
+               mask <<= 5;
+            }
+            value >>= 5;
+         }
+      }
+
+      return mask;
+   }
+
 #define N(X) eosio::chain::string_to_name(#X)
 
    struct name {

--- a/plugins/history_plugin/history_plugin.cpp
+++ b/plugins/history_plugin/history_plugin.cpp
@@ -80,10 +80,10 @@ CHAINDB_TAG(eosio::by_account_action_seq, accactionseq)
 CHAINDB_TAG(eosio::by_action_sequence_num, byactseqnum)
 
 CHAINDB_SET_TABLE_TYPE(eosio::account_history_object, eosio::account_history_table)
-CHAINDB_TABLE_TAG(eosio::account_history_object, acchistory, .history)
+CHAINDB_TABLE_TAG(eosio::account_history_object, .history, acchistory)
 
 CHAINDB_SET_TABLE_TYPE(eosio::action_history_object, eosio::action_history_table)
-CHAINDB_TABLE_TAG(eosio::action_history_object, acthistory, .history)
+CHAINDB_TABLE_TAG(eosio::action_history_object, .history, acthistory)
 
 FC_REFLECT(eosio::account_history_object, (id)(account)(action_sequence_num)(account_sequence_num))
 FC_REFLECT(eosio::action_history_object, (id)(action_sequence_num)(packed_action_trace)(block_num)(block_time)(trx_id))

--- a/plugins/history_plugin/include/eosio/history_plugin/account_control_history_object.hpp
+++ b/plugins/history_plugin/include/eosio/history_plugin/account_control_history_object.hpp
@@ -55,6 +55,6 @@ CHAINDB_TAG(eosio::by_controlling, bycontrol)
 CHAINDB_TAG(eosio::by_controlled_authority, controlauth)
 
 CHAINDB_SET_TABLE_TYPE( eosio::account_control_history_object, eosio::account_control_history_table )
-CHAINDB_TABLE_TAG(eosio::account_control_history_object, ctrlhistory, .history)
+CHAINDB_TABLE_TAG(eosio::account_control_history_object, .history, ctrlhistory)
 FC_REFLECT( eosio::account_control_history_object, (id)(controlled_account)(controlled_permission)(controlling_account) )
 

--- a/plugins/history_plugin/include/eosio/history_plugin/public_key_history_object.hpp
+++ b/plugins/history_plugin/include/eosio/history_plugin/public_key_history_object.hpp
@@ -55,7 +55,7 @@ CHAINDB_TAG(eosio::by_pub_key, bypubkey)
 CHAINDB_TAG(eosio::by_account_permission, byaccperm)
 
 CHAINDB_SET_TABLE_TYPE( eosio::public_key_history_object, eosio::public_key_history_table )
-CHAINDB_TABLE_TAG(eosio::public_key_history_object, pubkeyhist, .history)
+CHAINDB_TABLE_TAG(eosio::public_key_history_object, .history, pubkeyhist)
 
 FC_REFLECT( eosio::public_key_history_object, (id)(public_key)(name)(permission) )
 

--- a/unittests/auth_tests.cpp
+++ b/unittests/auth_tests.cpp
@@ -369,15 +369,29 @@ BOOST_AUTO_TEST_CASE( any_auth ) { try {
 
 } FC_LOG_AND_RETHROW() }
 
+BOOST_AUTO_TEST_CASE(no_dots_accounts) {
+try {
+    TESTER chain;
+
+    chain.produce_block();
+
+    account_name acc = N(.dot);
+
+    BOOST_CHECK_EXCEPTION(
+        chain.create_account(acc), action_validate_exception,
+        fc_exception_message_is("account name cannot start from '.'"));
+
+} FC_LOG_AND_RETHROW() }
+
 BOOST_AUTO_TEST_CASE(no_double_billing) {
 try {
    TESTER chain;
 
    chain.produce_block();
 
-   account_name acc1 = N("bill1");
-   account_name acc2 = N("bill2");
-   account_name acc1a = N("bill1a");
+   account_name acc1 = N(bill1);
+   account_name acc2 = N(bill2);
+   account_name acc1a = N(bill1a);
 
    chain.create_account(acc1);
    chain.create_account(acc1a);
@@ -432,10 +446,10 @@ try {
 
    chain.produce_block();
 
-   account_name acc1 = N("acc1");
-   account_name acc2 = N("acc2");
-   account_name acc3 = N("acc3");
-   account_name acc4 = N("acc4");
+   account_name acc1 = N(acc1);
+   account_name acc2 = N(acc2);
+   account_name acc3 = N(acc3);
+   account_name acc4 = N(acc4);
 
    chain.create_account(acc1);
    chain.produce_block();


### PR DESCRIPTION
Resolve #1004:
- Protect ABI for history_plugin
- Forbid to create accounts starts with '.'
- Don't create account for ABI

Resolve #1009:
- Forbid to create non-unique indexes with primary keys.