### PR TITLE
Add public keys of accounts to EE-genesis #1001

### DIFF
--- a/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
+++ b/programs/create-genesis/ee_genesis/event_engine_genesis.cpp
@@ -220,10 +220,20 @@ static abi_def create_accounts_abi() {
     });
 
     abi.structs.emplace_back( struct_def {
+       "key_weight", "", {
+            {"key", "public_key"},
+            {"weight", "uint16"}
+        }
+    });
+
+    abi.structs.emplace_back( struct_def {
         "account_info", "", {
             {"creator", "name"},
             {"owner", "name"},
             {"name", "string"},
+            {"owner_keys", "key_weight[]"},
+            {"active_keys", "key_weight[]"},
+            {"posting_keys", "key_weight[]"},
             {"created", "time_point_sec"},
             {"last_update", "time_point_sec"},
             {"reputation", "int64"},

--- a/programs/create-genesis/genesis_create.cpp
+++ b/programs/create-genesis/genesis_create.cpp
@@ -354,6 +354,10 @@ struct genesis_create::genesis_create_impl final {
             const auto& owner  = store_permission(name, config::owner_name, 0, own, usage_id++);
             const auto& active = store_permission(name, config::active_name, owner.id, act, usage_id++);
             const auto& posting= store_permission(name, posting_auth_name, active.id, post, usage_id++);
+            _exp_info.account_infos[a.account.id] = mvo
+                ("owner_keys", own.keys)
+                ("active_keys", act.keys)
+                ("posting_keys", post.keys);
 
             auto itr = std::find_if(_info.transit_account_authorities.begin(), _info.transit_account_authorities.end(),
                     [&](const auto& acc) {return acc.name == name;});
@@ -403,7 +407,7 @@ struct genesis_create::genesis_create_impl final {
                 u.scope = app;
                 u.name = s;
             });
-            _exp_info.account_infos[auth.account.id] = mvo
+            _exp_info.account_infos[auth.account.id] = _exp_info.account_infos[auth.account.id]
                 ("creator", app)
                 ("owner", n)
                 ("name", s)


### PR DESCRIPTION
Resolve #1001:
- Add `owner_keys`, `active_keys` and `posting_keys` to `account`.
- They have type `key_weight[]` which is equal to same fields in `newaccount` action's `authority`-es.