### PR TITLE
Event engine improvements #878 #1030

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -415,6 +415,7 @@ void apply_context::schedule_deferred_transaction( const uint128_t& sender_id, a
 //      // add_ram_usage( ptr->payer, -(config::billable_size_v<generated_transaction_object> + ptr->packed_trx.size()) );
 
       chaindb.modify( *ptr, get_storage_payer(owner), [&]( auto& gtx ) {
+            gtx.trx_id      = trx.id();
             gtx.sender      = receiver;
             gtx.sender_id   = sender_id;
             gtx.published   = control.pending_block_time();

--- a/plugins/event_engine_plugin/event_engine_plugin.cpp
+++ b/plugins/event_engine_plugin/event_engine_plugin.cpp
@@ -235,6 +235,10 @@ void event_engine_plugin_impl::send_genesis_file(const bfs::path& genesis_file) 
 void event_engine_plugin_impl::applied_transaction(const chain::transaction_trace_ptr& trx_trace) {
     ilog("Applied trx: ${block_num}, ${id}", ("block_num", trx_trace->block_num)("id", trx_trace->id));
 
+    if (trx_trace->failed_dtrx_trace) {
+        applied_transaction(trx_trace->failed_dtrx_trace);
+    }
+
     std::function<void(ApplyTrxMessage &msg, const chain::action_trace&)> process_action_trace = 
     [&](ApplyTrxMessage &msg, const chain::action_trace& trace) {
         if (is_handled_contract(trace.receipt.receiver)) {

--- a/plugins/event_engine_plugin/event_engine_plugin.cpp
+++ b/plugins/event_engine_plugin/event_engine_plugin.cpp
@@ -182,7 +182,8 @@ void event_engine_plugin_impl::irreversible_block(const chain::block_state_ptr& 
 void event_engine_plugin_impl::accepted_transaction(const chain::transaction_metadata_ptr& trx_meta) {
     ilog("Accepted trx: ${id}, ${signed_id}", ("id", trx_meta->id)("signed_id", trx_meta->signed_id));
 
-    AcceptTrxMessage msg(MsgChannel::Blocks, BaseMessage::AcceptTrx, trx_meta);
+    fc::variant trx = db.to_variant_with_abi(trx_meta->packed_trx->get_transaction(), abi_serializer_max_time);
+    AcceptTrxMessage msg(MsgChannel::Blocks, BaseMessage::AcceptTrx, trx_meta, std::move(trx));
     send_message(msg);
 }
 

--- a/plugins/event_engine_plugin/include/eosio/event_engine_plugin/messages.hpp
+++ b/plugins/event_engine_plugin/include/eosio/event_engine_plugin/messages.hpp
@@ -117,6 +117,7 @@ namespace eosio {
        chain::block_timestamp_type        block_time;
        fc::optional<chain::block_id_type> prod_block_id;
        std::vector<ActionData>            actions;
+       fc::optional<fc::exception>        except;
 
        ApplyTrxMessage(MsgChannel msg_channel, MsgType msg_type, const chain::transaction_trace_ptr& trace)
        : BaseMessage(msg_channel, msg_type)
@@ -124,6 +125,7 @@ namespace eosio {
        , block_num(trace->block_num)
        , block_time(trace->block_time)
        , prod_block_id(trace->producer_block_id)
+       , except(trace->except)
        {}
    };
 
@@ -209,4 +211,4 @@ FC_REFLECT_DERIVED(eosio::BlockMessage, (eosio::BaseMessage), (id)(previous)(pro
    (scheduled_shuffle_slot)(scheduled_slot)(active_schedule)(next_schedule)(block_num)(block_time)(block_slot)(next_block_time))
 FC_REFLECT_DERIVED(eosio::AcceptedBlockMessage, (eosio::BlockMessage), (trxs)(events))
 FC_REFLECT_DERIVED(eosio::AcceptTrxMessage, (eosio::BaseMessage)(eosio::TrxMetadata), )
-FC_REFLECT_DERIVED(eosio::ApplyTrxMessage, (eosio::BaseMessage), (id)(block_num)(block_time)(prod_block_id)(actions))
+FC_REFLECT_DERIVED(eosio::ApplyTrxMessage, (eosio::BaseMessage), (id)(block_num)(block_time)(prod_block_id)(actions)(except))

--- a/plugins/event_engine_plugin/include/eosio/event_engine_plugin/messages.hpp
+++ b/plugins/event_engine_plugin/include/eosio/event_engine_plugin/messages.hpp
@@ -29,12 +29,14 @@ namespace eosio {
        bool                       accepted;
        bool                       implicit;
        bool                       scheduled;
+       variant                    trx;
 
-       TrxMetadata(const chain::transaction_metadata_ptr &meta)
+       TrxMetadata(const chain::transaction_metadata_ptr &meta, const fc::variant& trx)
        : id(meta->id)
        , accepted(meta->accepted)
        , implicit(meta->implicit)
        , scheduled(meta->scheduled)
+       , trx(trx)
        {}
    };
 
@@ -103,9 +105,9 @@ namespace eosio {
    const auto core_genesis_code = N(core);
 
    struct AcceptTrxMessage : public BaseMessage, TrxMetadata {
-       AcceptTrxMessage(MsgChannel msg_channel, BaseMessage::MsgType msg_type, const chain::transaction_metadata_ptr &trx_meta)
+       AcceptTrxMessage(MsgChannel msg_channel, BaseMessage::MsgType msg_type, const chain::transaction_metadata_ptr &trx_meta, const fc::variant &trx = fc::variant())
        : BaseMessage(msg_channel, msg_type)
-       , TrxMetadata(trx_meta)
+       , TrxMetadata(trx_meta, trx)
        {}
    };
 
@@ -196,7 +198,7 @@ namespace eosio {
 
 FC_REFLECT(eosio::EventData, (code)(event)(data)(args))
 FC_REFLECT(eosio::ActionData, (receiver)(code)(action)(auth)(data)(args)(events))
-FC_REFLECT(eosio::TrxMetadata, (id)(accepted)(implicit)(scheduled))
+FC_REFLECT(eosio::TrxMetadata, (id)(accepted)(implicit)(scheduled)(trx))
 FC_REFLECT(eosio::TrxReceipt, (id)(status)(cpu_usage_us)(net_usage_words)(ram_kbytes)(storage_kbytes))
 
 FC_REFLECT_ENUM(eosio::MsgChannel, (Blocks)(Genesis))


### PR DESCRIPTION
Resolve #878 and #1030
- save new trx_id when deferred transaction replace
- send exception in ApplyTrx message
- send transaction in AcceptTrx message
- send ApplyTrx for failed deferred transaction

Example of AcceptTrx/ApplyTrx messages:
```
{
    "msg_channel": "Blocks",
    "msg_type": "AcceptTrx",
    "id": "95103c2a76fe9da18821079e44541aa57565e0de5fea672b54f36273819e0acd",
    "accepted": true,
    "implicit": false,
    "scheduled": true,
    "trx": {
        "expiration": "2019-07-26T08:54:36.000",
        "ref_block_num": 9492,
        "ref_block_prefix": 777331881,
        "max_net_usage_words": 0,
        "max_cpu_usage_ms": 0,
        "max_ram_kbytes": 0,
        "max_storage_kbytes": 0,
        "delay_sec": 5,
        "context_free_actions": [],
        "actions": [
            {
                "account": "tech.test",
                "name": "check",
                "authorization": [
                    {
                        "actor": "tech.test",
                        "permission": "active"
                    }
                ],
                "data": {
                    "arg": 0
                },
                "hex_data": "0000000000000000"
            }
        ],
        "transaction_extensions": []
    }
}
{
    "msg_channel": "Blocks",
    "msg_type": "ApplyTrx",
    "id": "95103c2a76fe9da18821079e44541aa57565e0de5fea672b54f36273819e0acd",
    "block_num": 9495,
    "block_time": "2019-07-26T08:54:42.000",
    "actions": [
        {
            "receiver": "tech.test",
            "code": "tech.test",
            "action": "check",
            "auth": [
                {
                    "actor": "tech.test",
                    "permission": "active"
                }
            ],
            "data": "",
            "args": {
                "arg": 0
            },
            "events": []
        }
    ],
    "except": {
        "code": 3050003,
        "name": "eosio_assert_message_exception",
        "message": "eosio_assert_message assertion failure",
        "stack": [
            {
                "context": {
                    "level": "error",
                    "file": "wasm_interface.cpp",
                    "line": 948,
                    "method": "eosio_assert",
                    "hostname": "",
                    "thread_name": "nodeos",
                    "timestamp": "2019-07-26T08:54:39.027"
                },
                "format": "assertion failure with message: ${s}",
                "data": {
                    "s": "Argument must be positive"
                }
            },
            {
                "context": {
                    "level": "warn",
                    "file": "apply_context.cpp",
                    "line": 79,
                    "method": "exec_one",
                    "hostname": "",
                    "thread_name": "nodeos",
                    "timestamp": "2019-07-26T08:54:39.028"
                },
                "format": "pending console output: ${console}",
                "data": {
                    "console": ""
                }
            }
        ],
        "strace": " 0# 0x0000000000E65B0D in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n 1# 0x0000000000C99FA1 in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n 2# 0x0000000000C99C92 in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n 3# 0x0000000000C9A36C in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n 4# 0x0000000000C9A3B4 in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n 5# 0x0000000000D70E1C in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n 6# 0x0000000001CFF655 in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n 7# 0x0000000001D02C8A in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n 8# 0x0000000001D0F04D in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n 9# 0x0000000001D0F5BA in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n10# 0x0000000000D71721 in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n11# 0x0000000000CC03E7 in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n12# 0x0000000000CC2F7A in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n13# 0x0000000000B8CAA1 in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n14# 0x0000000000AF2C62 in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n15# 0x0000000000AB0DAF in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n16# 0x0000000000A92F20 in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n17# 0x0000000000A0A299 in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n18# 0x00000000009FEF55 in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n19# 0x0000000000A12D54 in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n20# 0x0000000000A1B5D5 in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n21# 0x000000000048F91D in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n22# 0x00000000004834D8 in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n23# __libc_start_main in /lib/x86_64-linux-gnu/libc.so.6\n24# 0x00000000004806D9 in /mnt/working/cyberway.git/build/programs/nodeos/nodeos\n"
    }
}
```